### PR TITLE
🎨 Palette: Add loading state to Load More Channels button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2025-05-15 - [Localized Tooltips]
 **Learning:** Icon-only buttons provided no context on hover, relying solely on icons or screen reader labels.
 **Action:** Extended `translatePage` to handle `data-i18n-title`, allowing declarative localized `title` attributes. Updated dynamic buttons to explicitly set `.title` property for consistent tooltip experience.
+
+## 2024-10-24 - [Async UI State Restoration]
+**Learning:** When adding loading states to elements that trigger content updates (like "Load More" buttons), the element itself might be replaced or moved by the resulting render function.
+**Action:** Always re-query the DOM element by ID after the await completes before attempting to restore its state (text, disabled status), rather than relying on the closure variable reference.

--- a/public/app.js
+++ b/public/app.js
@@ -1216,9 +1216,17 @@ function renderProviderChannels(channels) {
       btn.id = 'btn-load-more-channels';
       btn.className = 'btn btn-sm btn-outline-primary w-100';
       btn.textContent = t('loadMore');
-      btn.onclick = () => {
+      btn.onclick = async function() {
+          this.disabled = true;
+          this.innerHTML = `<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> ${t('loading')}`;
+
           channelPage++;
-          loadProviderChannels(false);
+          await loadProviderChannels(false);
+
+          if (document.body.contains(this)) {
+              this.disabled = false;
+              this.textContent = t('loadMore');
+          }
       };
 
       li.appendChild(btn);


### PR DESCRIPTION
💡 What: Added a visual loading state (spinner + "Loading...") to the "Load More" button in the channel list.
🎯 Why: Users had no feedback when fetching more channels, leading to potential double-clicks or confusion about whether the app was responding.
📸 Before/After: See verification_loading.png
♿ Accessibility: The button is disabled while loading to prevent duplicate requests and indicates status via text.

---
*PR created automatically by Jules for task [17870031888921449913](https://jules.google.com/task/17870031888921449913) started by @Bladestar2105*