### PR TITLE
Fix IP blocker returning plain text instead of JSON

### DIFF
--- a/src/middleware/security.js
+++ b/src/middleware/security.js
@@ -57,7 +57,7 @@ export const ipBlocker = async (req, res, next) => {
     if (blocked) {
       if (blocked.expires_at > now) {
         console.warn(`⛔ IP Blocked: ${ip} (Reason: ${blocked.reason})`);
-        return res.status(403).send('Access Denied');
+        return res.status(403).json({ error: 'Access Denied', message: 'Your IP is blocked' });
       } else {
         // Expired, remove it
         db.prepare('DELETE FROM blocked_ips WHERE id = ?').run(blocked.id);

--- a/tests/security/ip_blocker.test.js
+++ b/tests/security/ip_blocker.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+// Mock dependencies
+vi.mock('../../src/database/db.js', () => {
+  return {
+    default: {
+      prepare: vi.fn()
+    }
+  };
+});
+
+import db from '../../src/database/db.js';
+import { ipBlocker } from '../../src/middleware/security.js';
+
+const app = express();
+app.use(ipBlocker);
+app.get('/test', (req, res) => res.json({ success: true }));
+
+describe('IP Blocker Middleware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should allow access for unblocked IP', async () => {
+    // 1. Whitelist check -> null
+    // 2. Blocklist check -> null
+    const getMock = vi.fn().mockReturnValue(null);
+    db.prepare.mockReturnValue({ get: getMock });
+
+    const res = await request(app).get('/test');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true });
+  });
+
+  it('should block access for blocked IP and return JSON', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const blockedIp = {
+      ip: '::ffff:127.0.0.1',
+      reason: 'Too many failed attempts',
+      expires_at: now + 3600 // Valid block
+    };
+
+    const getMock = vi.fn()
+        .mockReturnValueOnce(null) // Whitelist: null
+        .mockReturnValueOnce(blockedIp); // Blocklist: blockedIp
+
+    db.prepare.mockReturnValue({ get: getMock });
+
+    const res = await request(app).get('/test');
+
+    // Before fix, this returns 403 but text "Access Denied"
+    expect(res.status).toBe(403);
+
+    // This assertion should fail before fix
+    expect(res.headers['content-type']).toMatch(/json/);
+    expect(res.body).toHaveProperty('error');
+    expect(res.body.error).toContain('Access Denied');
+  });
+});


### PR DESCRIPTION
The IP blocker middleware was returning a plain text "Access Denied" string when an IP was blocked. The frontend, expecting a JSON response (as per `fetchJSON` helper), would fail to parse this and throw a SyntaxError ("Unexpected token 'A'...").

This change modifies `src/middleware/security.js` to return a JSON object `{ error: 'Access Denied', message: 'Your IP is blocked' }` with a 403 status code.

A new regression test `tests/security/ip_blocker.test.js` has been added to verify this behavior and prevent future regressions. The test mocks the database to simulate a blocked IP and asserts that the response is a valid JSON object.

---
*PR created automatically by Jules for task [10815379246326931846](https://jules.google.com/task/10815379246326931846) started by @Bladestar2105*