### PR TITLE
🎨 Palette: Improve accessibility of Share buttons

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -3860,12 +3860,12 @@ async function loadSharesList() {
                 <td>
                     <div class="input-group input-group-sm" style="max-width: 200px;">
                        <input class="form-control" value="${s.short_link || s.link}" readonly>
-                       <button class="btn btn-outline-secondary" onclick="copyToClipboard('${s.short_link || s.link}', this)">📋</button>
+                       <button class="btn btn-outline-secondary" onclick="copyToClipboard('${s.short_link || s.link}', this)" title="${t('copyToClipboardAction')}" aria-label="${t('copyToClipboardAction')}">📋</button>
                     </div>
                 </td>
                 <td>
-                    <button class="btn btn-sm btn-outline-secondary me-1" onclick='editShare(${JSON.stringify(s).replace(/'/g, "&#39;")})'>✏️</button>
-                    <button class="btn btn-sm btn-outline-danger" onclick="deleteShare('${s.token}')">🗑</button>
+                    <button class="btn btn-sm btn-outline-secondary me-1" onclick='editShare(${JSON.stringify(s).replace(/'/g, "&#39;")})' title="${t('updateShare')}" aria-label="${t('updateShare')}">✏️</button>
+                    <button class="btn btn-sm btn-outline-danger" onclick="deleteShare('${s.token}')" title="${t('deleteAction')}" aria-label="${t('deleteAction')}">🗑</button>
                 </td>
             `;
             tbody.appendChild(tr);

--- a/public/index.html
+++ b/public/index.html
@@ -1189,7 +1189,7 @@
                 <label class="form-label fw-bold text-success" data-i18n="shareLinkCreated">Share Link Created:</label>
                 <div class="input-group">
                    <input class="form-control" id="share-link-output" readonly>
-                   <button class="btn btn-outline-secondary" type="button" onclick="copyToClipboard(document.getElementById('share-link-output').value, this)">📋</button>
+                   <button class="btn btn-outline-secondary" type="button" onclick="copyToClipboard(document.getElementById('share-link-output').value, this)" data-i18n-label="copyToClipboardAction" data-i18n-title="copyToClipboardAction">📋</button>
                 </div>
              </div>
           </form>


### PR DESCRIPTION
Improved the accessibility and usability of the Share functionality by adding localized ARIA labels and titles to the "Copy to Clipboard", "Edit Share", and "Delete Share" buttons.

**Changes:**
- **`public/index.html`**: Added `data-i18n-label` and `data-i18n-title` attributes to the static "Copy to Clipboard" button in the Share Link Created section.
- **`public/app.js`**: Updated the `loadSharesList` function to inject `title` and `aria-label` attributes into the dynamically generated buttons for copying, editing, and deleting shares.

**Verification:**
- Verified syntax of `public/app.js` with `node -c`.
- Verified frontend changes using a Playwright script (`verify_buttons.py`) against a static server serving the `public` directory, confirming that all targeted buttons now possess the correct localized attributes.


---
*PR created automatically by Jules for task [9835746341257593454](https://jules.google.com/task/9835746341257593454) started by @Bladestar2105*