### PR TITLE
Fix SQLite error in shared_links slug migration

### DIFF
--- a/src/database/migrations.js
+++ b/src/database/migrations.js
@@ -526,10 +526,11 @@ export function migrateSharedLinkSlug(db) {
     const columns = tableInfo.map(c => c.name);
 
     if (!columns.includes('slug')) {
-      db.exec('ALTER TABLE shared_links ADD COLUMN slug TEXT UNIQUE');
-      db.exec('CREATE UNIQUE INDEX IF NOT EXISTS idx_shared_links_slug ON shared_links(slug)');
+      db.exec('ALTER TABLE shared_links ADD COLUMN slug TEXT');
       console.log('✅ DB Migration: slug column added to shared_links');
     }
+
+    db.exec('CREATE UNIQUE INDEX IF NOT EXISTS idx_shared_links_slug ON shared_links(slug)');
   } catch (e) {
     console.error('Shared Link Slug migration error:', e);
   }


### PR DESCRIPTION
Fixed `SqliteError: Cannot add a UNIQUE column` in `migrateSharedLinkSlug`. Modified `src/database/migrations.js` to add the `slug` column without the `UNIQUE` constraint and then create a unique index. Improved robustness by ensuring the index creation runs even if the column exists.

---
*PR created automatically by Jules for task [13230326534039196650](https://jules.google.com/task/13230326534039196650) started by @Bladestar2105*