### PR TITLE
Fix missing localization and hardcoded strings

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -346,12 +346,12 @@ function copyAllXtreamCredentials(btnElement) {
     const epg = document.getElementById('epg-url').value;
     const m3u = document.getElementById('m3u-link').value;
 
-    const text = `### Credentials for "${user}" ###\n` +
-                 `URL: ${url}\n` +
-                 `USERNAME: ${user}\n` +
-                 `PASSWORD: ${pass}\n` +
-                 `EPG-URL: ${epg}\n` +
-                 `M3U-URL: ${m3u}\n` +
+    const text = `### ${t('credentialsFor', {name: user})} ###\n` +
+                 `${t('url') || 'URL'}: ${url}\n` +
+                 `${t('usernameCaps')}: ${user}\n` +
+                 `${t('passwordCaps')}: ${pass}\n` +
+                 `${t('epgUrlCaps')}: ${epg}\n` +
+                 `${t('m3uUrlCaps')}: ${m3u}\n` +
                  `######`;
 
     copyToClipboard(text, btnElement);
@@ -437,7 +437,7 @@ async function loadUsers() {
         if (newWindow) {
             newWindow.document.write('Loading player...');
         } else {
-            alert(t('popupBlocked') || 'Popup blocked. Please allow popups for this site.');
+            alert(t('popupBlocked'));
             return;
         }
 
@@ -621,7 +621,7 @@ async function loadProviders(filterUserId = null) {
         else if (diffDays < 7) colorClass = 'text-warning fw-bold';
         else colorClass = 'text-success';
 
-        expiryInfo = `<br><small class="${colorClass}">${t('expiryDate') || 'Expires'}: ${expDate.toLocaleDateString()} (${diffDays} days)</small>`;
+        expiryInfo = `<br><small class="${colorClass}">${t('expiryDate') || 'Expires'}: ${expDate.toLocaleDateString()} (${diffDays} ${t('days')})</small>`;
     }
 
     const row = document.createElement('div');
@@ -1092,9 +1092,9 @@ async function importSelectedCategories(withChannels) {
       })
     });
 
-    let msg = `✅ ${result.categories_imported} categories imported`;
+    let msg = t('categoriesImported', {count: result.categories_imported});
     if (result.channels_imported > 0) {
-        msg += `, ${result.channels_imported} channels`;
+        msg += `, ${result.channels_imported} ${t('channels')}`;
     }
     alert(msg);
 
