### PR TITLE
🎨 Palette: Add password visibility toggle to login modal

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -277,6 +277,23 @@ function fallbackCopyTextToClipboard(text, btnElement, successCallback) {
     document.body.removeChild(textArea);
 }
 
+function togglePasswordVisibility(inputId, btn) {
+    const input = document.getElementById(inputId);
+    if (!input) return;
+
+    const isPassword = input.type === 'password';
+    input.type = isPassword ? 'text' : 'password';
+
+    // Update Button
+    btn.innerHTML = isPassword ? '🙈' : '👁️';
+
+    // Update ARIA and Title
+    const labelKey = isPassword ? 'hide_password' : 'show_password';
+    const label = t(labelKey);
+    btn.setAttribute('aria-label', label);
+    btn.title = label;
+}
+
 function copyAllXtreamCredentials(btnElement) {
     const url = document.getElementById('xtream-url').value;
     const user = document.getElementById('xtream-user').value;

--- a/public/i18n.js
+++ b/public/i18n.js
@@ -189,6 +189,8 @@ const translations = {
 
     // Password Change
     change_password: 'Change Password',
+    show_password: 'Show Password',
+    hide_password: 'Hide Password',
     old_password: 'Old Password',
     new_password: 'New Password',
     confirm_password: 'Confirm Password',
@@ -551,6 +553,8 @@ const translations = {
 
     // Password Change
     change_password: 'Passwort ändern',
+    show_password: 'Passwort anzeigen',
+    hide_password: 'Passwort verbergen',
     old_password: 'Altes Passwort',
     new_password: 'Neues Passwort',
     confirm_password: 'Passwort bestätigen',
@@ -913,6 +917,8 @@ const translations = {
 
     // Password Change
     change_password: 'Changer le mot de passe',
+    show_password: 'Afficher le mot de passe',
+    hide_password: 'Masquer le mot de passe',
     old_password: 'Ancien mot de passe',
     new_password: 'Nouveau mot de passe',
     confirm_password: 'Confirmer le mot de passe',
@@ -1275,6 +1281,8 @@ const translations = {
 
     // Password Change
     change_password: 'Αλλαγή κωδικού',
+    show_password: 'Εμφάνιση κωδικού',
+    hide_password: 'Απόκρυψη κωδικού',
     old_password: 'Παλιός κωδικός',
     new_password: 'Νέος κωδικός',
     confirm_password: 'Επιβεβαίωση κωδικού',

--- a/public/index.html
+++ b/public/index.html
@@ -871,7 +871,10 @@
             </div>
             <div class="mb-3">
               <label for="login-password" class="form-label" data-i18n="password">Password</label>
-              <input type="password" class="form-control" id="login-password" required>
+              <div class="input-group">
+                <input type="password" class="form-control" id="login-password" required>
+                <button class="btn btn-outline-secondary" type="button" onclick="togglePasswordVisibility('login-password', this)" data-i18n-label="show_password" data-i18n-title="show_password">👁️</button>
+              </div>
             </div>
             <div class="mb-3" id="login-otp-group" style="display:none;">
               <label for="login-otp" class="form-label" data-i18n="otp_code">2FA Code</label>


### PR DESCRIPTION
🎨 Palette: Add password visibility toggle to login modal

💡 **What:** Added a "Show/Hide Password" toggle button to the login modal password field.
🎯 **Why:** Users often need to verify their password before submitting, especially on mobile devices or when using complex passwords. This reduces login errors and frustration.
📸 **Before/After:**
*(Screenshots were generated during verification)*
- Before: Password always masked `*******`
- After: User can click 👁️ to reveal password as text.

♿ **Accessibility:**
- Added `aria-label` that updates dynamically ("Show Password" / "Hide Password").
- Button has proper keyboard focus support (via native `<button>` element).
- Added tooltip (`title`) for mouse users.

**Implementation Details:**
- Modified `public/index.html` to wrap the login password input in a Bootstrap `input-group`.
- Added `togglePasswordVisibility` function in `public/app.js`.
- Added translation keys to `public/i18n.js` for EN, DE, FR, EL.

---
*PR created automatically by Jules for task [12931183379976357591](https://jules.google.com/task/12931183379976357591) started by @Bladestar2105*