### PR TITLE
🎨 Palette: Add password visibility toggles

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -935,7 +935,10 @@
             </div>
             <div class="mb-3">
               <label class="form-label" data-i18n="new_password">New Password</label>
-              <input type="password" class="form-control" id="edit-user-password" data-i18n-placeholder="leaveBlankToKeep" placeholder="Leave blank to keep current">
+              <div class="input-group">
+                <input type="password" class="form-control" id="edit-user-password" data-i18n-placeholder="leaveBlankToKeep" placeholder="Leave blank to keep current">
+                <button class="btn btn-outline-secondary" type="button" onclick="togglePasswordVisibility('edit-user-password', this)" data-i18n-label="show_password" data-i18n-title="show_password">👁️</button>
+              </div>
             </div>
             <div class="mb-3 form-check">
               <input type="checkbox" class="form-check-input" id="edit-user-webui-access">
@@ -963,16 +966,25 @@
           <form id="change-password-form" onsubmit="handleChangePassword(event)">
             <div class="mb-3">
               <label for="old-password" class="form-label" data-i18n="old_password">Old Password</label>
-              <input type="password" class="form-control" id="old-password" required>
+              <div class="input-group">
+                <input type="password" class="form-control" id="old-password" required>
+                <button class="btn btn-outline-secondary" type="button" onclick="togglePasswordVisibility('old-password', this)" data-i18n-label="show_password" data-i18n-title="show_password">👁️</button>
+              </div>
             </div>
             <div class="mb-3">
               <label for="new-password" class="form-label" data-i18n="new_password">New Password</label>
-              <input type="password" class="form-control" id="new-password" required minlength="8">
+              <div class="input-group">
+                <input type="password" class="form-control" id="new-password" required minlength="8">
+                <button class="btn btn-outline-secondary" type="button" onclick="togglePasswordVisibility('new-password', this)" data-i18n-label="show_password" data-i18n-title="show_password">👁️</button>
+              </div>
               <small class="form-text text-secondary" data-i18n="password_min_length">Minimum 8 characters</small>
             </div>
             <div class="mb-3">
               <label for="confirm-password" class="form-label" data-i18n="confirm_password">Confirm Password</label>
-              <input type="password" class="form-control" id="confirm-password" required minlength="8">
+              <div class="input-group">
+                <input type="password" class="form-control" id="confirm-password" required minlength="8">
+                <button class="btn btn-outline-secondary" type="button" onclick="togglePasswordVisibility('confirm-password', this)" data-i18n-label="show_password" data-i18n-title="show_password">👁️</button>
+              </div>
             </div>
             <div id="change-password-error" class="alert alert-danger" style="display: none;"></div>
             <div id="change-password-success" class="alert alert-success" style="display: none;"></div>
@@ -1014,7 +1026,10 @@
                 </div>
                 <div class="col-md-6">
                    <label class="form-label" data-i18n="password">Password</label>
-                   <input class="form-control" name="password" required>
+                   <div class="input-group">
+                     <input class="form-control" name="password" id="provider-password" type="password" required>
+                     <button class="btn btn-outline-secondary" type="button" onclick="togglePasswordVisibility('provider-password', this)" data-i18n-label="show_password" data-i18n-title="show_password">👁️</button>
+                   </div>
                 </div>
              </div>
              <div class="mb-3">


### PR DESCRIPTION
💡 What: Added password visibility toggles (👁️/🙈) to all password input fields in modals (Change Password, Edit User, Add Provider).
🎯 Why: Users often make typos when setting passwords. Allowing them to reveal the password improves usability and reduces frustration.
📸 Before/After:
Before: Password fields were permanently masked.
After: Password fields have an "eye" icon to toggle visibility.
♿ Accessibility:
- Added `aria-label` to toggle buttons via `data-i18n-label`.
- `togglePasswordVisibility` function (existing) updates the button icon and ARIA label dynamically.
- Inputs are wrapped in `input-group` for proper semantic grouping and styling.

---
*PR created automatically by Jules for task [8741464212251760388](https://jules.google.com/task/8741464212251760388) started by @Bladestar2105*