### PR TITLE
fix: ensure imported users are active by default if is_active is missing

### DIFF
--- a/src/controllers/systemController.js
+++ b/src/controllers/systemController.js
@@ -326,6 +326,7 @@ export const importData = (req, res) => {
         const webuiAccess = user.webui_access !== undefined ? (user.webui_access ? 1 : 0) : 1;
         const otpEnabled = user.otp_enabled ? 1 : 0;
         const otpSecret = user.otp_secret || null;
+        const isActive = user.is_active !== undefined ? (user.is_active ? 1 : 0) : 1;
 
         const info = db.prepare(`
           INSERT INTO users (username, password, is_active, webui_access, hdhr_enabled, hdhr_token, otp_enabled, otp_secret)
@@ -333,7 +334,7 @@ export const importData = (req, res) => {
         `).run(
           user.username,
           user.password,
-          user.is_active,
+          isActive,
           webuiAccess,
           hdhrEnabled,
           hdhrToken,


### PR DESCRIPTION
The `importData` function in `src/controllers/systemController.js` previously passed `user.is_active` directly to the SQL `INSERT` statement. When importing JSON data where `is_active` was missing, this resulted in `undefined` being passed, which `better-sqlite3` binds as `NULL`. This caused imported users to have `is_active = NULL`, preventing them from generating valid streaming tokens. The fix involved sanitizing the input to ensure `is_active` defaults to `1` (active) if undefined, consistent with other boolean fields like `webui_access`. This highlights the importance of input sanitization and default value handling when processing external data for database insertion.

---
*PR created automatically by Jules for task [4483293122478188411](https://jules.google.com/task/4483293122478188411) started by @Bladestar2105*