### PR TITLE
Fix translations and revert Dashboard UI

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -230,7 +230,7 @@ function updateProviderUserSelect(users) {
   const select = document.getElementById('provider-user-select');
   if (!select) return;
   const currentVal = select.value;
-  select.innerHTML = '<option value="">Select User...</option>';
+  select.innerHTML = `<option value="">${t('selectUserPlaceholder')}</option>`;
   users.forEach(u => {
     const opt = document.createElement('option');
     opt.value = u.id;
@@ -684,7 +684,7 @@ async function importSelectedCategories(withChannels) {
 
   const checkboxes = document.querySelectorAll('.cat-checkbox:checked');
   if (checkboxes.length === 0) {
-    alert(t('noCategoriesFound')); // Reusing key or should add 'noSelection'?
+    alert(t('noSelection'));
     return;
   }
 
@@ -1033,7 +1033,7 @@ document.getElementById('provider-form').addEventListener('submit', async e => {
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify(body)
       });
-      alert(t('providerUpdated') || 'Provider updated');
+      alert(t('providerUpdated'));
       resetProviderForm();
     } else {
       await fetchJSON('/api/providers', {
@@ -1624,7 +1624,7 @@ document.addEventListener('DOMContentLoaded', () => {
        const selected = Array.from(document.querySelectorAll('.user-chan-check:checked')).map(cb => Number(cb.value));
        if (selected.length === 0) return;
 
-       if (!confirm(t('deleteChannelConfirm', {name: `${selected.length} items`}))) return;
+       if (!confirm(t('deleteChannelConfirm', {count: selected.length}))) return;
 
        try {
          await fetchJSON('/api/user-channels/bulk-delete', {
@@ -1651,7 +1651,7 @@ document.addEventListener('DOMContentLoaded', () => {
           let duration = blockForm.duration.value;
 
           if (duration === 'manual') {
-             const mins = prompt(t('minutes') || 'Minutes:', '60');
+             const mins = prompt(t('minutes'), '60');
              if (!mins) return;
              duration = Number(mins) * 60;
           } else {
@@ -1683,7 +1683,7 @@ document.addEventListener('DOMContentLoaded', () => {
                   headers: {'Content-Type': 'application/json'},
                   body: JSON.stringify({ip_block_duration: duration})
               });
-              alert(t('settingsSaved') || 'Settings Saved');
+              alert(t('settingsSaved'));
           } catch(e) { alert(e.message); }
       });
   }
@@ -1770,7 +1770,7 @@ async function loadSecurity() {
     const logBody = document.getElementById('security-logs-tbody');
     logBody.innerHTML = '';
     if (logs.length === 0) {
-        logBody.innerHTML = `<tr><td colspan="4" class="text-center text-muted">${t('noLogs') || 'No logs found'}</td></tr>`;
+        logBody.innerHTML = `<tr><td colspan="4" class="text-center text-muted">${t('noLogs')}</td></tr>`;
     } else {
         logs.forEach(log => {
             const tr = document.createElement('tr');
@@ -1802,7 +1802,7 @@ async function loadSecurity() {
     if (blocked.length === 0) {
         const li = document.createElement('li');
         li.className = 'list-group-item text-muted';
-        li.textContent = 'None';
+        li.textContent = t('none');
         blockedList.appendChild(li);
     }
     blocked.forEach(b => {
@@ -1822,7 +1822,7 @@ async function loadSecurity() {
 
         const btn = document.createElement('button');
         btn.className = 'btn btn-sm btn-outline-danger py-0';
-        btn.textContent = 'Unblock';
+        btn.textContent = t('unblock');
         btn.onclick = () => unblockIp(b.id);
 
         li.appendChild(div);
@@ -1836,7 +1836,7 @@ async function loadSecurity() {
     if (whitelist.length === 0) {
         const li = document.createElement('li');
         li.className = 'list-group-item text-muted';
-        li.textContent = 'None';
+        li.textContent = t('none');
         whitelistList.appendChild(li);
     }
     whitelist.forEach(w => {
@@ -1856,7 +1856,7 @@ async function loadSecurity() {
 
         const btn = document.createElement('button');
         btn.className = 'btn btn-sm btn-outline-danger py-0';
-        btn.textContent = 'Remove';
+        btn.textContent = t('remove');
         btn.onclick = () => removeWhitelist(w.id);
 
         li.appendChild(div);
@@ -1868,7 +1868,7 @@ async function loadSecurity() {
     const clientLogBody = document.getElementById('client-logs-tbody');
     clientLogBody.innerHTML = '';
     if (clientLogs.length === 0) {
-        clientLogBody.innerHTML = `<tr><td colspan="4" class="text-center text-muted">${t('noLogs') || 'No logs found'}</td></tr>`;
+        clientLogBody.innerHTML = `<tr><td colspan="4" class="text-center text-muted">${t('noLogs')}</td></tr>`;
     } else {
         clientLogs.forEach(log => {
             const tr = document.createElement('tr');
@@ -1903,7 +1903,7 @@ async function loadSecurity() {
 }
 
 async function clearSecurityLogs() {
-    if(!confirm(t('confirmClearLogs') || 'Clear security logs?')) return;
+    if(!confirm(t('confirmClearLogs'))) return;
     try {
         await fetchJSON('/api/security/logs', {method: 'DELETE'});
         loadSecurity();
@@ -1911,7 +1911,7 @@ async function clearSecurityLogs() {
 }
 
 async function clearClientLogs() {
-    if(!confirm(t('confirmClearLogs') || 'Clear client logs?')) return;
+    if(!confirm(t('confirmClearLogs'))) return;
     try {
         await fetchJSON('/api/client-logs', {method: 'DELETE'});
         loadSecurity();
@@ -1919,7 +1919,7 @@ async function clearClientLogs() {
 }
 
 async function unblockIp(id) {
-    if(!confirm(t('confirmUnblock') || 'Unblock IP?')) return;
+    if(!confirm(t('confirmUnblock'))) return;
     try {
         await fetchJSON(`/api/security/block/${id}`, {method: 'DELETE'});
         loadSecurity();
@@ -1927,7 +1927,7 @@ async function unblockIp(id) {
 }
 
 async function removeWhitelist(id) {
-    if(!confirm(t('confirmRemoveWhitelist') || 'Remove from whitelist?')) return;
+    if(!confirm(t('confirmRemoveWhitelist'))) return;
     try {
         await fetchJSON(`/api/security/whitelist/${id}`, {method: 'DELETE'});
         loadSecurity();
@@ -2465,7 +2465,7 @@ function updateCatBulkDeleteBtn() {
     const btn = document.getElementById('cat-bulk-delete-btn');
     if (btn) {
         btn.style.display = count > 0 ? 'block' : 'none';
-        btn.textContent = `${t('deleteSelected') || 'Delete Selected'} (${count})`;
+        btn.textContent = `${t('deleteSelected')} (${count})`;
     }
 }
 
@@ -2474,6 +2474,6 @@ function updateChanBulkDeleteBtn() {
     const btn = document.getElementById('chan-bulk-delete-btn');
     if (btn) {
         btn.style.display = count > 0 ? 'block' : 'none';
-        btn.textContent = `${t('deleteSelected') || 'Delete'} (${count})`;
+        btn.textContent = `${t('deleteSelected')} (${count})`;
     }
 }

--- a/public/i18n.js
+++ b/public/i18n.js
@@ -227,7 +227,21 @@ const translations = {
     details: 'Details',
     confirmUnblock: 'Really unblock this IP?',
     confirmRemoveWhitelist: 'Remove from whitelist?',
-    noLogs: 'No logs found'
+    noLogs: 'No logs found',
+    selectUserPlaceholder: '-- Select User --',
+    userUpdated: '✅ User updated',
+    providerUpdated: '✅ Provider updated',
+    settingsSaved: '✅ Settings saved',
+    confirmClearLogs: 'Really clear logs?',
+    deleteSelected: 'Delete Selected',
+    deleteChannelConfirm: 'Really delete {count} channels?',
+    unblock: 'Unblock',
+    remove: 'Remove',
+    none: 'None',
+    noSelection: 'No items selected',
+    editUser: 'Edit User',
+    leaveBlankToKeep: 'Leave blank to keep current',
+    enableEpg: 'Enable EPG'
   },
   
   de: {
@@ -454,7 +468,21 @@ const translations = {
     details: 'Details',
     confirmUnblock: 'IP wirklich entblocken?',
     confirmRemoveWhitelist: 'Von der Whitelist entfernen?',
-    noLogs: 'Keine Protokolle gefunden'
+    noLogs: 'Keine Protokolle gefunden',
+    selectUserPlaceholder: '-- User wählen --',
+    userUpdated: '✅ User aktualisiert',
+    providerUpdated: '✅ Provider aktualisiert',
+    settingsSaved: '✅ Einstellungen gespeichert',
+    confirmClearLogs: 'Protokolle wirklich löschen?',
+    deleteSelected: 'Auswahl löschen',
+    deleteChannelConfirm: 'Wirklich {count} Kanäle löschen?',
+    unblock: 'Entblocken',
+    remove: 'Entfernen',
+    none: 'Keine',
+    noSelection: 'Keine Auswahl',
+    editUser: 'User bearbeiten',
+    leaveBlankToKeep: 'Leer lassen um aktuelles zu behalten',
+    enableEpg: 'EPG aktivieren'
   },
 
   fr: {
@@ -681,7 +709,21 @@ const translations = {
     details: 'Détails',
     confirmUnblock: 'Vraiment débloquer cette IP ?',
     confirmRemoveWhitelist: 'Retirer de la liste blanche ?',
-    noLogs: 'Aucun journal trouvé'
+    noLogs: 'Aucun journal trouvé',
+    selectUserPlaceholder: '-- Sélectionner Utilisateur --',
+    userUpdated: '✅ Utilisateur mis à jour',
+    providerUpdated: '✅ Fournisseur mis à jour',
+    settingsSaved: '✅ Paramètres enregistrés',
+    confirmClearLogs: 'Vraiment effacer les journaux ?',
+    deleteSelected: 'Supprimer la sélection',
+    deleteChannelConfirm: 'Vraiment supprimer {count} chaînes ?',
+    unblock: 'Débloquer',
+    remove: 'Retirer',
+    none: 'Aucun',
+    noSelection: 'Aucune sélection',
+    editUser: 'Modifier Utilisateur',
+    leaveBlankToKeep: 'Laisser vide pour conserver l\'actuel',
+    enableEpg: 'Activer EPG'
   },
 
   el: {
@@ -898,7 +940,21 @@ const translations = {
     details: 'Λεπτομέρειες',
     confirmUnblock: 'Άρση αποκλεισμού IP;',
     confirmRemoveWhitelist: 'Αφαίρεση από τη λευκή λίστα;',
-    noLogs: 'Δεν βρέθηκαν αρχεία'
+    noLogs: 'Δεν βρέθηκαν αρχεία',
+    selectUserPlaceholder: '-- Επιλέξτε Χρήστη --',
+    userUpdated: '✅ Ο χρήστης ενημερώθηκε',
+    providerUpdated: '✅ Ο πάροχος ενημερώθηκε',
+    settingsSaved: '✅ Οι ρυθμίσεις αποθηκεύτηκαν',
+    confirmClearLogs: 'Πραγματικά εκκαθάριση αρχείων;',
+    deleteSelected: 'Διαγραφή Επιλεγμένων',
+    deleteChannelConfirm: 'Πραγματικά διαγραφή {count} καναλιών;',
+    unblock: 'Ξεμπλοκάρισμα',
+    remove: 'Αφαίρεση',
+    none: 'Κανένα',
+    noSelection: 'Καμία επιλογή',
+    editUser: 'Επεξεργασία Χρήστη',
+    leaveBlankToKeep: 'Αφήστε κενό για να διατηρήσετε τον τρέχοντα',
+    enableEpg: 'Ενεργοποίηση EPG'
   }
 };
 

--- a/public/index.html
+++ b/public/index.html
@@ -34,7 +34,7 @@
     }
   </style>
 </head>
-<body class="bg-light">
+<body>
 
   <!-- Navbar -->
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4" id="main-navbar" style="display: none;">
@@ -81,34 +81,30 @@
       <!-- Stats Cards -->
       <div class="row mb-4">
         <div class="col-md-3">
-          <div class="card text-white bg-primary mb-3">
+          <div class="card mb-3">
             <div class="card-body">
               <h5 class="card-title" data-i18n="totalUsers">Total Users</h5>
-              <p class="card-text display-4" id="stats-users">0</p>
             </div>
           </div>
         </div>
         <div class="col-md-3">
-          <div class="card text-white bg-success mb-3">
+          <div class="card mb-3">
             <div class="card-body">
               <h5 class="card-title" data-i18n="totalProviders">Total Providers</h5>
-              <p class="card-text display-4" id="stats-providers">0</p>
             </div>
           </div>
         </div>
         <div class="col-md-3">
-          <div class="card text-white bg-info mb-3">
+          <div class="card mb-3">
             <div class="card-body">
               <h5 class="card-title" data-i18n="activeStreams">Active Streams</h5>
-              <p class="card-text display-4" id="stats-streams">0</p>
             </div>
           </div>
         </div>
         <div class="col-md-3">
-          <div class="card text-white bg-secondary mb-3">
+          <div class="card mb-3">
             <div class="card-body">
               <h5 class="card-title" data-i18n="epgSources">EPG Sources</h5>
-              <p class="card-text display-4" id="stats-epg">0</p>
             </div>
           </div>
         </div>
@@ -706,24 +702,24 @@
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
-          <h5 class="modal-title">Edit User</h5>
+          <h5 class="modal-title" data-i18n="editUser">Edit User</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
         </div>
         <form id="edit-user-form">
           <div class="modal-body">
             <input type="hidden" id="edit-user-id">
             <div class="mb-3">
-              <label class="form-label">Username</label>
+              <label class="form-label" data-i18n="username">Username</label>
               <input type="text" class="form-control" id="edit-user-username" required>
             </div>
             <div class="mb-3">
-              <label class="form-label">New Password</label>
-              <input type="password" class="form-control" id="edit-user-password" placeholder="Leave blank to keep current">
+              <label class="form-label" data-i18n="new_password">New Password</label>
+              <input type="password" class="form-control" id="edit-user-password" data-i18n-placeholder="leaveBlankToKeep" placeholder="Leave blank to keep current">
             </div>
           </div>
           <div class="modal-footer">
-            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-            <button type="submit" class="btn btn-primary">Save Changes</button>
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" data-i18n="close">Close</button>
+            <button type="submit" class="btn btn-primary" data-i18n="saveChanges">Save Changes</button>
           </div>
         </form>
       </div>
@@ -804,7 +800,7 @@
                 <div class="col-md-6">
                    <div class="form-check mt-4">
                       <input class="form-check-input" type="checkbox" name="epg_enabled" id="prov-epg-enabled" checked>
-                      <label class="form-check-label" for="prov-epg-enabled">Enable EPG</label>
+                      <label class="form-check-label" for="prov-epg-enabled" data-i18n="enableEpg">Enable EPG</label>
                    </div>
                 </div>
                 <div class="col-md-6">


### PR DESCRIPTION
This PR addresses the user request to fix missing translations and revert the Dashboard UI.

**Translations:**
- Added missing keys for `selectUserPlaceholder`, `userUpdated`, `providerUpdated`, `settingsSaved`, `confirmClearLogs`, `deleteSelected`, `deleteChannelConfirm`, `unblock`, `remove`, `none`, `noSelection`, `editUser`, `leaveBlankToKeep`, `enableEpg`.
- Updated `public/app.js` to replace hardcoded strings with `t()` calls.
- Updated `public/index.html` to add `data-i18n` attributes to Modal headers, labels, and buttons.

**UI Changes:**
- Removed `bg-light` class from `<body>` in `public/index.html` to resolve a conflict with the dark theme defined in `style.css` (which caused invisible text).
- Simplified the Dashboard Stats Cards by removing Bootstrap background color classes (`bg-primary`, `bg-success`, etc.) and text color classes (`text-white`).
- Removed the numerical statistic elements (`<p class="display-4">`) from the dashboard cards, satisfying the request to "only change the headlines so the numbers are not there" (interpreted as showing headlines without numbers). The JavaScript logic handles the absence of these elements gracefully.

**Verification:**
- Verified frontend changes programmatically using a temporary Playwright script to confirm class removal and text presence.

---
*PR created automatically by Jules for task [956812159120998109](https://jules.google.com/task/956812159120998109) started by @Bladestar2105*