### PR TITLE
Fix provider sync interval ignored on failure

### DIFF
--- a/tests/sync_service.test.js
+++ b/tests/sync_service.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { calculateNextSync } from '../src/services/syncService.js';
+
+describe('calculateNextSync', () => {
+  const originalDateNow = Date.now;
+
+  beforeEach(() => {
+    // Mock time to a fixed timestamp (e.g., 1000000000 * 1000 ms)
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(1000000000 * 1000));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should calculate hourly interval correctly', () => {
+    const nextSync = calculateNextSync('hourly');
+    expect(nextSync).toBe(1000000000 + 3600);
+  });
+
+  it('should calculate every_6_hours interval correctly', () => {
+    const nextSync = calculateNextSync('every_6_hours');
+    expect(nextSync).toBe(1000000000 + 21600);
+  });
+
+  it('should calculate every_12_hours interval correctly', () => {
+    const nextSync = calculateNextSync('every_12_hours');
+    expect(nextSync).toBe(1000000000 + 43200);
+  });
+
+  it('should calculate daily interval correctly', () => {
+    const nextSync = calculateNextSync('daily');
+    expect(nextSync).toBe(1000000000 + 86400);
+  });
+
+  it('should calculate weekly interval correctly', () => {
+    const nextSync = calculateNextSync('weekly');
+    expect(nextSync).toBe(1000000000 + 604800);
+  });
+
+  it('should default to daily if interval is unknown', () => {
+    const nextSync = calculateNextSync('unknown_interval');
+    expect(nextSync).toBe(1000000000 + 86400);
+  });
+});


### PR DESCRIPTION
Modified `src/services/syncService.js` to update `next_sync` in the database when a sync operation fails. This prevents the sync scheduler from retrying indefinitely (every minute) and ensures the configured sync interval is respected regardless of success or failure.

Steps:
1.  Moved `config` variable declaration outside the `try` block in `performSync`.
2.  Moved `config` fetching to the beginning of `performSync`.
3.  Added logic in the `catch` block to calculate and update `next_sync` if `config` is available.
4.  Verified with a reproduction script (deleted after verification) and added a permanent unit test for `calculateNextSync`.

---
*PR created automatically by Jules for task [18429829752097155497](https://jules.google.com/task/18429829752097155497) started by @Bladestar2105*