### PR TITLE
fix: resolve 403 cascade and use native fMP4 for transcode playback

### DIFF
--- a/public/player.html
+++ b/public/player.html
@@ -972,17 +972,11 @@
       initDashPlayer(url);
     } else if (url.includes('.ts')) {
       if (wantTranscode) {
-        // Transcode mode: request .ts with transcode=true (FFmpeg re-encodes audio to AAC)
-        // Use mpegts.js to play the transcoded MPEG-TS stream, or .mp4 for broader compat
-        var transcodeUrl = url + (url.includes('?') ? '&' : '?') + 'transcode=true';
-        if (typeof mpegts !== 'undefined' && mpegts.isSupported()) {
-          initMpegtsPlayer(transcodeUrl, streamType);
-        } else {
-          // Fallback: request as .mp4 (fragmented MP4 with transcoded audio)
-          var mp4Url = url.replace(/\.ts($|\?)/, '.mp4$1');
-          var mp4TranscodeUrl = mp4Url + (mp4Url.includes('?') ? '&' : '?') + 'transcode=true';
-          initNativePlayer(mp4TranscodeUrl, streamType);
-        }
+        // Transcode mode: use .mp4 fragmented output (video copy + audio→AAC)
+        // Native <video> handles fMP4 — bypasses MSE entirely, no codec issues
+        var mp4Url = url.replace(/\.ts($|\?)/, '.mp4$1');
+        var mp4TranscodeUrl = mp4Url + (mp4Url.includes('?') ? '&' : '?') + 'transcode=true';
+        initNativePlayer(mp4TranscodeUrl, streamType);
       } else if (isIOS || (isSafari && hasNativeHLS)) {
         // iOS/Safari: use native HLS
         var hlsUrl2 = url.replace(/\.ts($|\?)/, '.m3u8$1');
@@ -1292,23 +1286,12 @@
       }
 
       if (url.includes('.ts')) {
-        // Transcode: request .ts with transcode=true (FFmpeg re-encodes audio to AAC)
-        var transcodeUrl = url + (url.includes('?') ? '&' : '?') + 'transcode=true';
-
-        if (isIOS || (isSafari && hasNativeHLS)) {
-          // iOS/Safari: use .mp4 fragmented output for native playback
-          var mp4Url = url.replace(/\.ts($|\?)/, '.mp4$1');
-          var mp4TranscodeUrl = mp4Url + (mp4Url.includes('?') ? '&' : '?') + 'transcode=true';
-          initNativePlayer(mp4TranscodeUrl, type);
-        } else if (typeof mpegts !== 'undefined' && mpegts.isSupported()) {
-          retryCount = 0;
-          initMpegtsPlayer(transcodeUrl, type);
-        } else {
-          // Fallback: fragmented MP4
-          var mp4Url2 = url.replace(/\.ts($|\?)/, '.mp4$1');
-          var mp4TranscodeUrl2 = mp4Url2 + (mp4Url2.includes('?') ? '&' : '?') + 'transcode=true';
-          initNativePlayer(mp4TranscodeUrl2, type);
-        }
+        // Transcode: use .mp4 fragmented output (video copy + audio→AAC)
+        // This bypasses MSE/mpegts.js entirely — native <video> handles fMP4
+        // which avoids the AC-3/HEVC addSourceBuffer errors completely
+        var mp4Url = url.replace(/\.ts($|\?)/, '.mp4$1');
+        var mp4TranscodeUrl = mp4Url + (mp4Url.includes('?') ? '&' : '?') + 'transcode=true';
+        initNativePlayer(mp4TranscodeUrl, type);
       } else {
         // For non-.ts URLs, just add transcode param
         var transcodeUrl2 = url + (url.includes('?') ? '&' : '?') + 'transcode=true';


### PR DESCRIPTION
Three critical fixes:

1. Auth service: Token-first authentication (src/services/authService.js)
   - getXtreamUser() now checks token auth BEFORE trying username/password
   - When a valid token exists, skip username/password auth entirely
   - Prevents HLS segment requests (which use placeholder path params 'token'/'auth') from logging failed login attempts
   - This was causing brute-force protection to trigger after ~10 segment requests, blocking the user's IP with 403 Forbidden

2. Player: Use native fMP4 for ALL transcode playback (player.html)
   - Transcode retry now ALWAYS requests .mp4 format instead of .ts
   - Server outputs fragmented MP4 (video copy + audio→AAC via FFmpeg)
   - Native <video> element plays fMP4 directly — no MSE needed at all
   - This completely bypasses the addSourceBuffer AC-3/HEVC errors
   - Previous approach used mpegts.js for transcode which still failed because mpegts.js detects AC-3 codec info before FFmpeg output arrives

3. Player: Manual transcode toggle also uses .mp4 native playback
   - 'Fix Audio' toggle now requests .mp4 format consistently
   - Same bypass of MSE/mpegts.js codec limitations