### PR TITLE
Fix duplicate Selected User prefix and NaN EPG stats

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -307,7 +307,7 @@ async function loadUsers() {
       // Auto-select
       selectedUser = user;
       selectedUserId = user.id;
-      document.getElementById('selected-user-label').textContent = `${t('selectedUser')}: ${user.username}`;
+      document.getElementById('selected-user-label').textContent = `${user.username}`;
 
       loadUserCategories();
       loadProviders(user.id);
@@ -335,7 +335,7 @@ async function loadUsers() {
     makeAccessible(span, () => {
       selectedUser = u;
       selectedUserId = u.id;
-      document.getElementById('selected-user-label').textContent = `${t('selectedUser')}: ${u.username} (id=${u.id})`;
+      document.getElementById('selected-user-label').textContent = `${u.username} (id=${u.id})`;
 
       const baseUrl = window.location.origin;
       const pass = u.plain_password || '********';
@@ -2830,7 +2830,7 @@ function updateMappingStats() {
     stats.textContent = t('mappingStats', {
         total: total,
         mapped: mapped,
-        percent: Math.round(mapped/total*100),
+        percent: total > 0 ? Math.round(mapped/total*100) : 0,
         manual: manual
     });
   }


### PR DESCRIPTION
This PR fixes two UI bugs:
1.  Duplicate "Selected User:" prefix in the user details header.
2.  "NaN%" display in EPG Mapping statistics when the total number of channels is 0.


---
*PR created automatically by Jules for task [4278610410703420847](https://jules.google.com/task/4278610410703420847) started by @Bladestar2105*