### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix SSRF bypass via 0.0.0.0 and ::

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -20,18 +20,31 @@ export async function isSafeUrl(urlStr) {
     if (ipVer === 0) return false;
 
     if (ipVer === 4) {
-        if (address.startsWith('127.') ||
+        if (address === '0.0.0.0' ||
+            address.startsWith('127.') ||
             address.startsWith('10.') ||
             address.startsWith('192.168.') ||
-            address.startsWith('169.254.')) return false;
+            address.startsWith('169.254.') ||
+            address.startsWith('192.0.0.') || // IETF Protocol Assignments
+            address.startsWith('192.0.2.') || // TEST-NET-1
+            address.startsWith('198.51.100.') || // TEST-NET-2
+            address.startsWith('203.0.113.') || // TEST-NET-3
+            address.startsWith('240.')) return false; // Class E (Reserved)
 
         if (address.startsWith('172.')) {
             const parts = address.split('.');
             const second = parseInt(parts[1], 10);
             if (second >= 16 && second <= 31) return false;
         }
+
+        // CGNAT (100.64.0.0/10)
+        if (address.startsWith('100.')) {
+            const parts = address.split('.');
+            const second = parseInt(parts[1], 10);
+            if (second >= 64 && second <= 127) return false;
+        }
     } else if (ipVer === 6) {
-         if (address === '::1' || address.includes('::ffff:') || address.startsWith('fe80:') || address.startsWith('fc') || address.startsWith('fd')) return false;
+         if (address === '::' || address === '::1' || address.includes('::ffff:') || address.startsWith('fe80:') || address.startsWith('fc') || address.startsWith('fd')) return false;
     }
 
     return true;

--- a/tests/security/is_safe_url.test.js
+++ b/tests/security/is_safe_url.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { isSafeUrl } from '../../src/utils/helpers.js';
+
+describe('isSafeUrl Security Checks', () => {
+  it('should block 0.0.0.0 (IPv4 Any)', async () => {
+    const safe = await isSafeUrl('http://0.0.0.0');
+    expect(safe).toBe(false);
+  });
+
+  it('should block :: (IPv6 Any)', async () => {
+    const safe = await isSafeUrl('http://[::]');
+    expect(safe).toBe(false);
+  });
+
+  it('should block 0.0.0.0 with port', async () => {
+    const safe = await isSafeUrl('http://0.0.0.0:8080');
+    expect(safe).toBe(false);
+  });
+
+  it('should block :: with port', async () => {
+    const safe = await isSafeUrl('http://[::]:8080');
+    expect(safe).toBe(false);
+  });
+
+  it('should allow public IPs', async () => {
+    const safe = await isSafeUrl('http://8.8.8.8');
+    expect(safe).toBe(true);
+  });
+
+  it('should block 127.0.0.1', async () => {
+    const safe = await isSafeUrl('http://127.0.0.1');
+    expect(safe).toBe(false);
+  });
+
+  it('should block ::1', async () => {
+    const safe = await isSafeUrl('http://[::1]');
+    expect(safe).toBe(false);
+  });
+
+  it('should block CGNAT range (100.64.0.1)', async () => {
+    const safe = await isSafeUrl('http://100.64.0.1');
+    expect(safe).toBe(false);
+  });
+
+  it('should block TEST-NET-1 (192.0.2.1)', async () => {
+    const safe = await isSafeUrl('http://192.0.2.1');
+    expect(safe).toBe(false);
+  });
+
+  it('should block TEST-NET-2 (198.51.100.1)', async () => {
+    const safe = await isSafeUrl('http://198.51.100.1');
+    expect(safe).toBe(false);
+  });
+
+  it('should block TEST-NET-3 (203.0.113.1)', async () => {
+    const safe = await isSafeUrl('http://203.0.113.1');
+    expect(safe).toBe(false);
+  });
+});


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: SSRF (Server-Side Request Forgery) bypass via `0.0.0.0` and `::` which map to localhost on many systems.
🎯 Impact: Attackers could access internal services running on localhost by using these IP addresses, bypassing existing `localhost` and `127.0.0.1` checks.
🔧 Fix: Explicitly block `0.0.0.0` and `::` in `isSafeUrl`. Also added blocks for other reserved/internal ranges like CGNAT.
✅ Verification: Added `tests/security/is_safe_url.test.js` which verifies that these IPs are now blocked. Ran `npx vitest` to confirm.

---
*PR created automatically by Jules for task [10572857270067695073](https://jules.google.com/task/10572857270067695073) started by @Bladestar2105*