### PR TITLE
Fix 502 EOF error in reverse proxy logs

### DIFF
--- a/src/controllers/streamController.js
+++ b/src/controllers/streamController.js
@@ -114,6 +114,7 @@ export const proxyMpd = async (req, res) => {
 
     if (!(await isSafeUrl(upstreamUrl))) {
         console.warn(`🛡️ Blocked unsafe upstream URL: ${redactUrl(upstreamUrl)}`);
+        streamManager.localStreams.delete(connectionId);
         streamManager.remove(connectionId);
         return res.sendStatus(403);
     }
@@ -125,6 +126,8 @@ export const proxyMpd = async (req, res) => {
 
     if (!upstream.ok) {
        console.error(`MPD proxy error: ${upstream.status} for ${redactUrl(upstreamUrl)}`);
+       if (upstream.body && !upstream.body.destroyed) try { upstream.body.destroy(); } catch(e) {}
+       streamManager.localStreams.delete(connectionId);
        streamManager.remove(connectionId);
        return res.sendStatus(upstream.status);
     }
@@ -157,6 +160,7 @@ export const proxyMpd = async (req, res) => {
 
   } catch (e) {
     console.error('MPD proxy error:', e);
+    streamManager.localStreams.delete(connectionId);
     streamManager.remove(connectionId);
     if (!res.headersSent) res.sendStatus(500);
   }
@@ -225,6 +229,7 @@ export const proxyLive = async (req, res) => {
 
     if (!(await isSafeUrl(remoteUrl))) {
       console.warn(`🛡️ Blocked unsafe upstream URL: ${redactUrl(remoteUrl)}`);
+      streamManager.localStreams.delete(connectionId);
       streamManager.remove(connectionId);
       return res.sendStatus(403);
     }
@@ -256,6 +261,8 @@ export const proxyLive = async (req, res) => {
 
         if (!upstream.ok) {
            console.error(`Transcode upstream fetch error: ${upstream.status}`);
+           if (upstream.body && !upstream.body.destroyed) try { upstream.body.destroy(); } catch(e) {}
+           streamManager.localStreams.delete(connectionId);
            streamManager.remove(connectionId);
            return res.sendStatus(upstream.status);
         }
@@ -311,6 +318,7 @@ export const proxyLive = async (req, res) => {
 
       } catch (e) {
         console.error('Transcode setup error:', e.message);
+        streamManager.localStreams.delete(connectionId);
         streamManager.remove(connectionId);
         return res.sendStatus(500);
       }
@@ -323,6 +331,8 @@ export const proxyLive = async (req, res) => {
 
     if (!upstream.ok || !upstream.body) {
       console.error(`Stream proxy error: ${upstream.status} ${upstream.statusText} for ${redactUrl(remoteUrl)}`);
+      if (upstream && upstream.body && !upstream.body.destroyed) try { upstream.body.destroy(); } catch(e) {}
+      streamManager.localStreams.delete(connectionId);
       streamManager.remove(connectionId);
       return res.sendStatus(502);
     }
@@ -406,6 +416,8 @@ export const proxyLive = async (req, res) => {
       if (err.code !== 'ERR_STREAM_PREMATURE_CLOSE' && err.type !== 'aborted') {
         console.error('Stream error:', err.message);
       }
+      if (upstream && upstream.body && !upstream.body.destroyed) try { upstream.body.destroy(); } catch(e) {}
+      streamManager.localStreams.delete(connectionId);
       streamManager.remove(connectionId);
       if (!res.headersSent) {
         res.sendStatus(502);
@@ -418,6 +430,7 @@ export const proxyLive = async (req, res) => {
 
   } catch (e) {
     console.error('Stream proxy error:', e.message);
+    streamManager.localStreams.delete(connectionId);
     streamManager.remove(connectionId);
     if (!res.headersSent) {
       res.sendStatus(500);
@@ -539,6 +552,7 @@ export const proxyMovie = async (req, res) => {
 
     if (!(await isSafeUrl(remoteUrl))) {
       console.warn(`🛡️ Blocked unsafe upstream URL: ${redactUrl(remoteUrl)}`);
+      streamManager.localStreams.delete(connectionId);
       streamManager.remove(connectionId);
       return res.sendStatus(403);
     }
@@ -577,6 +591,8 @@ export const proxyMovie = async (req, res) => {
 
             if (!upstream.ok) {
                  console.error(`VOD Transcode upstream fetch error: ${upstream.status}`);
+                 if (upstream.body && !upstream.body.destroyed) try { upstream.body.destroy(); } catch(e) {}
+                 streamManager.localStreams.delete(connectionId);
                  streamManager.remove(connectionId);
                  return res.sendStatus(upstream.status);
             }
@@ -611,6 +627,7 @@ export const proxyMovie = async (req, res) => {
 
         } catch(e) {
             console.error('VOD Transcode error:', e);
+            streamManager.localStreams.delete(connectionId);
             streamManager.remove(connectionId);
             return res.sendStatus(500);
         }
@@ -628,6 +645,8 @@ export const proxyMovie = async (req, res) => {
     if (!upstream.ok || !upstream.body) {
       if (upstream.status !== 200 && upstream.status !== 206) {
           console.error(`Movie proxy error: ${upstream.status} ${upstream.statusText} for ${redactUrl(remoteUrl)}`);
+          if (upstream.body && !upstream.body.destroyed) try { upstream.body.destroy(); } catch(e) {}
+          streamManager.localStreams.delete(connectionId);
           streamManager.remove(connectionId);
           return res.sendStatus(502);
       }
@@ -661,6 +680,7 @@ export const proxyMovie = async (req, res) => {
 
   } catch (e) {
     console.error('Movie proxy error:', e.message);
+    streamManager.localStreams.delete(connectionId);
     streamManager.remove(connectionId);
     if (!res.headersSent) res.sendStatus(500);
   }
@@ -697,6 +717,7 @@ export const proxySeries = async (req, res) => {
 
     if (!(await isSafeUrl(remoteUrl))) {
       console.warn(`🛡️ Blocked unsafe upstream URL: ${redactUrl(remoteUrl)}`);
+      streamManager.localStreams.delete(connectionId);
       streamManager.remove(connectionId);
       return res.sendStatus(403);
     }
@@ -718,6 +739,8 @@ export const proxySeries = async (req, res) => {
     if (!upstream.ok || !upstream.body) {
       if (upstream.status !== 200 && upstream.status !== 206) {
           console.error(`Series proxy error: ${upstream.status} ${upstream.statusText} for ${redactUrl(remoteUrl)}`);
+          if (upstream.body && !upstream.body.destroyed) try { upstream.body.destroy(); } catch(e) {}
+          streamManager.localStreams.delete(connectionId);
           streamManager.remove(connectionId);
           return res.sendStatus(502);
       }
@@ -750,6 +773,7 @@ export const proxySeries = async (req, res) => {
 
   } catch (e) {
     console.error('Series proxy error:', e.message);
+    streamManager.localStreams.delete(connectionId);
     streamManager.remove(connectionId);
     if (!res.headersSent) res.sendStatus(500);
   }
@@ -798,6 +822,7 @@ export const proxyTimeshift = async (req, res) => {
 
     if (!(await isSafeUrl(remoteUrl))) {
       console.warn(`🛡️ Blocked unsafe upstream URL: ${redactUrl(remoteUrl)}`);
+      streamManager.localStreams.delete(connectionId);
       streamManager.remove(connectionId);
       return res.sendStatus(403);
     }
@@ -823,6 +848,8 @@ export const proxyTimeshift = async (req, res) => {
 
     if (!upstream.ok || !upstream.body) {
       console.error(`Timeshift proxy error: ${upstream.status} ${upstream.statusText} for ${redactUrl(remoteUrl)}`);
+      if (upstream && upstream.body && !upstream.body.destroyed) try { upstream.body.destroy(); } catch(e) {}
+      streamManager.localStreams.delete(connectionId);
       streamManager.remove(connectionId);
       return res.sendStatus(502);
     }
@@ -877,6 +904,8 @@ export const proxyTimeshift = async (req, res) => {
       if (err.code !== 'ERR_STREAM_PREMATURE_CLOSE' && err.type !== 'aborted') {
         console.error('Timeshift stream error:', err.message);
       }
+      if (upstream && upstream.body && !upstream.body.destroyed) try { upstream.body.destroy(); } catch(e) {}
+      streamManager.localStreams.delete(connectionId);
       streamManager.remove(connectionId);
       if (!res.headersSent) {
         res.sendStatus(500);
@@ -892,6 +921,7 @@ export const proxyTimeshift = async (req, res) => {
 
   } catch (e) {
     console.error('Timeshift proxy error:', e.message);
+    streamManager.localStreams.delete(connectionId);
     streamManager.remove(connectionId);
     if (!res.headersSent) {
       res.sendStatus(500);

--- a/tests/stream_cleanup.test.js
+++ b/tests/stream_cleanup.test.js
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as streamController from '../src/controllers/streamController.js';
+import streamManager from '../src/stream_manager.js';
+import { getXtreamUser } from '../src/services/authService.js';
+import fetch from 'node-fetch';
+
+// Mock dependencies
+vi.mock('../src/database/db.js', () => ({
+  default: {
+    prepare: vi.fn().mockReturnValue({
+      get: vi.fn(),
+      run: vi.fn()
+    })
+  }
+}));
+
+vi.mock('../src/services/authService.js', () => ({
+  getXtreamUser: vi.fn()
+}));
+
+vi.mock('../src/utils/helpers.js', () => ({
+  isSafeUrl: vi.fn().mockResolvedValue(true),
+  getBaseUrl: vi.fn().mockReturnValue('http://localhost')
+}));
+
+vi.mock('../src/utils/crypto.js', () => ({
+  decrypt: vi.fn().mockReturnValue('decrypted'),
+  encrypt: vi.fn().mockReturnValue('encrypted')
+}));
+
+vi.mock('node-fetch');
+
+// We need to spy on streamManager methods, but we imported the real instance.
+// We can spy on it directly.
+
+describe('Stream Controller - 502 EOF Reproduction', () => {
+  let req, res;
+
+  beforeEach(() => {
+    req = {
+      params: { stream_id: '428', username: 'u', password: 'p' },
+      query: {},
+      path: '/live/u/p/428.ts',
+      ip: '127.0.0.1',
+      headers: {},
+      on: vi.fn()
+    };
+    res = {
+      sendStatus: vi.fn(),
+      setHeader: vi.fn(),
+      headersSent: false,
+      destroy: vi.fn(),
+      destroyed: false
+    };
+    vi.clearAllMocks();
+
+    // Clear stream manager local streams
+    streamManager.localStreams.clear();
+  });
+
+  it('should destroy response when upstream returns 502, causing EOF', async () => {
+    // Setup valid user
+    getXtreamUser.mockResolvedValue({ id: 1, username: 'test' });
+
+    // Setup channel found
+    const db = (await import('../src/database/db.js')).default;
+    db.prepare.mockReturnValue({
+      get: vi.fn().mockReturnValue({
+        user_channel_id: 1,
+        name: 'Test Channel',
+        provider_url: 'http://provider.com',
+        provider_user: 'u',
+        provider_pass: 'p',
+        remote_stream_id: '123'
+      }),
+      run: vi.fn()
+    });
+
+    // Mock fetch to return 502 or fail
+    fetch.mockResolvedValue({
+      ok: false,
+      status: 502,
+      statusText: 'Bad Gateway',
+      headers: { get: () => null },
+      body: { destroy: vi.fn() }
+    });
+
+    // Spy on streamManager.remove
+    const removeSpy = vi.spyOn(streamManager, 'remove');
+
+    // Spy on res.destroy
+    // res.destroy is already a mock
+
+    await streamController.proxyLive(req, res);
+
+    expect(fetch).toHaveBeenCalled();
+    expect(removeSpy).toHaveBeenCalled();
+
+    // Crucial check: verify that res.destroy was called
+    // In the current buggy implementation, streamManager.remove triggers resource.destroy which triggers res.destroy
+    // Note: streamManager.add registers res initially, then proxyLive updates it to an object { destroy: ... }
+    // but ONLY if upstream fetch succeeds and we proceed to pipe.
+
+    // Wait, in the failing fetch case:
+    // const upstream = await fetch(...)
+    // if (!upstream.ok) { ... streamManager.remove(...) ... }
+
+    // At this point, what is in streamManager?
+    // await streamManager.add(..., res) was called BEFORE fetch.
+    // So the resource IS `res`.
+
+    // So streamManager.remove(id) calls res.destroy().
+    // Expect res.destroy NOT to be called, because we manually removed it from localStreams
+    // before calling streamManager.remove.
+    expect(res.destroy).not.toHaveBeenCalled();
+
+    // And verify sendStatus was called
+    expect(res.sendStatus).toHaveBeenCalledWith(502);
+
+    // If res.destroy() is called, writing to it (sendStatus) typically fails or is ignored by the client (EOF).
+  });
+});


### PR DESCRIPTION
This PR fixes an issue where the Caddy reverse proxy (and other clients) would log "EOF" and a 502 error when the backend encountered an upstream error (e.g., provider 502/404).

The root cause was that `streamManager.remove(connectionId)` was being called *before* or *during* the error response handling. Since `streamManager.remove` triggers the `destroy` callback of the registered resource (which includes `res.destroy()`), the underlying TCP socket was being closed immediately, preventing the Express `res.sendStatus(502)` call from actually sending the response headers and body to the client.

The fix involves:
1. Manually destroying the upstream response body (if it exists) to prevent leaks.
2. Deleting the stream entry from `streamManager.localStreams` *before* calling `streamManager.remove(connectionId)`. This prevents `remove` from finding and destroying the `res` object.
3. Sending the error response using `res.sendStatus(...)`.

This change is applied to `proxyMpd`, `proxyLive`, `proxyMovie`, `proxySeries`, and `proxyTimeshift` handlers in `src/controllers/streamController.js`.

A regression test `tests/stream_cleanup.test.js` has been added to verify that `res.destroy` is not called during error handling.

---
*PR created automatically by Jules for task [6837580080342048142](https://jules.google.com/task/6837580080342048142) started by @Bladestar2105*