### PR TITLE
Fix EPG parsing for multiline attributes and XML entities

### DIFF
--- a/src/epg_utils.js
+++ b/src/epg_utils.js
@@ -1,6 +1,15 @@
 import fs from 'fs';
 import readline from 'readline';
 
+export function decodeXml(str) {
+  if (!str) return '';
+  return str.replace(/&quot;/g, '"')
+            .replace(/&apos;/g, "'")
+            .replace(/&lt;/g, '<')
+            .replace(/&gt;/g, '>')
+            .replace(/&amp;/g, '&');
+}
+
 export function cleanName(name) {
   if (!name) return '';
   let cleaned = name.toLowerCase();
@@ -163,53 +172,55 @@ export async function parseEpgXml(filePath, onProgramme) {
       crlfDelay: Infinity
   });
 
-  let currentProg = null;
   let buffer = '';
-
-  // Simple state machine
-  // We look for <programme ...> to start
-  // We collect until </programme>
-  // We extract data
+  let inProgramme = false;
 
   for await (const line of rl) {
       const trimmed = line.trim();
 
-      if (trimmed.startsWith('<programme')) {
-          buffer = trimmed;
-          currentProg = {};
-
-          // Quick extract attributes from the opening tag
-          const startMatch = trimmed.match(/start="([^"]+)"/);
-          const stopMatch = trimmed.match(/stop="([^"]+)"/);
-          const channelMatch = trimmed.match(/channel="([^"]+)"/);
-
-          if (startMatch) currentProg.start = parseXmltvDate(startMatch[1]);
-          if (stopMatch) currentProg.stop = parseXmltvDate(stopMatch[1]);
-          if (channelMatch) currentProg.channel_id = channelMatch[1];
+      if (!inProgramme) {
+          if (trimmed.startsWith('<programme')) {
+              inProgramme = true;
+              buffer = trimmed;
+          }
+      } else {
+          // In programme block
+          // Append with space to avoid merging attributes incorrectly
+          buffer += ' ' + trimmed;
       }
 
-      if (currentProg) {
-          if (!buffer.includes(trimmed)) {
-             buffer += ' ' + trimmed; // Append if not start line
-          }
+      if (inProgramme && buffer.includes('</programme>')) {
+          inProgramme = false;
 
-          if (trimmed.includes('</programme>')) {
-              // Parse Title
-              const titleMatch = buffer.match(/<title[^>]*>([^<]+)<\/title>/);
-              if (titleMatch) currentProg.title = titleMatch[1]; // decode entities if needed
+          // Extract attributes from the full block (handling multiline)
+          // Use [\s\S] to match across newlines if any, though buffer is single line here
+          // Buffer is constructed from lines with spaces in between.
 
-              // Parse Desc
-              const descMatch = buffer.match(/<desc[^>]*>([^<]+)<\/desc>/);
-              if (descMatch) currentProg.desc = descMatch[1];
+          const startMatch = buffer.match(/start="([^"]+)"/);
+          const stopMatch = buffer.match(/stop="([^"]+)"/);
+          const channelMatch = buffer.match(/channel="([^"]+)"/);
 
-              // Validate and emit
-              if (currentProg.channel_id && currentProg.start && currentProg.stop && currentProg.title) {
-                  onProgramme(currentProg);
+          const titleMatch = buffer.match(/<title[^>]*>([^<]+)<\/title>/);
+          const descMatch = buffer.match(/<desc[^>]*>([^<]+)<\/desc>/);
+
+          if (startMatch && stopMatch && channelMatch && titleMatch) {
+              const channelId = decodeXml(channelMatch[1]);
+              const title = decodeXml(titleMatch[1]);
+              const desc = descMatch ? decodeXml(descMatch[1]) : '';
+              const start = parseXmltvDate(startMatch[1]);
+              const stop = parseXmltvDate(stopMatch[1]);
+
+              if (channelId && start && stop && title) {
+                  onProgramme({
+                      channel_id: channelId,
+                      title: title,
+                      desc: desc,
+                      start: start,
+                      stop: stop
+                  });
               }
-
-              currentProg = null;
-              buffer = '';
           }
+          buffer = '';
       }
   }
 }
@@ -246,7 +257,7 @@ export function parseEpgChannels(filePath, onChannel) {
              const nameMatch = fullBlock.match(/<display-name[^>]*>([^<]+)<\/display-name>/);
 
              if (idMatch && nameMatch) {
-                 onChannel({ id: idMatch[1], name: nameMatch[1] });
+                 onChannel({ id: decodeXml(idMatch[1]), name: decodeXml(nameMatch[1]) });
              }
          }
 

--- a/src/services/epgService.js
+++ b/src/services/epgService.js
@@ -5,7 +5,7 @@ import fetch from 'node-fetch';
 import { createWriteStream } from 'fs';
 import db from '../database/db.js';
 import { EPG_CACHE_DIR } from '../config/constants.js';
-import { mergeEpgFiles, filterEpgFile } from '../epg_utils.js';
+import { mergeEpgFiles, filterEpgFile, decodeXml } from '../epg_utils.js';
 import { isSafeUrl } from '../utils/helpers.js';
 
 if (!fs.existsSync(EPG_CACHE_DIR)) fs.mkdirSync(EPG_CACHE_DIR, { recursive: true });
@@ -40,7 +40,7 @@ export async function loadAllEpgChannels() {
       const channelRegex = /<channel id="([^"]+)">([\s\S]*?)<\/channel>/g;
       let match;
       while ((match = channelRegex.exec(content)) !== null) {
-        const id = match[1];
+        const id = decodeXml(match[1]);
         if (seenIds.has(id)) continue;
 
         const inner = match[2];
@@ -49,7 +49,7 @@ export async function loadAllEpgChannels() {
 
         allChannels.push({
           id: id,
-          name: nameMatch ? nameMatch[1] : id,
+          name: nameMatch ? decodeXml(nameMatch[1]) : id,
           logo: iconMatch ? iconMatch[1] : null,
           source: item.source
         });


### PR DESCRIPTION
This PR fixes a critical issue where EPG data was missing for many channels. The root cause was that the XML parser (`parseEpgXml`) assumed attributes were on the same line as the opening tag, failing for pretty-printed XML. Additionally, XML entities (like `&amp;`) were not decoded, causing mismatches between channel IDs in the playlist and the EPG data.

Changes:
- Added `decodeXml` utility function.
- Refactored `parseEpgXml` to parse attributes from the full programme block (supporting multiline).
- Applied `decodeXml` to channel IDs, titles, and descriptions in EPG parsing functions.

---
*PR created automatically by Jules for task [7707033460703246698](https://jules.google.com/task/7707033460703246698) started by @Bladestar2105*