### PR TITLE
Fix ReferenceError in Stream Proxy

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -3510,7 +3510,7 @@ app.get(['/live/:username/:password/:stream_id.ts', '/live/:username/:password/:
     const cookies = upstream.headers.get('set-cookie');
 
     // Handle M3U8 Playlists (Rewrite URLs)
-    if (ext === 'm3u8') {
+    if (reqExt === 'm3u8') {
       const text = await upstream.text();
       const baseUrl = remoteUrl;
       const tokenParam = req.query.token ? `&token=${encodeURIComponent(req.query.token)}` : '';


### PR DESCRIPTION
Fixed a critical bug in the stream proxy where `ext` was used instead of `reqExt`, causing 500 errors for streaming requests. This restores streaming functionality for Apple TV and other clients using the proxy.

---
*PR created automatically by Jules for task [15698542266495550552](https://jules.google.com/task/15698542266495550552) started by @Bladestar2105*