### PR TITLE
Prevent admin username collision and harden API security

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -96,7 +96,8 @@ function getProxiedUrl(url) {
   if (!url) return '';
   // If we are on HTTPS and the URL is HTTP, use proxy
   if (window.location.protocol === 'https:' && url.startsWith('http://')) {
-    return `/api/proxy/image?url=${encodeURIComponent(url)}`;
+    const token = getToken();
+    return `/api/proxy/image?url=${encodeURIComponent(url)}&token=${token}`;
   }
   return url;
 }

--- a/public/player.html
+++ b/public/player.html
@@ -479,7 +479,7 @@
     if (!url) return '';
     // If we are on HTTPS and the URL is HTTP, use proxy
     if (window.location.protocol === 'https:' && url.startsWith('http://')) {
-      return `/api/proxy/image?url=${encodeURIComponent(url)}`;
+      return `/api/proxy/image?url=${encodeURIComponent(url)}&token=${token}`;
     }
     return url;
   }

--- a/src/controllers/hdhrController.js
+++ b/src/controllers/hdhrController.js
@@ -10,6 +10,8 @@ export const discover = async (req, res) => {
       return res.status(401).json({ error: 'Unauthorized' });
     }
 
+    if (user.is_share_guest) return res.status(403).json({ error: 'Access denied' });
+
     if (!user.hdhr_enabled) {
         return res.status(403).json({ error: 'HDHomeRun emulation is disabled for this user' });
     }
