### PR TITLE
Add missing static files to suppress 404 errors

### DIFF
--- a/public/css/support_parent.css
+++ b/public/css/support_parent.css
@@ -1,0 +1,1 @@
+/* Placeholder for support_parent.css */

--- a/public/js/lkk_ch.js
+++ b/public/js/lkk_ch.js
@@ -1,0 +1,1 @@
+// Placeholder for lkk_ch.js

--- a/public/js/twint_ch.js
+++ b/public/js/twint_ch.js
@@ -1,0 +1,1 @@
+// Placeholder for twint_ch.js


### PR DESCRIPTION
Added empty placeholder files for `public/css/support_parent.css`, `public/js/lkk_ch.js`, and `public/js/twint_ch.js`.
These files are frequently requested by client-side browser extensions (likely related to Twint, LKK, or support widgets), causing 404 errors in the server logs.
Providing empty files suppresses these errors without affecting application functionality.

---
*PR created automatically by Jules for task [13953412997619621693](https://jules.google.com/task/13953412997619621693) started by @Bladestar2105*