### PR TITLE
Fix express-rate-limit validation error when trust proxy is enabled

### DIFF
--- a/src/middleware/security.js
+++ b/src/middleware/security.js
@@ -9,6 +9,7 @@ export const authLimiter = rateLimit({
   message: { error: 'Too many authentication attempts, please try again later' },
   standardHeaders: true,
   legacyHeaders: false,
+  validate: { trustProxy: false }
 });
 
 // General API rate limiting
@@ -18,6 +19,7 @@ export const apiLimiter = rateLimit({
   message: { error: 'Too many requests, please try again later' },
   standardHeaders: true,
   legacyHeaders: false,
+  validate: { trustProxy: false }
 });
 
 export const securityHeaders = helmet({


### PR DESCRIPTION
The application was logging `ValidationError: The Express 'trust proxy' setting is true, which allows anyone to trivially bypass IP-based rate limiting` when `TRUST_PROXY=true` was set.

This change updates the `express-rate-limit` configuration to explicitly disable this validation check, as the user has confirmed that their IP handling is correct and they want to allow the permissive proxy setting.

Verified by creating a temporary test case that inspects the rate limiter configuration and by running the full test suite to ensure no regressions.

---
*PR created automatically by Jules for task [16481677377102366572](https://jules.google.com/task/16481677377102366572) started by @Bladestar2105*