@@ -40,6 +42,7 @@ export const lineupStatus = async (req, res) => {
     if (!user) {
       return res.status(401).json({ error: 'Unauthorized' });
     }
+    if (user.is_share_guest) return res.status(403).json({ error: 'Access denied' });
     if (!user.hdhr_enabled) return res.status(403).json({ error: 'Disabled' });
 
     res.json({
@@ -60,6 +63,7 @@ export const lineup = async (req, res) => {
     if (!user) {
       return res.status(401).json({ error: 'Unauthorized' });
     }
+    if (user.is_share_guest) return res.status(403).json({ error: 'Access denied' });
     if (!user.hdhr_enabled) return res.status(403).json({ error: 'Disabled' });
 
     const channels = db.prepare(`
@@ -102,6 +106,7 @@ export const auto = async (req, res) => {
     if (!user) {
       return res.status(401).send('Unauthorized');
     }
+    if (user.is_share_guest) return res.status(403).send('Access denied');
     if (!user.hdhr_enabled) return res.status(403).send('Disabled');
 
     const channelId = req.params.channelId;
@@ -144,6 +149,7 @@ export const deviceXml = async (req, res) => {
     if (!user) {
       return res.status(401).send('Unauthorized');
     }
+    if (user.is_share_guest) return res.status(403).send('Access denied');
     if (!user.hdhr_enabled) {
       return res.status(403).send('Disabled');
     }

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -53,6 +53,24 @@ export const createUser = async (req, res) => {
       });
     }
 
+    // Check for duplicate username (users)
+    const duplicate = db.prepare('SELECT id FROM users WHERE username = ?').get(u);
+    if (duplicate) {
+        return res.status(400).json({
+            error: 'username_taken',
+            message: 'Username is already taken'
+        });
+    }
+
+    // Check for duplicate username (admin_users)
+    const duplicateAdmin = db.prepare('SELECT id FROM admin_users WHERE username = ?').get(u);
+    if (duplicateAdmin) {
+        return res.status(400).json({
+            error: 'username_taken',
+            message: 'Username is reserved by an administrator'
+        });
+    }
+
     // Validate password
     if (p.length < 8) {
       return res.status(400).json({
@@ -110,6 +128,9 @@ export const updateUser = async (req, res) => {
         if (u !== existing.username) {
            const duplicate = db.prepare('SELECT id FROM users WHERE username = ?').get(u);
            if (duplicate) return res.status(400).json({ error: 'username_taken' });
+
+           const duplicateAdmin = db.prepare('SELECT id FROM admin_users WHERE username = ?').get(u);
+           if (duplicateAdmin) return res.status(400).json({ error: 'username_taken' });
         }
         updates.push('username = ?');
         params.push(u);

--- a/src/controllers/xtreamController.js
+++ b/src/controllers/xtreamController.js
@@ -20,6 +20,10 @@ export const playerApi = async (req, res) => {
       return res.json({user_info: {auth: 0, message: 'Invalid credentials'}});
     }
 
+    if (user.is_share_guest) {
+        return res.json({user_info: {auth: 0, message: 'Access denied'}});
+    }
+
     const now = Math.floor(Date.now() / 1000);
 
     if (!action || action === '') {
@@ -249,6 +253,8 @@ export const getPlaylist = async (req, res) => {
     const user = await getXtreamUser(req);
     if (!user) return res.sendStatus(401);
 
+    if (user.is_share_guest) return res.sendStatus(403);
+
     const rows = db.prepare(`
       SELECT uc.id as user_channel_id, pc.name, pc.logo, pc.epg_channel_id, pc.stream_type, pc.mime_type,
              cat.name as category_name, map.epg_channel_id as manual_epg_id
@@ -311,6 +317,8 @@ export const xmltv = async (req, res) => {
   try {
     const user = await getXtreamUser(req);
     if (!user) return res.sendStatus(401);
+
+    if (user.is_share_guest) return res.sendStatus(403);
 
     const consolidatedFile = path.join(EPG_CACHE_DIR, 'epg.xml');
     if (fs.existsSync(consolidatedFile)) {

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -4,7 +4,11 @@ import db from '../database/db.js';
 
 export function authenticateToken(req, res, next) {
   const authHeader = req.headers['authorization'];
-  const token = authHeader && authHeader.split(' ')[1];
+  let token = authHeader && authHeader.split(' ')[1];
+
+  if (!token && req.query.token) {
+    token = req.query.token;
+  }
 
   if (!token) {
     return res.status(401).json({ error: 'No token provided' });

--- a/src/routes/proxy.js
+++ b/src/routes/proxy.js
@@ -3,6 +3,7 @@ import fetch from 'node-fetch';
 import http from 'http';
 import https from 'https';
 import { isSafeUrl, safeLookup } from '../utils/helpers.js';
+import { authenticateToken } from '../middleware/auth.js';
 
 const router = express.Router();
 
@@ -10,7 +11,7 @@ const router = express.Router();
 const httpAgent = new http.Agent({ lookup: safeLookup });
 const httpsAgent = new https.Agent({ lookup: safeLookup });
 
-router.get('/image', async (req, res) => {
+router.get('/image', authenticateToken, async (req, res) => {
   const { url } = req.query;
 
   if (!url) {

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -144,6 +144,8 @@ export async function getXtreamUser(req) {
   const password = (req.params.password || req.query.password || '').trim();
   const token = (req.query.token || req.params.token || '').trim();
 
+  // console.log('DEBUG getXtreamUser token:', token);
+
   let user = null;
 
   // Check token auth first (avoids logging failed attempts for placeholder credentials)

--- a/tests/security/proxy_auth.test.js
+++ b/tests/security/proxy_auth.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { authenticateToken } from '../../src/middleware/auth.js';
+import jwt from 'jsonwebtoken';
+import { JWT_SECRET } from '../../src/utils/crypto.js';
+import db, { initDb } from '../../src/database/db.js';
+
+describe('Proxy Authentication', () => {
+    beforeAll(() => {
+        initDb(true);
+        db.prepare("INSERT OR IGNORE INTO admin_users (id, username, password) VALUES (1, 'admin', 'adminpass')").run();
+    });
+
+    it('should authenticate with token in query param', () => {
+        const token = jwt.sign({ id: 1, is_admin: true }, JWT_SECRET);
+        const req = {
+            headers: {},
+            query: { token: token }
+        };
+        const res = {
+            status: vi.fn().mockReturnThis(),
+            json: vi.fn()
+        };
+        const next = vi.fn();
+
+        authenticateToken(req, res, next);
+
+        expect(next).toHaveBeenCalled();
+    });
+
+    it('should fail without token', () => {
+        const req = {
+            headers: {},
+            query: {}
+        };
+        const res = {
+            status: vi.fn().mockReturnThis(),
+            json: vi.fn()
+        };
+        const next = vi.fn();
+
+        authenticateToken(req, res, next);
+
+        expect(res.status).toHaveBeenCalledWith(401);
+        expect(next).not.toHaveBeenCalled();
+    });
+});

--- a/tests/security/shared_link_restrictions.test.js
+++ b/tests/security/shared_link_restrictions.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
+import db, { initDb } from '../../src/database/db.js';
+import * as hdhrController from '../../src/controllers/hdhrController.js';
+import * as xtreamController from '../../src/controllers/xtreamController.js';
+
+describe('Shared Link API Restrictions', () => {
+    let sharedToken = 'share123';
+    let userId;
+
+    beforeAll(() => {
+        initDb(true);
+    });
+
+    beforeEach(() => {
+        // Create user
+        db.prepare('INSERT OR REPLACE INTO users (username, password, hdhr_enabled, is_active) VALUES (?, ?, 1, 1)').run('shareuser', 'pass');
+        const user = db.prepare('SELECT id FROM users WHERE username = ?').get('shareuser');
+        userId = user.id;
+
+        // Create shared link
+        db.prepare('INSERT OR REPLACE INTO shared_links (token, user_id, channels) VALUES (?, ?, ?)').run(sharedToken, userId, '[]');
+    });
+
+    afterEach(() => {
+        db.prepare('DELETE FROM shared_links WHERE token = ?').run(sharedToken);
+        db.prepare('DELETE FROM users WHERE id = ?').run(userId);
+    });
+
+    it('should block HDHR access for shared link', async () => {
+        const req = {
+            params: { token: sharedToken },
+            query: {},
+            get: (h) => h === 'host' ? 'localhost' : '',
+            protocol: 'http'
+        };
+        const res = {
+            status: vi.fn().mockReturnThis(),
+            json: vi.fn(),
+            send: vi.fn()
+        };
+
+        await hdhrController.discover(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(403);
+        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+            error: 'Access denied'
+        }));
+    });
+
+    it('should block Xtream Player API for shared link', async () => {
+        const req = {
+            params: {},
+            query: { token: sharedToken, action: 'get_live_streams' },
+            get: (h) => h === 'host' ? 'localhost' : '',
+            protocol: 'http'
+        };
+        const res = {
+            status: vi.fn().mockReturnThis(),
+            json: vi.fn(),
+            send: vi.fn()
+        };
+
+        await xtreamController.playerApi(req, res);
+
+        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+            user_info: expect.objectContaining({ auth: 0, message: 'Access denied' })
+        }));
+    });
+});

--- a/tests/security/user_admin_collision.test.js
+++ b/tests/security/user_admin_collision.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import db, { initDb } from '../../src/database/db.js';
+import * as userController from '../../src/controllers/userController.js';
+
+describe('User Admin Username Collision', () => {
+    beforeAll(() => {
+        initDb(true);
+        // Create an admin user
+        db.prepare('INSERT OR IGNORE INTO admin_users (username, password) VALUES (?, ?)').run('admin', 'adminpass');
+    });
+
+    afterEach(() => {
+        // Clean up test users
+        db.prepare('DELETE FROM users WHERE username = ?').run('admin');
+        db.prepare('DELETE FROM users WHERE username = ?').run('testuser');
+    });
+
+    it('should fail to create a user with the same username as an admin', async () => {
+        const req = {
+            user: { is_admin: true },
+            body: {
+                username: 'admin',
+                password: 'password123',
+                webui_access: true
+            }
+        };
+
+        const res = {
+            status: vi.fn().mockReturnThis(),
+            json: vi.fn()
+        };
+
+        await userController.createUser(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+            error: 'username_taken'
+        }));
+    });
+
+    it('should fail to update a user to the same username as an admin', async () => {
+        // Create a normal user first
+        const info = db.prepare('INSERT INTO users (username, password) VALUES (?, ?)').run('testuser', 'password');
+        const userId = info.lastInsertRowid;
+
+        const req = {
+            user: { is_admin: true },
+            params: { id: userId },
+            body: {
+                username: 'admin'
+            }
+        };
+
+        const res = {
+            status: vi.fn().mockReturnThis(),
+            json: vi.fn()
+        };
+
+        await userController.updateUser(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+            error: 'username_taken'
+        }));
+    });
+});


### PR DESCRIPTION
This change prevents creating regular users with usernames reserved by administrators. It also performs a security audit and fixes missing authentication on the image proxy endpoint, while ensuring shared link users cannot access privileged API endpoints.

---
*PR created automatically by Jules for task [9871762795400598585](https://jules.google.com/task/9871762795400598585) started by @Bladestar2105*