### PR TITLE
🎨 Palette: Add global '/' shortcut for search

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2587,6 +2587,40 @@ document.addEventListener('DOMContentLoaded', () => {
       }
   }, true);
 
+  // Global Keyboard Shortcuts
+  document.addEventListener('keydown', (e) => {
+    // '/' to focus search
+    // Ensure no modifier keys are pressed and we are not in an input/editable field
+    if (e.key === '/' &&
+        !e.ctrlKey && !e.metaKey && !e.altKey &&
+        !['INPUT', 'TEXTAREA'].includes(document.activeElement.tagName) &&
+        !document.activeElement.isContentEditable) {
+
+      e.preventDefault();
+
+      const candidates = [
+        // Modals (Higher priority)
+        'category-import-search',
+        'epg-browse-search',
+        'epg-select-search',
+        // Views
+        'channel-search',
+        'epg-mapping-search'
+      ];
+
+      for (const id of candidates) {
+        const el = document.getElementById(id);
+        // Check if element exists, is visible (has dimensions), and not disabled
+        if (el && (el.offsetWidth > 0 || el.offsetHeight > 0) && !el.disabled) {
+          el.focus();
+          // Select text if any
+          if (el.value) el.select();
+          break;
+        }
+      }
+    }
+  });
+
   // Global Click Handlers (Delegation)
   document.addEventListener('click', (e) => {
     // 1. switchView links


### PR DESCRIPTION
Implemented a global keyboard shortcut (`/`) to focus the relevant search bar.

💡 **What:** Added a `keydown` listener to `public/app.js` that detects the `/` key.
🎯 **Why:** Allows power users to quickly access the search function without reaching for the mouse, a common pattern in many web applications.
📸 **Details:**
- Prioritizes search inputs in open modals (e.g., Import, EPG Browse).
- If no modal is open, focuses the search input in the active view (Dashboard or EPG Mapping).
- Prevents triggering if the user is already typing in an input or using a modifier key.
- Automatically selects any existing text in the search box for quick replacement.
♿ **Accessibility:** enhances keyboard navigation efficiency.

---
*PR created automatically by Jules for task [98322362457639150](https://jules.google.com/task/98322362457639150) started by @Bladestar2105*