### PR TITLE
Fix startup crash on clean DB due to StreamManager init order

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -27,19 +27,21 @@ let redisClient = null;
         redisClient = createClient({ url: process.env.REDIS_URL });
         redisClient.on('error', (err) => console.error('Redis Client Error', err));
         await redisClient.connect();
-        streamManager.init(db, redisClient);
       } catch (e) {
         console.error('Failed to connect to Redis, falling back to SQLite:', e);
-        streamManager.init(db, null);
+        redisClient = null;
       }
-  } else {
-    streamManager.init(db, null);
   }
 
   if (cluster.isPrimary) {
     // Init DB and Run Migrations
     initDb(true);
+  }
 
+  // Initialize Stream Manager (Redis or SQLite)
+  streamManager.init(db, redisClient);
+
+  if (cluster.isPrimary) {
     // Create default admin
     await createDefaultAdmin();
 


### PR DESCRIPTION
Fixed a startup crash (`SqliteError: no such table: current_streams`) that occurred when starting the application with a clean database. The `StreamManager` was attempting to prepare SQL statements before the database migrations had run.

Refactored `src/server.js` to ensure that `initDb(true)` is called before `streamManager.init(db, ...)` in the primary process. This guarantees that all required tables exist before `StreamManager` interacts with the database.

Verified the fix by creating a reproduction script (confirming the failure with old order) and a verification script (confirming success with new order), and ran all existing tests to ensure no regressions.

---
*PR created automatically by Jules for task [7259970164998728458](https://jules.google.com/task/7259970164998728458) started by @Bladestar2105*