### PR TITLE
Bind Web-Player tokens to browser session to prevent sharing

### DIFF
--- a/src/database/db.js
+++ b/src/database/db.js
@@ -231,6 +231,7 @@ export function initDb(isPrimary) {
             migrations.migrateUserPasswords(db);
             migrations.migrateProviderExpiry(db);
             migrations.migrateHdhrColumns(db);
+            migrations.migrateTemporaryTokensSchema(db);
 
             // Clear ephemeral streams
             db.exec('DELETE FROM current_streams');

--- a/src/database/migrations.js
+++ b/src/database/migrations.js
@@ -471,3 +471,17 @@ export function migrateHdhrColumns(db) {
     console.error('HDHR Columns migration error:', e);
   }
 }
+
+export function migrateTemporaryTokensSchema(db) {
+  try {
+    const tableInfo = db.prepare("PRAGMA table_info(temporary_tokens)").all();
+    const columns = tableInfo.map(c => c.name);
+
+    if (!columns.includes('session_id')) {
+      db.exec('ALTER TABLE temporary_tokens ADD COLUMN session_id TEXT');
+      console.log('✅ DB Migration: session_id column added to temporary_tokens');
+    }
+  } catch (e) {
+    console.error('Temporary Tokens Schema migration error:', e);
+  }
+}

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -86,3 +86,11 @@ export function getSetting(db, key, defaultValue) {
     return defaultValue;
   }
 }
+
+export function getCookie(req, name) {
+  const cookieHeader = req.headers.cookie;
+  if (!cookieHeader) return null;
+  const match = cookieHeader.match(new RegExp('(^| )' + name + '=([^;]+)'));
+  if (match) return match[2];
+  return null;
+}

--- a/tests/security/player_session.test.js
+++ b/tests/security/player_session.test.js
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import db, { initDb } from '../../src/database/db.js';
+import { createPlayerToken } from '../../src/controllers/authController.js';
+import { getXtreamUser } from '../../src/services/authService.js';
+
+describe('Player Session Security', () => {
+    beforeAll(() => {
+        initDb(true);
+        // Clean up dependent tables first
+        db.prepare('DELETE FROM temporary_tokens').run();
+        db.prepare('DELETE FROM users').run();
+
+        // Create user
+        db.prepare('INSERT INTO users (username, password) VALUES (?, ?)').run('testuser', 'password');
+    });
+
+    afterAll(() => {
+        // Cleanup to avoid polluting other tests
+        db.prepare('DELETE FROM temporary_tokens').run();
+        db.prepare('DELETE FROM users').run();
+    });
+
+    it('should generate a player token with a session cookie', () => {
+        const userId = db.prepare('SELECT id FROM users WHERE username = ?').get('testuser').id;
+        const req = {
+            body: { user_id: userId },
+            user: { is_admin: true, id: 999, username: 'admin' }
+        };
+        const res = {
+            json: vi.fn(),
+            status: vi.fn().mockReturnThis(),
+            cookie: vi.fn()
+        };
+
+        createPlayerToken(req, res);
+
+        expect(res.json).toHaveBeenCalled();
+        const responseData = res.json.mock.calls[0][0];
+        expect(responseData).toHaveProperty('token');
+
+        expect(res.cookie).toHaveBeenCalled();
+        const cookieArgs = res.cookie.mock.calls[0];
+        expect(cookieArgs[0]).toBe('player_session');
+        expect(cookieArgs[2]).toHaveProperty('httpOnly', true);
+        expect(cookieArgs[2]).toHaveProperty('sameSite', 'strict');
+
+        const token = responseData.token;
+        const sessionId = cookieArgs[1];
+
+        // Verify DB
+        const dbToken = db.prepare('SELECT * FROM temporary_tokens WHERE token = ?').get(token);
+        expect(dbToken).toBeDefined();
+        expect(dbToken.session_id).toBe(sessionId);
+    });
+
+    it('should authenticate with valid token and matching cookie', async () => {
+        const userId = db.prepare('SELECT id FROM users WHERE username = ?').get('testuser').id;
+        // Create token manually to know values
+        const token = 'valid-token';
+        const sessionId = 'valid-session-id';
+        const now = Math.floor(Date.now() / 1000);
+        db.prepare('DELETE FROM temporary_tokens').run();
+        db.prepare('INSERT INTO temporary_tokens (token, user_id, expires_at, session_id) VALUES (?, ?, ?, ?)')
+          .run(token, userId, now + 3600, sessionId);
+
+        const req = {
+            query: { token },
+            headers: {
+                cookie: `player_session=${sessionId}`
+            },
+            params: {}
+        };
+
+        const user = await getXtreamUser(req);
+        expect(user).toBeDefined();
+        expect(user.id).toBe(userId);
+    });
+
+    it('should fail authentication with valid token but missing cookie', async () => {
+        const userId = db.prepare('SELECT id FROM users WHERE username = ?').get('testuser').id;
+        const token = 'missing-cookie-token';
+        const sessionId = 'session-id-2';
+        const now = Math.floor(Date.now() / 1000);
+        db.prepare('INSERT INTO temporary_tokens (token, user_id, expires_at, session_id) VALUES (?, ?, ?, ?)')
+          .run(token, userId, now + 3600, sessionId);
+
+        const req = {
+            query: { token },
+            headers: {}, // No cookie
+            params: {}
+        };
+
+        const user = await getXtreamUser(req);
+        expect(user).toBeNull();
+    });
+
+    it('should fail authentication with valid token but wrong cookie', async () => {
+        const userId = db.prepare('SELECT id FROM users WHERE username = ?').get('testuser').id;
+        const token = 'wrong-cookie-token';
+        const sessionId = 'session-id-3';
+        const now = Math.floor(Date.now() / 1000);
+        db.prepare('INSERT INTO temporary_tokens (token, user_id, expires_at, session_id) VALUES (?, ?, ?, ?)')
+          .run(token, userId, now + 3600, sessionId);
+
+        const req = {
+            query: { token },
+            headers: {
+                cookie: `player_session=wrong-session-id`
+            },
+            params: {}
+        };
+
+        const user = await getXtreamUser(req);
+        expect(user).toBeNull();
+    });
+});


### PR DESCRIPTION
This PR addresses a security vulnerability where Web-Player tokens (URLs) could be copied and used in other browsers without a valid session.

Changes:
1.  **Database Migration**: Added `session_id` to `temporary_tokens`.
2.  **Backend**:
    *   `createPlayerToken` now generates a `session_id` and sets a `HttpOnly`, `SameSite=Strict` cookie named `player_session`.
    *   `getXtreamUser` (authentication service) now verifies that the `player_session` cookie matches the session ID stored in the database for the given token.
3.  **Utilities**: Added `getCookie` helper.
4.  **Tests**: Added `tests/security/player_session.test.js` to verify cookie generation and validation logic.

This ensures that the token is only valid in the browser instance where it was generated.

---
*PR created automatically by Jules for task [4932509948594876803](https://jules.google.com/task/4932509948594876803) started by @Bladestar2105*