### PR TITLE
feat: EPG Mapping improvements - Category View and Mode Switching

### DIFF
--- a/public/i18n.js
+++ b/public/i18n.js
@@ -343,7 +343,15 @@ const translations = {
     '2fa_enabled_success': '2FA Enabled Successfully',
     '2fa_disabled_success': '2FA Disabled',
     confirm_disable_2fa: 'Disable 2FA?',
-    '2fa_enabled': '2FA is enabled'
+    '2fa_enabled': '2FA is enabled',
+    webui_access: 'Web UI Access',
+    modeProvider: 'By Provider',
+    modeCategory: 'By Category',
+    selectUser: 'Select User',
+    selectCategory: 'Select Category',
+    selectCategoryPlaceholder: '-- Select Category --',
+    selectUserFirst: 'Please select a user first',
+    select_options_to_load: 'Select options above to load channels'
   },
   
   de: {
@@ -686,7 +694,15 @@ const translations = {
     '2fa_enabled_success': '2FA erfolgreich aktiviert',
     '2fa_disabled_success': '2FA deaktiviert',
     confirm_disable_2fa: '2FA wirklich deaktivieren?',
-    '2fa_enabled': '2FA ist aktiviert'
+    '2fa_enabled': '2FA ist aktiviert',
+    webui_access: 'Web UI Zugriff',
+    modeProvider: 'Nach Provider',
+    modeCategory: 'Nach Kategorie',
+    selectUser: 'Benutzer wählen',
+    selectCategory: 'Kategorie wählen',
+    selectCategoryPlaceholder: '-- Kategorie wählen --',
+    selectUserFirst: 'Bitte zuerst einen Benutzer wählen',
+    select_options_to_load: 'Bitte Optionen wählen'
   },
 
   fr: {
@@ -1029,7 +1045,15 @@ const translations = {
     '2fa_enabled_success': '2FA activé avec succès',
     '2fa_disabled_success': '2FA désactivé',
     confirm_disable_2fa: 'Désactiver 2FA ?',
-    '2fa_enabled': '2FA est activé'
+    '2fa_enabled': '2FA est activé',
+    webui_access: 'Accès Web UI',
+    modeProvider: 'Par Fournisseur',
+    modeCategory: 'Par Catégorie',
+    selectUser: 'Sélectionner Utilisateur',
+    selectCategory: 'Sélectionner Catégorie',
+    selectCategoryPlaceholder: '-- Sélectionner Catégorie --',
+    selectUserFirst: 'Veuillez d\'abord sélectionner un utilisateur',
+    select_options_to_load: 'Sélectionnez les options pour charger'
   },
 
   el: {
@@ -1362,7 +1386,15 @@ const translations = {
     '2fa_enabled_success': 'Το 2FA ενεργοποιήθηκε',
     '2fa_disabled_success': 'Το 2FA απενεργοποιήθηκε',
     confirm_disable_2fa: 'Απενεργοποίηση 2FA;',
-    '2fa_enabled': 'Το 2FA είναι ενεργό'
+    '2fa_enabled': 'Το 2FA είναι ενεργό',
+    webui_access: 'Πρόσβαση Web UI',
+    modeProvider: 'Ανά Πάροχο',
+    modeCategory: 'Ανά Κατηγορία',
+    selectUser: 'Επιλογή Χρήστη',
+    selectCategory: 'Επιλογή Κατηγορίας',
+    selectCategoryPlaceholder: '-- Επιλέξτε Κατηγορία --',
+    selectUserFirst: 'Παρακαλώ επιλέξτε πρώτα έναν χρήστη',
+    select_options_to_load: 'Επιλέξτε επιλογές για φόρτωση'
   }
 };
 

--- a/scripts/test_security_audit.js
+++ b/scripts/test_security_audit.js
@@ -1,0 +1,119 @@
+
+import fetch from 'node-fetch';
+import { spawn } from 'child_process';
+import fs from 'fs';
+
+const PORT = 3008;
+const BASE_URL = `http://localhost:${PORT}`;
+const DATA_DIR = './test_data_security_audit';
+
+let serverProcess;
+
+async function startServer() {
+  if (fs.existsSync(DATA_DIR)) fs.rmSync(DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(DATA_DIR);
+
+  const env = {
+      ...process.env,
+      PORT,
+      DATA_DIR,
+      INITIAL_ADMIN_PASSWORD: 'adminpass'
+  };
+
+  serverProcess = spawn('node', ['src/server.js'], { env, stdio: 'pipe' });
+
+  // Wait for server
+  for (let i = 0; i < 30; i++) {
+      try {
+          await fetch(`${BASE_URL}/api/login`, { method: 'OPTIONS' });
+          console.log('Server is up!');
+          return;
+      } catch (e) {
+          await new Promise(r => setTimeout(r, 1000));
+      }
+  }
+  throw new Error('Server failed to start');
+}
+
+async function stopServer() {
+  if (serverProcess) {
+    serverProcess.kill();
+    try { process.kill(-serverProcess.pid); } catch(e){}
+  }
+}
+
+async function runTests() {
+  console.log('🚀 Starting Security Audit...');
+  try {
+    await startServer();
+
+    // 1. Setup: Admin + 2 Users
+    console.log('🔹 Setup...');
+    let res = await fetch(`${BASE_URL}/api/login`, {
+        method: 'POST', headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({username: 'admin', password: 'adminpass'})
+    });
+    const adminToken = (await res.json()).token;
+
+    // User 1
+    res = await fetch(`${BASE_URL}/api/users`, {
+        method: 'POST', headers: {'Content-Type': 'application/json', 'Authorization': `Bearer ${adminToken}`},
+        body: JSON.stringify({username: 'user1', password: 'password123'})
+    });
+    const user1Id = (await res.json()).id;
+
+    // User 2
+    res = await fetch(`${BASE_URL}/api/users`, {
+        method: 'POST', headers: {'Content-Type': 'application/json', 'Authorization': `Bearer ${adminToken}`},
+        body: JSON.stringify({username: 'user2', password: 'password123'})
+    });
+    const user2Id = (await res.json()).id;
+
+    // Login as User 1
+    res = await fetch(`${BASE_URL}/api/login`, {
+        method: 'POST', headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({username: 'user1', password: 'password123'})
+    });
+    const user1Token = (await res.json()).token;
+
+    // 2. Test: IDOR on Categories
+    // User 1 tries to fetch User 2's categories
+    console.log('🔹 Testing IDOR on Categories...');
+    res = await fetch(`${BASE_URL}/api/users/${user2Id}/categories`, {
+        headers: {'Authorization': `Bearer ${user1Token}`}
+    });
+    if (res.status !== 403) {
+        throw new Error(`IDOR Failed: User 1 could access User 2 categories! Status: ${res.status}`);
+    }
+    console.log('✅ User 1 blocked from User 2 categories (403)');
+
+    // 3. Test: IDOR on Category Channels
+    // First, admin creates a category for User 2
+    res = await fetch(`${BASE_URL}/api/users/${user2Id}/categories`, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json', 'Authorization': `Bearer ${adminToken}`},
+        body: JSON.stringify({name: 'User2 Cat'})
+    });
+    const user2CatId = (await res.json()).id;
+
+    // User 1 tries to access channels of User 2's category
+    console.log('🔹 Testing IDOR on Category Channels...');
+    res = await fetch(`${BASE_URL}/api/user-categories/${user2CatId}/channels`, {
+        headers: {'Authorization': `Bearer ${user1Token}`}
+    });
+    if (res.status !== 403) {
+        throw new Error(`IDOR Failed: User 1 could access User 2 category channels! Status: ${res.status}`);
+    }
+    console.log('✅ User 1 blocked from User 2 category channels (403)');
+
+    console.log('🎉 Security Audit Passed!');
+
+  } catch (e) {
+    console.error('❌ Test Failed:', e);
+    process.exit(1);
+  } finally {
+    await stopServer();
+  }
+}
+
+runTests();


### PR DESCRIPTION
- Implemented "By Category" mode for EPG Mapping, allowing users to map channels within their own categories.
- Admins can switch between "By Provider" and "By Category" modes.
- In "By Category" mode, Admins can select any user to map their category channels.
- Non-admin users are forced into "By Category" mode for their own account.
- Updated backend `/api/user-categories/:catId/channels` endpoint to return `manual_epg_id` for UI display.
- Added visual tests for EPG Mapping UI modes.