### PR TITLE
Fix 500 error when deleting users with temporary tokens

### DIFF
--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -186,6 +186,7 @@ export const deleteUser = (req, res) => {
       db.prepare('DELETE FROM sync_logs WHERE user_id = ?').run(id);
       db.prepare('DELETE FROM category_mappings WHERE user_id = ?').run(id);
 
+      db.prepare('DELETE FROM temporary_tokens WHERE user_id = ?').run(id);
       db.prepare('DELETE FROM users WHERE id = ?').run(id);
     })();
 

--- a/tests/user_controller.test.js
+++ b/tests/user_controller.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import db, { initDb } from '../src/database/db.js';
+import * as userController from '../src/controllers/userController.js';
+
+describe('User Deletion Regression', () => {
+    beforeAll(() => {
+        initDb(true);
+    });
+
+    it('should successfully delete a user with temporary tokens', () => {
+        // Create user
+        const info = db.prepare('INSERT INTO users (username, password) VALUES (?, ?)').run('testuser_fixed', 'password');
+        const userId = info.lastInsertRowid;
+
+        // Create temporary token
+        db.prepare('INSERT INTO temporary_tokens (token, user_id, expires_at) VALUES (?, ?, ?)').run('token123_fixed', userId, Math.floor(Date.now() / 1000) + 10000);
+
+        // Mock req and res
+        const req = {
+            user: { is_admin: true },
+            params: { id: userId }
+        };
+
+        const res = {
+            status: vi.fn().mockReturnThis(),
+            json: vi.fn()
+        };
+
+        // Call controller
+        userController.deleteUser(req, res);
+
+        // Assert success
+        // If it failed, res.status(500).json(...) would have been called.
+        // We verify that res.json was called with {success: true}
+        expect(res.json).toHaveBeenCalledWith({ success: true });
+
+        // Assert user is gone
+        const user = db.prepare('SELECT * FROM users WHERE id = ?').get(userId);
+        expect(user).toBeUndefined();
+
+        // Assert token is gone
+        const token = db.prepare('SELECT * FROM temporary_tokens WHERE user_id = ?').get(userId);
+        expect(token).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Fixed an issue where deleting a user would fail with a 500 Internal Server Error if the user had active temporary tokens (e.g. from generated player tokens). This was due to a foreign key constraint violation. 

The fix ensures `temporary_tokens` associated with the user are deleted before the user record is removed. A new regression test `tests/user_controller.test.js` has been added to verify this fix.

---
*PR created automatically by Jules for task [1282959423702261617](https://jules.google.com/task/1282959423702261617) started by @Bladestar2105*