### PR TITLE
Allow mixed HTTPS/HTTP via Image Proxy

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -92,6 +92,15 @@ async function fetchJSON(url, options = {}) {
   return res.json();
 }
 
+function getProxiedUrl(url) {
+  if (!url) return '';
+  // If we are on HTTPS and the URL is HTTP, use proxy
+  if (window.location.protocol === 'https:' && url.startsWith('http://')) {
+    return `/api/proxy/image?url=${encodeURIComponent(url)}`;
+  }
+  return url;
+}
+
 let currentUser = null;
 let selectedUser = null;
 let selectedUserId = null;
@@ -1335,7 +1344,7 @@ function renderProviderChannels(channels) {
     
     if (ch.logo) {
       const img = document.createElement('img');
-      img.src = ch.logo;
+      img.src = getProxiedUrl(ch.logo);
       img.style.width = '20px';
       img.style.height = '20px';
       img.style.marginLeft = '5px';
@@ -1464,7 +1473,7 @@ async function loadUserCategoryChannels() {
     
     if (ch.logo) {
       const img = document.createElement('img');
-      img.src = ch.logo;
+      img.src = getProxiedUrl(ch.logo);
       img.style.width = '20px';
       img.style.height = '20px';
       img.style.marginLeft = '5px';
@@ -2781,7 +2790,7 @@ async function loadStatistics() {
             tr.innerHTML = `
                 <td>${idx+1}</td>
                 <td>
-                    ${ch.logo ? `<img src="${ch.logo}" width="20" class="me-1" onerror="this.style.display='none'">` : ''}
+                    ${ch.logo ? `<img src="${getProxiedUrl(ch.logo)}" width="20" class="me-1" onerror="this.style.display='none'">` : ''}
                     ${ch.name}
                 </td>
                 <td>${ch.views}</td>
@@ -3048,7 +3057,7 @@ function renderEpgMappingChannels() {
       <td>${idx + 1}</td>
       <td>
         <div class="d-flex align-items-center">
-          ${ch.logo ? `<img src="${ch.logo}" width="24" height="24" class="me-2" onerror="this.style.display='none'">` : ''}
+          ${ch.logo ? `<img src="${getProxiedUrl(ch.logo)}" width="24" height="24" class="me-2" onerror="this.style.display='none'">` : ''}
           <span>${ch.name}</span>
         </div>
       </td>
@@ -3201,7 +3210,7 @@ function filterEpgSelectionList() {
           <strong>${epg.name}</strong> <br>
           <small class="text-muted">${epg.id}</small>
         </div>
-        ${epg.logo ? `<img src="${epg.logo}" height="30" onerror="this.style.display='none'">` : ''}
+        ${epg.logo ? `<img src="${getProxiedUrl(epg.logo)}" height="30" onerror="this.style.display='none'">` : ''}
       </div>
     `;
 

--- a/src/app.js
+++ b/src/app.js
@@ -16,6 +16,7 @@ import xtreamRoutes from './routes/xtream.js';
 import epgRoutes from './routes/epg.js';
 import systemRoutes from './routes/system.js';
 import hdhrRoutes from './routes/hdhr.js';
+import proxyRoutes from './routes/proxy.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -80,6 +81,7 @@ app.use('/api', providerRoutes);
 app.use('/api', channelRoutes);
 app.use('/api', epgRoutes);
 app.use('/api', systemRoutes);
+app.use('/api/proxy', proxyRoutes);
 app.use('/', streamRoutes);
 app.use('/', xtreamRoutes);
 app.use('/hdhr', hdhrRoutes);

--- a/src/routes/proxy.js
+++ b/src/routes/proxy.js
@@ -1,0 +1,45 @@
+import express from 'express';
+import fetch from 'node-fetch';
+import { isSafeUrl } from '../utils/helpers.js';
+
+const router = express.Router();
+
+router.get('/image', async (req, res) => {
+  const { url } = req.query;
+
+  if (!url) {
+    return res.status(400).send('URL is required');
+  }
+
+  try {
+    // 1. SSRF Protection
+    if (!(await isSafeUrl(url))) {
+      return res.status(403).send('Access denied (unsafe URL)');
+    }
+
+    const response = await fetch(url, {
+        headers: { 'User-Agent': 'IPTV-Manager/1.0' }
+    });
+
+    if (!response.ok) {
+      return res.status(response.status).send(`Failed to fetch image: ${response.statusText}`);
+    }
+
+    const contentType = response.headers.get('content-type');
+    if (!contentType || !contentType.startsWith('image/')) {
+       return res.status(400).send('URL is not an image');
+    }
+
+    res.setHeader('Content-Type', contentType);
+    // Cache control to reduce load
+    res.setHeader('Cache-Control', 'public, max-age=86400'); // 1 day
+
+    response.body.pipe(res);
+
+  } catch (error) {
+    console.error('Proxy Error:', error);
+    res.status(500).send('Internal Server Error');
+  }
+});
+
+export default router;


### PR DESCRIPTION
Implemented an image proxy to resolve "Mixed Content" warnings when loading HTTP picons on an HTTPS site.
- Created `src/routes/proxy.js` with SSRF protection and content-type validation.
- Registered the proxy route in `src/app.js`.
- Added `getProxiedUrl` helper in `public/app.js` to rewrite URLs.
- Verified with backend tests and manual curl testing.

---
*PR created automatically by Jules for task [18428833947807157207](https://jules.google.com/task/18428833947807157207) started by @Bladestar2105*