### PR TITLE
⚡ Async EPG Cache Write

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -4472,7 +4472,7 @@ app.post('/api/epg-sources/:id/update', authenticateToken, async (req, res) => {
       
       const epgData = await response.text();
       const cacheFile = path.join(EPG_CACHE_DIR, `epg_provider_${providerId}.xml`);
-      fs.writeFileSync(cacheFile, epgData, 'utf8');
+      await fs.promises.writeFile(cacheFile, epgData, 'utf8');
       
       await generateConsolidatedEpg();
 


### PR DESCRIPTION
💡 **What:**
Replaced `fs.writeFileSync` with `await fs.promises.writeFile` in `src/server.js` (line ~4475) within the provider EPG update endpoint.

🎯 **Why:**
Writing large EPG XML files (potentially 50MB+) synchronously blocks the Node.js event loop. This prevents the server from handling other requests (like health checks, stream proxies, or UI interactions) until the write completes, causing latency spikes.

📊 **Measured Improvement:**
Benchmarking was attempted using a 50MB dummy EPG file and concurrent latency checks. However, the benchmark could not be fully executed in the test environment due to native dependency build issues (`better-sqlite3`).

**Rationale for Improvement:**
In a single-threaded Node.js environment, any CPU-intensive or synchronous I/O operation halts all other execution. Switching to `fs.promises.writeFile` offloads the file I/O to the `libuv` thread pool, allowing the main thread to continue processing other concurrent requests, thereby eliminating the blocking latency associated with the file write.

---
*PR created automatically by Jules for task [4177893365669363424](https://jules.google.com/task/4177893365669363424) started by @Bladestar2105*