### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF via DNS Rebinding in Proxy Endpoint

### DIFF
--- a/tests/security/proxy_ssrf.test.js
+++ b/tests/security/proxy_ssrf.test.js
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import dns from 'dns';
+import { safeLookup, isPrivateIP } from '../../src/utils/helpers.js';
+
+// Mock dns module
+vi.mock('dns', () => {
+  return {
+    default: {
+      lookup: vi.fn(),
+      promises: {
+        lookup: vi.fn()
+      }
+    },
+    lookup: vi.fn() // For named import usage if any, or default.lookup
+  };
+});
+
+describe('SSRF Protection', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('isPrivateIP', () => {
+    it('should identify private IPv4 ranges', () => {
+      expect(isPrivateIP('127.0.0.1')).toBe(true);
+      expect(isPrivateIP('10.0.0.5')).toBe(true);
+      expect(isPrivateIP('172.16.0.1')).toBe(true);
+      expect(isPrivateIP('192.168.1.1')).toBe(true);
+      expect(isPrivateIP('169.254.0.1')).toBe(true);
+    });
+
+    it('should identify private IPv6 ranges', () => {
+      expect(isPrivateIP('::1')).toBe(true);
+      expect(isPrivateIP('fe80::1')).toBe(true);
+      expect(isPrivateIP('::ffff:127.0.0.1')).toBe(true);
+    });
+
+    it('should allow public IPs', () => {
+      expect(isPrivateIP('8.8.8.8')).toBe(false);
+      expect(isPrivateIP('1.1.1.1')).toBe(false);
+      expect(isPrivateIP('2606:4700:4700::1111')).toBe(false);
+    });
+  });
+
+  describe('safeLookup', () => {
+    it('should return address for public IP', () => new Promise(done => {
+      dns.lookup.mockImplementation((hostname, options, callback) => {
+        callback(null, '8.8.8.8', 4);
+      });
+
+      safeLookup('google.com', {}, (err, address, family) => {
+        expect(err).toBeNull();
+        expect(address).toBe('8.8.8.8');
+        done();
+      });
+    }));
+
+    it('should error for private IP', () => new Promise(done => {
+      dns.lookup.mockImplementation((hostname, options, callback) => {
+        callback(null, '127.0.0.1', 4);
+      });
+
+      safeLookup('localhost', {}, (err, address, family) => {
+        expect(err).toBeDefined();
+        expect(err.message).toContain('unsafe IP');
+        done();
+      });
+    }));
+
+    it('should handle DNS errors', () => new Promise(done => {
+       const dnsError = new Error('ENOTFOUND');
+       dns.lookup.mockImplementation((hostname, options, callback) => {
+        callback(dnsError);
+      });
+
+      safeLookup('invalid.domain', {}, (err) => {
+        expect(err).toBe(dnsError);
+        done();
+      });
+    }));
+  });
+});


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix SSRF via DNS Rebinding

🚨 Severity: HIGH
💡 Vulnerability: The `/api/proxy/image` endpoint was vulnerable to Server-Side Request Forgery (SSRF) via DNS Rebinding. An attacker could use a domain that resolves to a public IP during the initial `isSafeUrl` check but then resolves to a private IP (e.g., 127.0.0.1) during the `fetch` request, bypassing the protection.
🎯 Impact: An attacker could access internal services running on localhost or the private network, potentially leaking sensitive information or interacting with internal APIs.
🔧 Fix: Implemented `safeLookup`, a custom DNS lookup function for `http.Agent` and `https.Agent`. This ensures that the IP address is validated *at the moment of connection*, eliminating the race condition. Also refactored IP validation logic into `isPrivateIP`.
✅ Verification: Added `tests/security/proxy_ssrf.test.js` which mocks DNS responses to verify that private IPs are blocked even if the initial hostname looks safe (simulated). Ran `npx vitest run tests/security/proxy_ssrf.test.js` and existing tests.

---
*PR created automatically by Jules for task [9100610606330558310](https://jules.google.com/task/9100610606330558310) started by @Bladestar2105*