### PR TITLE
🎨 Palette: Add visual feedback to Add Channel button

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1322,15 +1322,36 @@ function renderProviderChannels(channels) {
         alert(t('selectUserAndCategory'));
         return;
       }
+
+      const originalText = btn.textContent;
+      const originalClass = btn.className;
+      setLoadingState(btn, true, 'loading', false);
+
       try {
         await fetchJSON(`/api/user-categories/${selectedCategoryId}/channels`, {
           method: 'POST',
           headers: {'Content-Type': 'application/json'},
           body: JSON.stringify({provider_channel_id: ch.id})
         });
+
         loadUserCategoryChannels();
+
+        // Success state
+        btn.disabled = true; // Keep disabled during success message
+        btn.innerHTML = `✅ ${t('added')}`;
+        btn.className = 'btn btn-sm btn-outline-success ms-2';
+
+        setTimeout(() => {
+             // Only restore if the button is still in the DOM (though garbage collection handles it, but good practice)
+             btn.className = originalClass;
+             btn.textContent = originalText;
+             btn.disabled = false;
+        }, 1500);
+
       } catch (e) {
         alert(t('errorPrefix') + ' ' + e.message);
+        setLoadingState(btn, false);
+        btn.textContent = originalText;
       }
     };
     


### PR DESCRIPTION
💡 What: Added visual feedback to the "Add" button in the channel list.
🎯 Why: Users received no immediate feedback when clicking "Add", leading to uncertainty about whether the action succeeded.
📸 Before/After: Button now shows spinner -> "✅ Added" -> Reverts.
♿ Accessibility: Provides visual confirmation of action status.

---
*PR created automatically by Jules for task [5807188969896074819](https://jules.google.com/task/5807188969896074819) started by @Bladestar2105*