### PR TITLE
Fix SqliteError during sync due to reserved keyword "cast"

### DIFF
--- a/src/controllers/xtreamController.js
+++ b/src/controllers/xtreamController.js
@@ -145,7 +145,7 @@ export const playerApi = async (req, res) => {
 
     if (action === 'get_series') {
       const rows = db.prepare(`
-        SELECT uc.id as user_channel_id, uc.user_category_id, pc.name, pc.logo, pc.plot, pc.cast, pc.director, pc.genre, pc.releaseDate, pc.added, pc.rating, pc.rating_5based, pc.youtube_trailer, pc.episode_run_time, pc.metadata, cat.is_adult as category_is_adult
+        SELECT uc.id as user_channel_id, uc.user_category_id, pc.name, pc.logo, pc.plot, pc."cast", pc.director, pc.genre, pc.releaseDate, pc.added, pc.rating, pc.rating_5based, pc.youtube_trailer, pc.episode_run_time, pc.metadata, cat.is_adult as category_is_adult
         FROM user_channels uc
         JOIN provider_channels pc ON pc.id = uc.provider_channel_id
         JOIN user_categories cat ON cat.id = uc.user_category_id

--- a/src/database/migrations.js
+++ b/src/database/migrations.js
@@ -159,7 +159,7 @@ export function migrateChannelsSchemaV3(db) {
 
         const updateStmt = db.prepare(`
             UPDATE provider_channels
-            SET rating = ?, rating_5based = ?, added = ?, plot = ?, cast = ?, director = ?, genre = ?, releaseDate = ?, youtube_trailer = ?, episode_run_time = ?
+            SET rating = ?, rating_5based = ?, added = ?, plot = ?, "cast" = ?, director = ?, genre = ?, releaseDate = ?, youtube_trailer = ?, episode_run_time = ?
             WHERE id = ?
         `);
 

--- a/src/services/syncService.js
+++ b/src/services/syncService.js
@@ -255,13 +255,13 @@ export async function performSync(providerId, userId, isManual = false) {
     // Prepare channel statements
     const insertChannel = db.prepare(`
       INSERT OR IGNORE INTO provider_channels
-      (provider_id, remote_stream_id, name, original_category_id, logo, stream_type, epg_channel_id, original_sort_order, tv_archive, tv_archive_duration, metadata, mime_type, rating, rating_5based, added, plot, cast, director, genre, releaseDate, youtube_trailer, episode_run_time)
+      (provider_id, remote_stream_id, name, original_category_id, logo, stream_type, epg_channel_id, original_sort_order, tv_archive, tv_archive_duration, metadata, mime_type, rating, rating_5based, added, plot, "cast", director, genre, releaseDate, youtube_trailer, episode_run_time)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
     const updateChannel = db.prepare(`
       UPDATE provider_channels
-      SET name = ?, original_category_id = ?, logo = ?, epg_channel_id = ?, original_sort_order = ?, tv_archive = ?, tv_archive_duration = ?, stream_type = ?, metadata = ?, mime_type = ?, rating = ?, rating_5based = ?, added = ?, plot = ?, cast = ?, director = ?, genre = ?, releaseDate = ?, youtube_trailer = ?, episode_run_time = ?
+      SET name = ?, original_category_id = ?, logo = ?, epg_channel_id = ?, original_sort_order = ?, tv_archive = ?, tv_archive_duration = ?, stream_type = ?, metadata = ?, mime_type = ?, rating = ?, rating_5based = ?, added = ?, plot = ?, "cast" = ?, director = ?, genre = ?, releaseDate = ?, youtube_trailer = ?, episode_run_time = ?
       WHERE provider_id = ? AND remote_stream_id = ?
     `);
 


### PR DESCRIPTION
Fixes a critical issue where provider synchronization fails with `SqliteError: near ",": syntax error`. This was caused by the use of the unquoted column name `cast`, which is a reserved keyword in SQLite (for type casting). The fix involves quoting the column name as `"cast"` in all relevant SQL queries (INSERT, UPDATE, SELECT) to ensure correct parsing by the SQLite engine. This change is purely syntactic and ensures compatibility with stricter SQLite environments or configurations.

---
*PR created automatically by Jules for task [2196627783728499931](https://jules.google.com/task/2196627783728499931) started by @Bladestar2105*