### PR TITLE
Fix: Reset assigned channel list when switching category types

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -473,6 +473,17 @@ async function loadUserCategories() {
   list.innerHTML = '';
   selectedCategoryId = null;
 
+  // Reset Assigned List
+  const userChanList = document.getElementById('user-channel-list');
+  if (userChanList) userChanList.innerHTML = '';
+
+  const assignedHeader = document.getElementById('assigned-channels-header');
+  if (assignedHeader) assignedHeader.textContent = t('assigned', {count: 0});
+
+  const chanSelectAll = document.getElementById('chan-select-all-toggle');
+  if (chanSelectAll) chanSelectAll.checked = false;
+  updateChanBulkDeleteBtn();
+
   const typeRadio = document.querySelector('.category-type-filter:checked');
   const type = typeRadio ? typeRadio.value : 'live';
 


### PR DESCRIPTION
This change fixes a UI issue where the "Assigned" channels list was not cleared when switching between Live, Movie, and Series sections. 

Previously, when the user switched sections, the category list would reload (clearing the active selection), but the channel list corresponding to the *previously selected* category would remain visible. This could lead to confusion as the displayed channels did not belong to any currently selected category.

The fix ensures that whenever `loadUserCategories` is called (which happens on section switch), the assigned channel list is explicitly cleared, the count header is reset to "Assigned (0)", and any selection tools (checkboxes, buttons) are reset to their default state.

---
*PR created automatically by Jules for task [2732784782866881628](https://jules.google.com/task/2732784782866881628) started by @Bladestar2105*