### PR TITLE
Add Category Type Tabs and Filtering

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -473,7 +473,18 @@ async function loadUserCategories() {
   list.innerHTML = '';
   selectedCategoryId = null;
 
-  cats.forEach(c => {
+  const typeRadio = document.querySelector('.category-type-filter:checked');
+  const type = typeRadio ? typeRadio.value : 'live';
+
+  // Filter categories by type (and handle legacy ones defaulting to 'live' if null, though backend sets default)
+  const filtered = cats.filter(c => (c.type || 'live') === type);
+
+  if (filtered.length === 0) {
+      list.innerHTML = `<li class="list-group-item text-muted small">${t('noResults', {search: ''})}</li>`;
+      return;
+  }
+
+  filtered.forEach(c => {
     const li = document.createElement('li');
     li.className = 'list-group-item d-flex justify-content-between align-items-center';
     li.dataset.id = c.id;
@@ -1168,11 +1179,15 @@ document.getElementById('category-form').addEventListener('submit', async e => {
     return;
   }
   const f = e.target;
+
+  const typeRadio = document.querySelector('.category-type-filter:checked');
+  const type = typeRadio ? typeRadio.value : 'live';
+
   try {
     await fetchJSON(`/api/users/${selectedUserId}/categories`, {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({name: f.name.value})
+      body: JSON.stringify({name: f.name.value, type: type})
     });
     f.reset();
     loadUserCategories();
@@ -1691,6 +1706,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
   document.querySelectorAll('.channel-type-filter').forEach(el => {
       el.addEventListener('change', loadProviderChannels);
+  });
+
+  document.querySelectorAll('.category-type-filter').forEach(el => {
+      el.addEventListener('change', loadUserCategories);
   });
 
   // Bulk Import Events

--- a/public/index.html
+++ b/public/index.html
@@ -171,6 +171,18 @@
                        <div class="row">
                           <div class="col-md-5">
                              <h6 data-i18n="categories">Categories</h6>
+                             <div class="mb-2">
+                                <div class="btn-group btn-group-sm w-100" role="group">
+                                   <input type="radio" class="btn-check category-type-filter" name="cat-filter-type" id="cat-filter-live" value="live" checked autocomplete="off">
+                                   <label class="btn btn-outline-secondary" for="cat-filter-live" data-i18n="typeLive">Live</label>
+
+                                   <input type="radio" class="btn-check category-type-filter" name="cat-filter-type" id="cat-filter-movie" value="movie" autocomplete="off">
+                                   <label class="btn btn-outline-secondary" for="cat-filter-movie" data-i18n="typeMovie">Movies</label>
+
+                                   <input type="radio" class="btn-check category-type-filter" name="cat-filter-type" id="cat-filter-series" value="series" autocomplete="off">
+                                   <label class="btn btn-outline-secondary" for="cat-filter-series" data-i18n="typeSeries">Series</label>
+                                </div>
+                             </div>
                              <form id="category-form" class="input-group input-group-sm mb-2">
                                 <input class="form-control" name="name" placeholder="New Category" required />
                                 <button class="btn btn-outline-secondary" type="submit">+</button>


### PR DESCRIPTION
Implemented category type filtering in the dashboard. Users can now filter categories by Live, Movies, and Series using tabs, similar to how channels are filtered. The backend was updated to store and manage category types in the `user_categories` table.

---
*PR created automatically by Jules for task [14677216479164150944](https://jules.google.com/task/14677216479164150944) started by @Bladestar2105*