### PR TITLE
Fix login loop for IPTV users with WebUI access

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2470,6 +2470,8 @@ async function updateDashboardCounters() {
         return;
     }
 
+    if (!currentUser || !currentUser.is_admin) return;
+
     try {
         const data = await fetchJSON('/api/statistics');
         updateStatsCounters('streams', data.active_streams.length);


### PR DESCRIPTION
Prevents `updateDashboardCounters` from calling the admin-only `/api/statistics` endpoint for non-admin users, which was causing a 403 Forbidden response and triggering a logout/login loop.

Test Plan:
- Added `tests/reproduce_login_loop.test.js` (temporarily) to verify backend returns 403 for non-admins.
- Manually verified with Playwright script that non-admin users can login and stay logged in.
- Ran full test suite to ensure no regressions.

---
*PR created automatically by Jules for task [15114707055797769995](https://jules.google.com/task/15114707055797769995) started by @Bladestar2105*