### PR TITLE
Fix 500 error returning HTML during import (JSON expected)

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -5,6 +5,7 @@ import morgan from 'morgan';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { securityHeaders, ipBlocker, apiLimiter } from './middleware/security.js';
+import { errorHandler } from './middleware/errorHandler.js';
 
 import authRoutes from './routes/auth.js';
 import userRoutes from './routes/users.js';
@@ -82,5 +83,8 @@ app.use('/api', systemRoutes);
 app.use('/', streamRoutes);
 app.use('/', xtreamRoutes);
 app.use('/hdhr', hdhrRoutes);
+
+// Error Handler
+app.use(errorHandler);
 
 export default app;

--- a/src/middleware/errorHandler.js
+++ b/src/middleware/errorHandler.js
@@ -1,0 +1,23 @@
+import multer from 'multer';
+
+export const errorHandler = (err, req, res, next) => {
+  console.error(err.stack);
+
+  if (res.headersSent) {
+    return next(err);
+  }
+
+  if (err instanceof multer.MulterError) {
+    if (err.code === 'LIMIT_FILE_SIZE') {
+      return res.status(400).json({ error: 'File too large' });
+    }
+    return res.status(400).json({ error: err.message });
+  }
+
+  if (err.type === 'entity.too.large') { // Body parser limit
+      return res.status(413).json({ error: 'Payload too large' });
+  }
+
+  // Default to 500
+  res.status(500).json({ error: err.message || 'Internal Server Error' });
+};

--- a/tests/middleware_error.test.js
+++ b/tests/middleware_error.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import multer from 'multer';
+import { errorHandler } from '../src/middleware/errorHandler.js';
+
+describe('Error Handling Middleware', () => {
+    const app = express();
+
+    // Setup routes that throw errors
+    app.get('/error', (req, res, next) => {
+        next(new Error('Generic Error'));
+    });
+
+    app.get('/multer-error', (req, res, next) => {
+        const err = new multer.MulterError('LIMIT_FILE_SIZE');
+        next(err);
+    });
+
+    app.get('/multer-other-error', (req, res, next) => {
+        const err = new multer.MulterError('LIMIT_UNEXPECTED_FILE');
+        next(err);
+    });
+
+    app.get('/body-parser-error', (req, res, next) => {
+        const err = new Error('Payload too large');
+        err.type = 'entity.too.large';
+        next(err);
+    });
+
+    // Register middleware
+    app.use(errorHandler);
+
+    it('should return 500 JSON for generic errors', async () => {
+        const res = await request(app).get('/error');
+        expect(res.status).toBe(500);
+        expect(res.headers['content-type']).toMatch(/json/);
+        expect(res.body).toEqual({ error: 'Generic Error' });
+    });
+
+    it('should return 400 JSON for Multer LIMIT_FILE_SIZE', async () => {
+        const res = await request(app).get('/multer-error');
+        expect(res.status).toBe(400);
+        expect(res.headers['content-type']).toMatch(/json/);
+        expect(res.body).toEqual({ error: 'File too large' });
+    });
+
+    it('should return 400 JSON for other Multer errors', async () => {
+        const res = await request(app).get('/multer-other-error');
+        expect(res.status).toBe(400);
+        expect(res.headers['content-type']).toMatch(/json/);
+        expect(res.body).toEqual({ error: 'Unexpected field' });
+    });
+
+    it('should return 413 JSON for body parser limit errors', async () => {
+        const res = await request(app).get('/body-parser-error');
+        expect(res.status).toBe(413);
+        expect(res.headers['content-type']).toMatch(/json/);
+        expect(res.body).toEqual({ error: 'Payload too large' });
+    });
+});


### PR DESCRIPTION
Added global error handler middleware to ensure all errors, including Multer errors during file upload, are returned as JSON. This fixes the issue where the client received an HTML error page (500) causing a JSON parsing error. verified with a new unit test.

---
*PR created automatically by Jules for task [18062189093660146309](https://jules.google.com/task/18062189093660146309) started by @Bladestar2105*