### PR TITLE
Enhance shared links: auto-delete, cross-category, editing

### DIFF
--- a/src/routes/shares.js
+++ b/src/routes/shares.js
@@ -5,6 +5,7 @@ import { authenticateToken } from '../middleware/auth.js';
 const router = express.Router();
 
 router.post('/', authenticateToken, shareController.createShare);
+router.put('/:token', authenticateToken, shareController.updateShare);
 router.get('/', authenticateToken, shareController.getShares);
 router.delete('/:token', authenticateToken, shareController.deleteShare);
 

--- a/src/services/schedulerService.js
+++ b/src/services/schedulerService.js
@@ -109,6 +109,8 @@ export function startCleanupScheduler() {
       db.prepare('DELETE FROM client_logs WHERE timestamp < ?').run(now - retention);
       db.prepare('DELETE FROM security_logs WHERE timestamp < ?').run(now - retention);
       db.prepare('DELETE FROM blocked_ips WHERE expires_at < ?').run(now);
+      // Clean expired shares
+      db.prepare('DELETE FROM shared_links WHERE end_time IS NOT NULL AND end_time < ?').run(now);
     } catch (e) {
       console.error('Cleanup error:', e);
     }

--- a/tests/shares_edit.test.js
+++ b/tests/shares_edit.test.js
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockPrepare, mockRun, mockGet, mockAll } = vi.hoisted(() => {
+    const mockRun = vi.fn();
+    const mockGet = vi.fn();
+    const mockAll = vi.fn();
+    const mockPrepare = vi.fn(() => ({
+        run: mockRun,
+        get: mockGet,
+        all: mockAll
+    }));
+    return { mockPrepare, mockRun, mockGet, mockAll };
+});
+
+vi.mock('../src/database/db.js', () => ({
+    default: {
+        prepare: mockPrepare
+    }
+}));
+
+import { updateShare } from '../src/controllers/shareController.js';
+
+describe('Share Controller - updateShare', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should update share successfully', () => {
+        const req = {
+            params: { token: 'test-token' },
+            body: {
+                name: 'Updated Name',
+                channels: [1, 2, 3],
+                start_time: '2023-01-01T00:00:00.000Z',
+                end_time: '2023-01-02T00:00:00.000Z'
+            },
+            user: { id: 1, is_admin: false }
+        };
+        const res = {
+            json: vi.fn(),
+            status: vi.fn(() => res)
+        };
+
+        mockRun.mockReturnValue({ changes: 1 });
+
+        updateShare(req, res);
+
+        expect(mockPrepare).toHaveBeenCalledWith(expect.stringContaining('UPDATE shared_links'));
+        expect(mockRun).toHaveBeenCalledWith(
+            JSON.stringify([1, 2, 3]),
+            'Updated Name',
+            1672531200,
+            1672617600,
+            'test-token',
+            1
+        );
+        expect(res.json).toHaveBeenCalledWith({ success: true, token: 'test-token' });
+    });
+
+    it('should return 404 if share not found', () => {
+        const req = {
+            params: { token: 'test-token' },
+            body: { channels: [1] },
+            user: { id: 1, is_admin: false }
+        };
+        const res = {
+            json: vi.fn(),
+            status: vi.fn(() => res)
+        };
+
+        mockRun.mockReturnValue({ changes: 0 });
+
+        updateShare(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(404);
+        expect(res.json).toHaveBeenCalledWith({ error: 'Share not found' });
+    });
+});


### PR DESCRIPTION
This PR introduces improvements to the stream sharing feature:
1.  **Automatic Cleanup**: A scheduled job now runs every hour to delete expired shared links from the database.
2.  **Cross-Category Sharing**: Users can now select channels from multiple categories before creating a share. A global selection state is maintained in the frontend.
3.  **Edit Shares**: Added a "Edit" button to the shares list, allowing users to modify the name, expiration, and channel list of existing shares.

Technical details:
-   Modified `src/services/schedulerService.js` to include `shared_links` cleanup.
-   Updated `public/app.js` to use `globalSelectedChannels` Set for managing selections.
-   Added `updateShare` to `src/controllers/shareController.js` and `PUT /api/shares/:token` route.
-   Added unit tests for `updateShare` controller.

---
*PR created automatically by Jules for task [556675900878839610](https://jules.google.com/task/556675900878839610) started by @Bladestar2105*