### PR TITLE
🎨 Palette: Keyboard Accessibility for Lists

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2025-05-15 - [Localized Tooltips]
 **Learning:** Icon-only buttons provided no context on hover, relying solely on icons or screen reader labels.
 **Action:** Extended `translatePage` to handle `data-i18n-title`, allowing declarative localized `title` attributes. Updated dynamic buttons to explicitly set `.title` property for consistent tooltip experience.
+
+## 2025-05-15 - [Keyboard Accessible List Items]
+**Learning:** List items (`span` elements) used for selecting users and categories were only clickable (`onclick`) and lacked keyboard support, making the app unusable for keyboard-only users.
+**Action:** Created `makeAccessible` helper to add `tabindex="0"`, `role="button"`, and `onkeydown` handler (Enter/Space support) to interactive non-button elements.

--- a/public/app.js
+++ b/public/app.js
@@ -116,6 +116,19 @@ function debounce(func, wait) {
   };
 }
 
+// Utility: Accessibility Helper
+function makeAccessible(element, clickHandler) {
+  element.tabIndex = 0;
+  element.role = 'button';
+  element.onclick = clickHandler;
+  element.onkeydown = (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      clickHandler(e);
+    }
+  };
+}
+
 // i18n: Seite übersetzen
 function translatePage() {
   // Texte übersetzen
@@ -319,7 +332,8 @@ async function loadUsers() {
     const span = document.createElement('span');
     span.textContent = `${u.username} (id=${u.id})`;
     span.style.cursor = 'pointer';
-    span.onclick = () => {
+
+    makeAccessible(span, () => {
       selectedUser = u;
       selectedUserId = u.id;
       document.getElementById('selected-user-label').textContent = `${t('selectedUser')}: ${u.username} (id=${u.id})`;
@@ -346,7 +360,7 @@ async function loadUsers() {
       if (provForm && !provForm.provider_id.value) {
           if(provForm.user_id) provForm.user_id.value = u.id;
       }
-    };
+    });
     
     const btnGroup = document.createElement('div');
 
@@ -731,12 +745,13 @@ async function loadUserCategories() {
     span.textContent = c.is_adult ? `🔞 ${c.name}` : c.name;
     span.style.cursor = 'pointer';
     span.style.flex = '1';
-    span.onclick = () => {
+
+    makeAccessible(span, () => {
       [...list.children].forEach(el => el.classList.remove('active'));
       li.classList.add('active');
       selectedCategoryId = c.id;
       loadUserCategoryChannels();
-    };
+    });
     li.appendChild(span);
     
     const btnGroup = document.createElement('div');


### PR DESCRIPTION
💡 What: Added keyboard accessibility to the User Selection and Category Selection lists.
🎯 Why: Previously, these list items were only interactive via mouse (`onclick`), making the application inaccessible to keyboard-only users.
📸 Before/After: Visuals are unchanged, but elements now have focus indicators and respond to Enter/Space keys.
♿ Accessibility: Added `tabindex="0"`, `role="button"`, and `keydown` handlers for Enter/Space to interactive `span` elements.

---
*PR created automatically by Jules for task [12775925182826484698](https://jules.google.com/task/12775925182826484698) started by @Bladestar2105*