### PR TITLE
🎨 Palette: Add localized ARIA labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - [Localized ARIA Labels]
+**Learning:** The app's i18n system (`translatePage`) only handled text content and placeholders. Static icon-only buttons lacked accessible names.
+**Action:** Extended `translatePage` to handle `data-i18n-label`, allowing declarative, localized `aria-label` assignment in HTML. For dynamic elements, use `setAttribute('aria-label', t('key'))`.

--- a/public/app.js
+++ b/public/app.js
@@ -128,6 +128,12 @@ function translatePage() {
     const key = el.getAttribute('data-i18n-placeholder');
     el.placeholder = t(key);
   });
+
+  // ARIA Labels übersetzen
+  document.querySelectorAll('[data-i18n-label]').forEach(el => {
+    const key = el.getAttribute('data-i18n-label');
+    el.setAttribute('aria-label', t(key));
+  });
   
   // HTML title
   document.title = t('title');
@@ -290,6 +296,7 @@ async function loadUsers() {
     playBtn.className = 'btn btn-sm btn-outline-success me-1';
     playBtn.innerHTML = '▶️'; // Play icon
     playBtn.title = t('openWebPlayer') || 'Open Web Player';
+    playBtn.setAttribute('aria-label', t('openWebPlayer') || 'Open Web Player');
     playBtn.onclick = async () => {
         try {
             playBtn.disabled = true;
@@ -309,11 +316,13 @@ async function loadUsers() {
     const editBtn = document.createElement('button');
     editBtn.className = 'btn btn-sm btn-outline-secondary me-1';
     editBtn.innerHTML = '✏️'; // Edit icon
+    editBtn.setAttribute('aria-label', t('editUser') || t('edit'));
     editBtn.onclick = () => showEditUserModal(u);
 
     const delBtn = document.createElement('button');
     delBtn.className = 'btn btn-sm btn-danger';
     delBtn.textContent = t('delete');
+    delBtn.setAttribute('aria-label', t('deleteAction'));
     delBtn.onclick = async () => {
       if (!confirm(t('deleteUserConfirm', {name: u.username}))) return;
       await fetchJSON(`/api/users/${u.id}`, {method: 'DELETE'});
@@ -453,6 +462,7 @@ async function loadProviders(filterUserId = null) {
     const editBtn = document.createElement('button');
     editBtn.className = 'btn btn-sm btn-outline-secondary me-1';
     editBtn.innerHTML = '✏️';
+    editBtn.setAttribute('aria-label', t('edit'));
     editBtn.onclick = () => prepareEditProvider(p);
 
     const syncBtn = document.createElement('button');
@@ -488,17 +498,20 @@ async function loadProviders(filterUserId = null) {
     configBtn.className = 'btn btn-sm btn-outline-secondary me-1';
     configBtn.innerHTML = '⚙️';
     configBtn.title = t('syncConfig');
+    configBtn.setAttribute('aria-label', t('syncConfig'));
     configBtn.onclick = () => showSyncConfigModal(p.id);
     
     const logsBtn = document.createElement('button');
     logsBtn.className = 'btn btn-sm btn-outline-info me-1';
     logsBtn.innerHTML = '📊';
     logsBtn.title = t('syncLogs');
+    logsBtn.setAttribute('aria-label', t('syncLogs'));
     logsBtn.onclick = () => showSyncLogs(p.id);
     
     const delBtn = document.createElement('button');
     delBtn.className = 'btn btn-sm btn-danger';
     delBtn.textContent = t('delete');
+    delBtn.setAttribute('aria-label', t('deleteAction'));
     delBtn.onclick = async () => {
       if (!confirm(t('deleteProviderConfirm', {name: p.name}))) return;
       await fetchJSON(`/api/providers/${p.id}`, {method: 'DELETE'});
@@ -673,6 +686,7 @@ async function loadUserCategories() {
     const delBtn = document.createElement('button');
     delBtn.className = 'btn btn-sm btn-danger';
     delBtn.textContent = t('delete');
+    delBtn.setAttribute('aria-label', t('deleteAction'));
     delBtn.onclick = async () => {
       if (!confirm(t('deleteCategoryConfirm', {name: c.name}))) return;
       await fetchJSON(`/api/user-categories/${c.id}`, {method: 'DELETE'});
@@ -1170,6 +1184,7 @@ async function loadUserCategoryChannels() {
     const delBtn = document.createElement('button');
     delBtn.className = 'btn btn-sm btn-danger ms-2';
     delBtn.textContent = t('delete');
+    delBtn.setAttribute('aria-label', t('deleteAction'));
     delBtn.onclick = async () => {
       await fetchJSON(`/api/user-channels/${ch.user_channel_id}`, {method: 'DELETE'});
       loadUserCategoryChannels();
@@ -1492,6 +1507,7 @@ async function loadEpgSources() {
       updateBtn.className = 'btn btn-sm btn-outline-info';
       updateBtn.innerHTML = '🔄';
       updateBtn.title = t('updateNow');
+      updateBtn.setAttribute('aria-label', t('updateNow'));
       updateBtn.disabled = source.is_updating;
       updateBtn.onclick = async () => {
         updateBtn.disabled = true;
@@ -1516,6 +1532,7 @@ async function loadEpgSources() {
         editBtn.className = 'btn btn-sm btn-outline-secondary';
         editBtn.innerHTML = '✏️';
         editBtn.title = t('edit');
+        editBtn.setAttribute('aria-label', t('edit'));
         editBtn.onclick = () => showEditEpgSourceModal(source);
         
         const toggleBtn = document.createElement('button');
@@ -1533,6 +1550,7 @@ async function loadEpgSources() {
         const delBtn = document.createElement('button');
         delBtn.className = 'btn btn-sm btn-danger';
         delBtn.textContent = '🗑';
+        delBtn.setAttribute('aria-label', t('deleteAction'));
         delBtn.onclick = async () => {
           if (!confirm(t('confirmDeleteEpgSource', {name: source.name}))) return;
           await fetchJSON(`/api/epg-sources/${source.id}`, {method: 'DELETE'});

--- a/public/i18n.js
+++ b/public/i18n.js
@@ -119,6 +119,9 @@ const translations = {
     browse: 'Browse',
     updateAll: 'Update All',
     save: 'Save',
+    generateRandomUser: 'Generate Random User',
+    copyToClipboardAction: 'Copy to Clipboard',
+    deleteAction: 'Delete',
     
     // Loading states
     loading: 'Loading...',
@@ -445,6 +448,9 @@ const translations = {
     browse: 'Durchsuchen',
     updateAll: 'Alle aktualisieren',
     save: 'Speichern',
+    generateRandomUser: 'Zufälligen Benutzer generieren',
+    copyToClipboardAction: 'In die Zwischenablage kopieren',
+    deleteAction: 'Löschen',
     
     // Loading states
     loading: 'Lädt...',
@@ -771,6 +777,9 @@ const translations = {
     browse: 'Parcourir',
     updateAll: 'Tout mettre à jour',
     save: 'Enregistrer',
+    generateRandomUser: 'Générer un utilisateur aléatoire',
+    copyToClipboardAction: 'Copier dans le presse-papier',
+    deleteAction: 'Supprimer',
     
     // Loading states
     loading: 'Chargement...',
@@ -1097,6 +1106,9 @@ const translations = {
     browse: 'Περιήγηση',
     updateAll: 'Ενημέρωση όλων',
     save: 'Αποθήκευση',
+    generateRandomUser: 'Δημιουργία τυχαίου χρήστη',
+    copyToClipboardAction: 'Αντιγραφή στο πρόχειρο',
+    deleteAction: 'Διαγραφή',
     
     // Loading states
     loading: 'Φόρτωση...',

--- a/public/index.html
+++ b/public/index.html
@@ -125,7 +125,7 @@
                   <div class="col-4"><input class="form-control form-control-sm" name="username" data-i18n-placeholder="username" placeholder="Username" required /></div>
                   <div class="col-4"><input class="form-control form-control-sm" name="password" type="text" data-i18n-placeholder="password" placeholder="Password" required /></div>
                   <div class="col-2"><button class="btn btn-sm btn-primary w-100" type="submit" data-i18n="addUser">Add</button></div>
-                  <div class="col-2"><button class="btn btn-sm btn-outline-secondary w-100" type="button" onclick="generateUser()" title="Generate Random">⚡</button></div>
+                  <div class="col-2"><button class="btn btn-sm btn-outline-secondary w-100" type="button" onclick="generateUser()" title="Generate Random" data-i18n-label="generateRandomUser">⚡</button></div>
                </form>
                <ul id="user-list" class="list-group list-group-flush" style="max-height: 400px; overflow-y: auto;"></ul>
             </div>
@@ -186,7 +186,7 @@
                              </div>
                              <form id="category-form" class="input-group input-group-sm mb-2">
                                 <input class="form-control" name="name" data-i18n-placeholder="newCategory" placeholder="New Category" required />
-                                <button class="btn btn-outline-secondary" type="submit">+</button>
+                                <button class="btn btn-outline-secondary" type="submit" data-i18n-label="addCategory">+</button>
                              </form>
                              <div class="d-flex justify-content-between align-items-center mb-1">
                                 <div class="form-check form-check-sm">
@@ -241,7 +241,7 @@
                           <label class="form-label small fw-bold" data-i18n="url">URL</label>
                           <div class="input-group input-group-sm">
                              <input type="text" class="form-control" id="xtream-url" readonly>
-                             <button class="btn btn-outline-secondary" onclick="copyToClipboard(document.getElementById('xtream-url').value)">📋</button>
+                             <button class="btn btn-outline-secondary" onclick="copyToClipboard(document.getElementById('xtream-url').value)" data-i18n-label="copyToClipboardAction">📋</button>
                           </div>
                        </div>
 
@@ -250,14 +250,14 @@
                              <label class="form-label small fw-bold" data-i18n="username">Username</label>
                              <div class="input-group input-group-sm">
                                 <input type="text" class="form-control" id="xtream-user" readonly>
-                                <button class="btn btn-outline-secondary" onclick="copyToClipboard(document.getElementById('xtream-user').value)">📋</button>
+                                <button class="btn btn-outline-secondary" onclick="copyToClipboard(document.getElementById('xtream-user').value)" data-i18n-label="copyToClipboardAction">📋</button>
                              </div>
                           </div>
                           <div class="col-md-6">
                              <label class="form-label small fw-bold" data-i18n="password">Password</label>
                              <div class="input-group input-group-sm">
                                 <input type="text" class="form-control" id="xtream-pass" readonly>
-                                <button class="btn btn-outline-secondary" onclick="copyToClipboard(document.getElementById('xtream-pass').value)">📋</button>
+                                <button class="btn btn-outline-secondary" onclick="copyToClipboard(document.getElementById('xtream-pass').value)" data-i18n-label="copyToClipboardAction">📋</button>
                              </div>
                           </div>
                        </div>
@@ -266,7 +266,7 @@
                           <label class="form-label small fw-bold" data-i18n="epgUrlLabel">EPG URL</label>
                           <div class="input-group input-group-sm">
                              <input type="text" class="form-control" id="epg-url" readonly>
-                             <button class="btn btn-outline-secondary" onclick="copyToClipboard(document.getElementById('epg-url').value)">📋</button>
+                             <button class="btn btn-outline-secondary" onclick="copyToClipboard(document.getElementById('epg-url').value)" data-i18n-label="copyToClipboardAction">📋</button>
                           </div>
                        </div>
 
@@ -274,7 +274,7 @@
                           <label class="form-label small fw-bold" data-i18n="m3uLink">M3U Link</label>
                           <div class="input-group input-group-sm">
                              <input type="text" class="form-control" id="m3u-link" readonly>
-                             <button class="btn btn-outline-secondary" onclick="copyToClipboard(document.getElementById('m3u-link').value)">📋</button>
+                             <button class="btn btn-outline-secondary" onclick="copyToClipboard(document.getElementById('m3u-link').value)" data-i18n-label="copyToClipboardAction">📋</button>
                           </div>
                        </div>
 
@@ -290,7 +290,7 @@
          <div class="card-header d-flex justify-content-between align-items-center">
             <span data-i18n="epgSources">EPG Sources</span>
             <div>
-               <button id="add-epg-source-btn" class="btn btn-sm btn-primary">+</button>
+               <button id="add-epg-source-btn" class="btn btn-sm btn-primary" data-i18n-label="addEpgSource">+</button>
                <button id="browse-epg-sources-btn" class="btn btn-sm btn-secondary" data-i18n="browse">Browse</button>
                <button id="update-all-epg-btn" class="btn btn-sm btn-info" data-i18n="updateAll">Update All</button>
             </div>


### PR DESCRIPTION
💡 **What:**
- Added `data-i18n-label` support to `translatePage()` in `public/app.js` to automatically set `aria-label` from translation keys.
- Added `aria-label` to static icon-only buttons in `public/index.html` (Generate User, Copy Credentials, Add Category, Add EPG Source).
- Updated dynamic button creation in `public/app.js` (User Play, Edit, Delete; Provider Edit, Config, Logs, Delete; EPG Source Update, Edit, Delete) to include localized `aria-label`.
- Added new translation keys (`generateRandomUser`, `copyToClipboardAction`, `deleteAction`) to `public/i18n.js` for English, German, French, and Greek.

🎯 **Why:**
- Icon-only buttons were inaccessible to screen reader users (e.g., "⚡" read as "High voltage sign" or just "button").
- Provides a consistent, localized accessibility experience.

♿ **Accessibility:**
- All major icon-only buttons now have descriptive, localized accessible names (e.g., "Generate Random User", "Delete").


---
*PR created automatically by Jules for task [12251341996927748507](https://jules.google.com/task/12251341996927748507) started by @Bladestar2105*