### PR TITLE
Fix invalid file type error during import

### DIFF
--- a/tests/crypto_upgrade.test.js
+++ b/tests/crypto_upgrade.test.js
@@ -1,9 +1,9 @@
 
 import { encrypt, decrypt, ENCRYPTION_KEY } from '../src/utils/crypto.js';
 import crypto from 'crypto';
-import assert from 'assert';
+import { describe, it, expect } from 'vitest';
 
-console.log('🧪 Starting Crypto Upgrade Tests...');
+describe('Crypto Upgrade Tests', () => {
 
 // Helper to create legacy CBC ciphertext
 function legacyEncrypt(text, keyHex) {
@@ -15,80 +15,66 @@ function legacyEncrypt(text, keyHex) {
 }
 
 // 1. Verify New Encryption Format (GCM)
-console.log('1. Testing New Encryption (GCM)...');
-const plaintext = 'This is a secure message';
-const encrypted = encrypt(plaintext);
-console.log('   Encrypted:', encrypted);
+it('Testing New Encryption (GCM)...', () => {
+    const plaintext = 'This is a secure message';
+    const encrypted = encrypt(plaintext);
+    console.log('   Encrypted:', encrypted);
 
-const parts = encrypted.split(':');
-if (parts.length !== 3) {
-    console.error('❌ FAILED: Expected 3 parts (IV:Ciphertext:Tag), got ' + parts.length);
-    process.exit(1);
-} else {
+    const parts = encrypted.split(':');
+    expect(parts.length).toBe(3);
     console.log('✅ Format correct (3 parts)');
-}
+});
 
 // 2. Verify Decryption of New Format
-console.log('2. Testing Decryption of New Format...');
-const decrypted = decrypt(encrypted);
-if (decrypted !== plaintext) {
-    console.error(`❌ FAILED: Decrypted '${decrypted}' does not match '${plaintext}'`);
-    process.exit(1);
-} else {
+it('Testing Decryption of New Format...', () => {
+    const plaintext = 'This is a secure message';
+    const encrypted = encrypt(plaintext);
+    const decrypted = decrypt(encrypted);
+    expect(decrypted).toBe(plaintext);
     console.log('✅ Decryption successful');
-}
+});
 
 // 3. Verify Backward Compatibility (Legacy CBC)
-console.log('3. Testing Backward Compatibility (CBC)...');
-const legacyPlaintext = 'This is a legacy message';
-const legacyCiphertext = legacyEncrypt(legacyPlaintext, ENCRYPTION_KEY);
-console.log('   Legacy Ciphertext:', legacyCiphertext);
+it('Testing Backward Compatibility (CBC)...', () => {
+    const legacyPlaintext = 'This is a legacy message';
+    const legacyCiphertext = legacyEncrypt(legacyPlaintext, ENCRYPTION_KEY);
+    console.log('   Legacy Ciphertext:', legacyCiphertext);
 
-const legacyParts = legacyCiphertext.split(':');
-if (legacyParts.length !== 2) {
-    console.error('❌ SETUP ERROR: Legacy helper produced wrong format');
-    process.exit(1);
-}
+    const legacyParts = legacyCiphertext.split(':');
+    expect(legacyParts.length).toBe(2);
 
-const decryptedLegacy = decrypt(legacyCiphertext);
-if (decryptedLegacy !== legacyPlaintext) {
-    console.error(`❌ FAILED: Legacy decryption failed. Got '${decryptedLegacy}', expected '${legacyPlaintext}'`);
-    process.exit(1);
-} else {
+    const decryptedLegacy = decrypt(legacyCiphertext);
+    expect(decryptedLegacy).toBe(legacyPlaintext);
     console.log('✅ Legacy decryption successful');
-}
+});
 
 // 4. Verify Integrity Check (Tampering)
-console.log('4. Testing Integrity Check (Tampering)...');
+it('Testing Integrity Check (Tampering)...', () => {
+    const plaintext = 'This is a secure message';
+    const encrypted = encrypt(plaintext);
+    const parts = encrypted.split(':');
 
-// 4a. Tamper Ciphertext
-const tamperedParts1 = [...parts];
-const ct = Buffer.from(tamperedParts1[1], 'hex');
-ct[0] = ct[0] ^ 0xFF; // Flip first byte
-tamperedParts1[1] = ct.toString('hex');
-const tamperedCiphertext = tamperedParts1.join(':');
+    // 4a. Tamper Ciphertext
+    const tamperedParts1 = [...parts];
+    const ct = Buffer.from(tamperedParts1[1], 'hex');
+    ct[0] = ct[0] ^ 0xFF; // Flip first byte
+    tamperedParts1[1] = ct.toString('hex');
+    const tamperedCiphertext = tamperedParts1.join(':');
 
-const decryptedTampered1 = decrypt(tamperedCiphertext);
-if (decryptedTampered1 !== null) {
-    console.error('❌ FAILED: Tampered ciphertext should return null, got:', decryptedTampered1);
-    process.exit(1);
-} else {
+    const decryptedTampered1 = decrypt(tamperedCiphertext);
+    expect(decryptedTampered1).toBe(null);
     console.log('✅ Tampered ciphertext rejected (returns null)');
-}
 
-// 4b. Tamper Tag
-const tamperedParts2 = [...parts];
-const tag = Buffer.from(tamperedParts2[2], 'hex');
-tag[0] = tag[0] ^ 0xFF; // Flip first byte
-tamperedParts2[2] = tag.toString('hex');
-const tamperedTag = tamperedParts2.join(':');
+    // 4b. Tamper Tag
+    const tamperedParts2 = [...parts];
+    const tag = Buffer.from(tamperedParts2[2], 'hex');
+    tag[0] = tag[0] ^ 0xFF; // Flip first byte
+    tamperedParts2[2] = tag.toString('hex');
+    const tamperedTag = tamperedParts2.join(':');
 
-const decryptedTampered2 = decrypt(tamperedTag);
-if (decryptedTampered2 !== null) {
-    console.error('❌ FAILED: Tampered tag should return null, got:', decryptedTampered2);
-    process.exit(1);
-} else {
+    const decryptedTampered2 = decrypt(tamperedTag);
+    expect(decryptedTampered2).toBe(null);
     console.log('✅ Tampered tag rejected (returns null)');
-}
+});
 
-console.log('🎉 All Crypto Upgrade Tests Passed!');
+});

--- a/tests/upload_middleware.test.js
+++ b/tests/upload_middleware.test.js
@@ -1,0 +1,58 @@
+
+import { describe, it, expect, vi } from 'vitest';
+import { fileFilter } from '../src/middleware/upload.js';
+
+describe('Upload Middleware - fileFilter', () => {
+    it('should accept allowed mime types', () => {
+        const allowedTypes = [
+            'application/octet-stream',
+            'application/json',
+            'application/gzip',
+            'application/x-gzip',
+            'application/zip',
+            'application/x-zip-compressed'
+        ];
+
+        allowedTypes.forEach(type => {
+            const file = { mimetype: type, originalname: 'test.dat' };
+            const cb = vi.fn();
+            fileFilter({}, file, cb);
+            expect(cb).toHaveBeenCalledWith(null, true);
+        });
+    });
+
+    it('should accept allowed extensions regardless of mime type', () => {
+        const allowedExtensions = ['.bin', '.json', '.gz', '.enc'];
+
+        allowedExtensions.forEach(ext => {
+            const file = { mimetype: 'application/unknown', originalname: `file${ext}` };
+            const cb = vi.fn();
+            fileFilter({}, file, cb);
+            expect(cb).toHaveBeenCalledWith(null, true);
+        });
+    });
+
+    it('should accept allowed extensions with mixed case', () => {
+        const file = { mimetype: 'application/unknown', originalname: 'file.BIN' };
+        const cb = vi.fn();
+        fileFilter({}, file, cb);
+        expect(cb).toHaveBeenCalledWith(null, true);
+    });
+
+    it('should reject invalid mime type AND extension', () => {
+        const file = { mimetype: 'image/png', originalname: 'image.png' };
+        const cb = vi.fn();
+        fileFilter({}, file, cb);
+        expect(cb).toHaveBeenCalledWith(expect.any(Error));
+        expect(cb.mock.calls[0][0].message).toBe('Invalid file type');
+    });
+
+    it('should log rejected files', () => {
+        const consoleSpy = vi.spyOn(console, 'warn');
+        const file = { mimetype: 'text/plain', originalname: 'malicious.txt' };
+        const cb = vi.fn();
+        fileFilter({}, file, cb);
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Rejected file: malicious.txt (text/plain)'));
+        consoleSpy.mockRestore();
+    });
+});


### PR DESCRIPTION
Fixed an issue where importing an export file failed with "Invalid file type" due to strict MIME type validation in `multer` middleware.
The fix expands the allowed MIME types and adds a fallback check for file extensions (`.bin`, `.json`, `.gz`, `.enc`) to handle cases where browsers or OS send unexpected MIME types (e.g. for `.bin` files).
Also added a unit test suite for the upload middleware and refactored a legacy crypto test script to be compatible with Vitest.

---
*PR created automatically by Jules for task [11308971524207910293](https://jules.google.com/task/11308971524207910293) started by @Bladestar2105*