@@ -1984,7 +1984,7 @@ async function handleImport(e) {
         if (!response.ok) throw new Error(res.error || 'Import failed');
 
         const stats = res.stats;
-        alert(`${t('importSuccess')}\n\nUsers: ${stats.users_imported} (Skipped: ${stats.users_skipped})\nProviders: ${stats.providers}\nCategories: ${stats.categories}\nChannels: ${stats.channels}`);
+        alert(`${t('importSuccess')}\n\n${t('totalUsers')}: ${stats.users_imported} (${t('skipped')}: ${stats.users_skipped})\n${t('providers')}: ${stats.providers}\n${t('categories')}: ${stats.categories}\n${t('channels')}: ${stats.channels}`);
 
         f.reset();
         loadUsers();
@@ -2664,12 +2664,12 @@ async function loadStatistics() {
 }
 
 function formatDuration(sec) {
-    if (!sec) return '0s';
+    if (!sec) return `0${t('time_s')}`;
     const h = Math.floor(sec / 3600);
     const m = Math.floor((sec % 3600) / 60);
     const s = Math.floor(sec % 60);
-    if (h > 0) return `${h}h ${m}m`;
-    return `${m}m ${s}s`;
+    if (h > 0) return `${h}${t('time_h')} ${m}${t('time_m')}`;
+    return `${m}${t('time_m')} ${s}${t('time_s')}`;
 }
 
 // === EPG Mapping Logic ===

--- a/public/i18n.js
+++ b/public/i18n.js
@@ -365,7 +365,24 @@ const translations = {
     selectCategory: 'Select Category',
     selectCategoryPlaceholder: '-- Select Category --',
     selectUserFirst: 'Please select a user first',
-    select_options_to_load: 'Select options above to load channels'
+    select_options_to_load: 'Select options above to load channels',
+    // New
+    days: 'days',
+    providers: 'Providers',
+    skipped: 'Skipped',
+    credentialsFor: 'Credentials for "{name}"',
+    usernameCaps: 'USERNAME',
+    passwordCaps: 'PASSWORD',
+    epgUrlCaps: 'EPG-URL',
+    m3uUrlCaps: 'M3U-URL',
+    categoriesImported: '✅ {count} categories imported',
+    errorLoadingData: 'Error loading data',
+    popupBlocked: 'Popup blocked. Please allow popups for this site.',
+    otpPlaceholder: '123456',
+    optional: '(Optional)',
+    time_h: 'h',
+    time_m: 'm',
+    time_s: 's'
   },
   
   de: {
@@ -730,7 +747,24 @@ const translations = {
     selectCategory: 'Kategorie wählen',
     selectCategoryPlaceholder: '-- Kategorie wählen --',
     selectUserFirst: 'Bitte zuerst einen Benutzer wählen',
-    select_options_to_load: 'Bitte Optionen wählen'
+    select_options_to_load: 'Bitte Optionen wählen',
+    // New
+    days: 'Tage',
+    providers: 'Provider',
+    skipped: 'Übersprungen',
+    credentialsFor: 'Zugangsdaten für "{name}"',
+    usernameCaps: 'BENUTZERNAME',
+    passwordCaps: 'PASSWORT',
+    epgUrlCaps: 'EPG-URL',
+    m3uUrlCaps: 'M3U-URL',
+    categoriesImported: '✅ {count} Kategorien importiert',
+    errorLoadingData: 'Fehler beim Laden der Daten',
+    popupBlocked: 'Popup blockiert. Bitte erlauben Sie Popups für diese Seite.',
+    otpPlaceholder: '123456',
+    optional: '(Optional)',
+    time_h: 'h',
+    time_m: 'm',
+    time_s: 's'
   },
 
   fr: {
@@ -1095,7 +1129,24 @@ const translations = {
     selectCategory: 'Sélectionner Catégorie',
     selectCategoryPlaceholder: '-- Sélectionner Catégorie --',
     selectUserFirst: 'Veuillez d\'abord sélectionner un utilisateur',
-    select_options_to_load: 'Sélectionnez les options pour charger'
+    select_options_to_load: 'Sélectionnez les options pour charger',
+    // New
+    days: 'jours',
+    providers: 'Fournisseurs',
+    skipped: 'Ignoré',
+    credentialsFor: 'Identifiants pour "{name}"',
+    usernameCaps: 'NOM D\'UTILISATEUR',
+    passwordCaps: 'MOT DE PASSE',
+    epgUrlCaps: 'URL EPG',
+    m3uUrlCaps: 'URL M3U',
+    categoriesImported: '✅ {count} catégories importées',
+    errorLoadingData: 'Erreur lors du chargement des données',
+    popupBlocked: 'Popup bloqué. Veuillez autoriser les popups pour ce site.',
+    otpPlaceholder: '123456',
+    optional: '(Optionnel)',
+    time_h: 'h',
+    time_m: 'm',
+    time_s: 's'
   },
 
   el: {
@@ -1460,7 +1511,24 @@ const translations = {
     selectCategory: 'Επιλογή Κατηγορίας',
     selectCategoryPlaceholder: '-- Επιλέξτε Κατηγορία --',
     selectUserFirst: 'Παρακαλώ επιλέξτε πρώτα έναν χρήστη',
-    select_options_to_load: 'Επιλέξτε επιλογές για φόρτωση'
+    select_options_to_load: 'Επιλέξτε επιλογές για φόρτωση',
+    // New
+    days: 'ημέρες',
+    providers: 'Πάροχοι',
+    skipped: 'Παραλείφθηκαν',
+    credentialsFor: 'Διαπιστευτήρια για "{name}"',
+    usernameCaps: 'ΟΝΟΜΑ ΧΡΗΣΤΗ',
+    passwordCaps: 'ΚΩΔΙΚΟΣ',
+    epgUrlCaps: 'URL EPG',
+    m3uUrlCaps: 'URL M3U',
+    categoriesImported: '✅ {count} κατηγορίες εισήχθησαν',
+    errorLoadingData: 'Σφάλμα φόρτωσης δεδομένων',
+    popupBlocked: 'Το αναδυόμενο παράθυρο αποκλείστηκε. Παρακαλώ επιτρέψτε τα αναδυόμενα παράθυρα.',
+    otpPlaceholder: '123456',
+    optional: '(Προαιρετικό)',
+    time_h: 'ώ',
+    time_m: 'λ',
+    time_s: 'δ'
   }
 };
 

--- a/public/index.html
+++ b/public/index.html
@@ -883,7 +883,7 @@
             </div>
             <div class="mb-3" id="login-otp-group" style="display:none;">
               <label for="login-otp" class="form-label" data-i18n="otp_code">2FA Code</label>
-              <input type="text" class="form-control" id="login-otp" autocomplete="off" placeholder="123456">
+              <input type="text" class="form-control" id="login-otp" autocomplete="off" data-i18n-placeholder="otpPlaceholder" placeholder="123456">
             </div>
             <div id="login-error" class="alert alert-danger" style="display: none;"></div>
             <button type="submit" class="btn btn-primary w-100" id="login-btn" data-i18n="login">Login</button>
@@ -909,7 +909,7 @@
              </div>
              <p data-i18n="scan_qr">Scan the QR code with your authenticator app (Google Authenticator, Authy, etc.)</p>
              <div class="input-group mb-3">
-                <input type="text" id="otp-verify-input" class="form-control" placeholder="123456">
+                <input type="text" id="otp-verify-input" class="form-control" data-i18n-placeholder="otpPlaceholder" placeholder="123456">
                 <button class="btn btn-primary" onclick="verifyAndEnableOtp()" data-i18n="verify">Verify</button>
              </div>
           </div>
@@ -1039,7 +1039,7 @@
              </div>
              <div class="mb-3">
                 <label class="form-label" data-i18n="epgUrl">EPG URL</label>
-                <input class="form-control" name="epg_url" placeholder="(Optional)">
+                <input class="form-control" name="epg_url" data-i18n-placeholder="optional" placeholder="(Optional)">
              </div>
              <div class="mb-3">
                 <label class="form-label" data-i18n="expiryDate">Expiry Date</label>

--- a/public/player.html
+++ b/public/player.html
@@ -613,7 +613,7 @@
       }
     } catch (e) {
       console.error('Init error:', e);
-      showToast('Error loading data: ' + e.message, 'danger', 10000);
+      showToast(t('errorLoadingData') + ': ' + e.message, 'danger', 10000);
     } finally {
       loadingEl.style.display = 'none';
     }


### PR DESCRIPTION
Replaced hardcoded strings with translation keys across the frontend to support full localization.

- **`public/i18n.js`**: Added missing translation keys for `days`, `skipped`, `credentialsFor`, `usernameCaps`, `passwordCaps`, `epgUrlCaps`, `m3uUrlCaps`, `categoriesImported`, `errorLoadingData`, `popupBlocked`, `otpPlaceholder`, `optional`, `time_h`, `time_m`, `time_s`, and `providers`.
- **`public/app.js`**:
    - Replaced hardcoded English in `loadProviders` (expiry date).
    - Replaced hardcoded message in `importSelectedCategories`.
    - Replaced hardcoded statistics message in `handleImport`.
    - Replaced hardcoded labels in `copyAllXtreamCredentials`.
    - Replaced hardcoded suffixes in `formatDuration`.
    - Replaced hardcoded alert in `loadUsers`.
- **`public/index.html`**: Added `data-i18n-placeholder` attributes for OTP inputs and optional EPG URL input.
- **`public/player.html`**: Localized the "Error loading data" toast message.

Verified visually with Playwright script (checking German localization of login and dashboard) and ensured no regressions with `npx vitest`.

---
*PR created automatically by Jules for task [14263079922055228789](https://jules.google.com/task/14263079922055228789) started by @Bladestar2105*