### PR TITLE
⚡ Bolt: Stream EPG channel parsing to reduce memory usage

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-01 - Memory Bottleneck in XML Parsing
+**Learning:** Loading entire XML files into memory via `fs.readFile` and using regex on the full string causes massive memory usage (3x file size or more) and can crash the process for large files (e.g. EPGs).
+**Action:** Always use streaming parsers (like `fs.createReadStream` + `readline`) for processing large files line-by-line to keep memory footprint constant.


### PR DESCRIPTION
Implemented a chunk-based streaming XML parser for EPG channels to solve a critical memory bottleneck.
Previously, `epg_worker.js` loaded the entire EPG file into memory, causing high memory usage (3x file size) and potential crashes.
The new `parseEpgChannels` function in `src/epg_utils.js` processes the file in chunks, maintaining a constant low memory footprint.
It is robust enough to handle minified XML files (no newlines) as well as standard XMLTV formats.

---
*PR created automatically by Jules for task [1602149590401962770](https://jules.google.com/task/1602149590401962770) started by @Bladestar2105*