### PR TITLE
Fix Edit Share button text and missing translation

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -3659,7 +3659,7 @@ function updateChanBulkDeleteBtn() {
     }
 
     if (shareBtn) {
-        shareBtn.textContent = t('share');
+        shareBtn.textContent = editingShareToken ? t('updateShare') : t('share');
     }
 }
 
@@ -3920,7 +3920,6 @@ window.editShare = function(s) {
     const shareBtn = document.getElementById('chan-bulk-share-btn');
     if (shareBtn) {
         shareBtn.style.display = 'block';
-        shareBtn.textContent = t('updateShare') || 'Update Share';
     }
 
     updateChanBulkDeleteBtn(); // To refresh button visibility/text based on populated channels

--- a/public/i18n.js
+++ b/public/i18n.js
@@ -393,6 +393,7 @@ const translations = {
 
     // Sharing
     share: 'Share',
+    updateShare: 'Update Share',
     manageShares: 'Manage Shares',
     createShareLink: 'Create Share Link',
     shareName: 'Name (Optional)',
@@ -801,6 +802,7 @@ const translations = {
 
     // Sharing
     share: 'Teilen',
+    updateShare: 'Freigabe aktualisieren',
     manageShares: 'Freigaben verwalten',
     createShareLink: 'Freigabe-Link erstellen',
     shareName: 'Name (Optional)',
@@ -1209,6 +1211,7 @@ const translations = {
 
     // Sharing
     share: 'Partager',
+    updateShare: 'Mettre à jour le partage',
     manageShares: 'Gérer les partages',
     createShareLink: 'Créer un lien de partage',
     shareName: 'Nom (Optionnel)',
@@ -1617,6 +1620,7 @@ const translations = {
 
     // Sharing
     share: 'Κοινοποίηση',
+    updateShare: 'Ενημέρωση Κοινοποίησης',
     manageShares: 'Διαχείριση Κοινοποιήσεων',
     createShareLink: 'Δημιουργία Συνδέσμου',
     shareName: 'Όνομα (Προαιρετικό)',


### PR DESCRIPTION
Fixed an issue where the "Update Share" button text would revert to "Share" when editing a shared link and selecting channels.
- Added missing `updateShare` translation key to `public/i18n.js`.
- Modified `updateChanBulkDeleteBtn` in `public/app.js` to respect `editingShareToken` state.
- Removed redundant button text setting in `editShare`.
- Verified with UI simulation test (Playwright).

---
*PR created automatically by Jules for task [8944568286381049543](https://jules.google.com/task/8944568286381049543) started by @Bladestar2105*