### PR TITLE
feat(security): use bcrypt for user password storage

### DIFF
--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -212,12 +212,7 @@ export const changePassword = async (req, res) => {
       return res.status(401).json({error: 'invalid_old_password'});
     }
 
-    let newPasswordStored;
-    if (isAdmin) {
-        newPasswordStored = await bcrypt.hash(newPassword, BCRYPT_ROUNDS);
-    } else {
-        newPasswordStored = encrypt(newPassword);
-    }
+    const newPasswordStored = await bcrypt.hash(newPassword, BCRYPT_ROUNDS);
 
     // Update password
     db.prepare(`UPDATE ${table} SET password = ? WHERE id = ?`).run(newPasswordStored, userId);

--- a/src/database/db.js
+++ b/src/database/db.js
@@ -228,6 +228,7 @@ export function initDb(isPrimary) {
             migrations.checkIsAdultColumn(db);
             migrations.migrateIndexes(db);
             migrations.migrateOtpSecrets(db);
+            migrations.migrateUserPasswords(db);
 
             // Clear ephemeral streams
             db.exec('DELETE FROM current_streams');


### PR DESCRIPTION
This PR enhances security by replacing reversible password encryption with one-way hashing using `bcrypt` for user accounts. 

Previously, user passwords were stored using reversible AES encryption. If the encryption key were compromised, all user passwords would be exposed. This change ensures that passwords are hashed, making them resistant to such attacks.

Changes:
- **`src/controllers/userController.js`**: `createUser` and `updateUser` now use `bcrypt.hash` to store passwords.
- **`src/controllers/authController.js`**: `changePassword` now uses `bcrypt.hash` for all users (previously only admins used bcrypt).
- **`src/database/migrations.js`**: Added `migrateUserPasswords` function which iterates through all users, decrypts legacy passwords (if possible), and re-saves them as bcrypt hashes. This migration runs synchronously during startup to ensure consistency.
- **`src/database/db.js`**: Registered the new migration.

Verification:
- Existing tests passed.
- Server starts successfully and runs migrations.
- `login` logic was verified to support both legacy (encrypted) and new (bcrypt) password formats, ensuring no service disruption during migration.

---
*PR created automatically by Jules for task [10439711702765050137](https://jules.google.com/task/10439711702765050137) started by @Bladestar2105*