### PR TITLE
Fix provider update scheduler for multiple users

### DIFF
--- a/src/controllers/systemController.js
+++ b/src/controllers/systemController.js
@@ -4,7 +4,6 @@ import crypto from 'crypto';
 import db from '../database/db.js';
 import streamManager from '../services/streamManager.js';
 import { encryptWithPassword, decryptWithPassword, decrypt, encrypt } from '../utils/crypto.js';
-import { startSyncScheduler } from '../services/schedulerService.js';
 import { calculateNextSync } from '../services/syncService.js';
 import { isIP } from 'net';
 
@@ -527,8 +526,6 @@ export const createSyncConfig = (req, res) => {
       auto_add_channels ? 1 : 0
     );
 
-    startSyncScheduler();
-
     res.json({id: info.lastInsertRowid});
   } catch (e) {
     res.status(500).json({error: e.message});
@@ -559,8 +556,6 @@ export const updateSyncConfig = (req, res) => {
       id
     );
 
-    startSyncScheduler();
-
     res.json({success: true});
   } catch (e) {
     res.status(500).json({error: e.message});
@@ -572,8 +567,6 @@ export const deleteSyncConfig = (req, res) => {
     if (!req.user.is_admin) return res.status(403).json({error: 'Access denied'});
     const id = Number(req.params.id);
     db.prepare('DELETE FROM sync_configs WHERE id = ?').run(id);
-
-    startSyncScheduler();
 
     res.json({success: true});
   } catch (e) {

--- a/src/services/schedulerService.js
+++ b/src/services/schedulerService.js
@@ -7,31 +7,32 @@ import { performSync } from './syncService.js';
 import { updateEpgSource, generateConsolidatedEpg } from './epgService.js';
 import { isSafeUrl } from '../utils/helpers.js';
 
-let syncIntervals = new Map();
+let syncInterval = null;
+const runningSyncs = new Set();
 
 export function startSyncScheduler() {
-  // Clear existing intervals
-  syncIntervals.forEach(interval => clearInterval(interval));
-  syncIntervals.clear();
+  if (syncInterval) clearInterval(syncInterval);
 
-  // Load all enabled sync configs
-  const configs = db.prepare('SELECT * FROM sync_configs WHERE enabled = 1').all();
-
-  for (const config of configs) {
-    const checkInterval = 60000; // Check every minute
-
-    const interval = setInterval(async () => {
+  // Check every minute
+  syncInterval = setInterval(async () => {
+    try {
       const now = Math.floor(Date.now() / 1000);
-      const currentConfig = db.prepare('SELECT * FROM sync_configs WHERE id = ?').get(config.id);
+      const configs = db.prepare('SELECT * FROM sync_configs WHERE enabled = 1 AND next_sync <= ?').all(now);
 
-      if (currentConfig && currentConfig.enabled && currentConfig.next_sync <= now) {
-        await performSync(currentConfig.provider_id, currentConfig.user_id, false);
+      for (const config of configs) {
+        if (runningSyncs.has(config.id)) continue;
+        runningSyncs.add(config.id);
+
+        performSync(config.provider_id, config.user_id, false)
+          .catch(e => console.error(`Scheduled sync error for provider ${config.provider_id}:`, e))
+          .finally(() => runningSyncs.delete(config.id));
       }
-    }, checkInterval);
+    } catch (e) {
+      console.error('Sync Scheduler error:', e);
+    }
+  }, 60000);
 
-    syncIntervals.set(config.id, interval);
-    console.log(`📅 Scheduled sync for provider ${config.provider_id} (${config.sync_interval})`);
-  }
+  console.log('📅 Sync Scheduler started');
 }
 
 export function startEpgScheduler() {
@@ -42,60 +43,64 @@ export function startEpgScheduler() {
     const now = Math.floor(Date.now() / 1000);
 
     // 1. Custom Sources
-    const sources = db.prepare('SELECT * FROM epg_sources WHERE enabled = 1 AND is_updating = 0').all();
-    for (const source of sources) {
-      if (source.last_update + source.update_interval <= now) {
-        try {
-          await updateEpgSource(source.id);
-        } catch (e) {
-          console.error(`Scheduled EPG update failed for ${source.name}:`, e.message);
+    try {
+      const sources = db.prepare('SELECT * FROM epg_sources WHERE enabled = 1 AND is_updating = 0').all();
+      for (const source of sources) {
+        if (source.last_update + source.update_interval <= now) {
+          try {
+            await updateEpgSource(source.id);
+          } catch (e) {
+            console.error(`Scheduled EPG update failed for ${source.name}:`, e.message);
+          }
         }
       }
-    }
+    } catch (e) { console.error('EPG Scheduler (Custom) error:', e); }
 
     // 2. Provider Sources
-    const providers = db.prepare("SELECT * FROM providers WHERE epg_url IS NOT NULL AND TRIM(epg_url) != '' AND epg_enabled = 1").all();
-    for (const provider of providers) {
-      const cacheFile = path.join(EPG_CACHE_DIR, `epg_provider_${provider.id}.xml`);
-      let lastUpdate = 0;
-      if (fs.existsSync(cacheFile)) {
-        const stats = fs.statSync(cacheFile);
-        lastUpdate = Math.floor(stats.mtimeMs / 1000);
-      }
+    try {
+      const providers = db.prepare("SELECT * FROM providers WHERE epg_url IS NOT NULL AND TRIM(epg_url) != '' AND epg_enabled = 1").all();
+      for (const provider of providers) {
+        const cacheFile = path.join(EPG_CACHE_DIR, `epg_provider_${provider.id}.xml`);
+        let lastUpdate = 0;
+        if (fs.existsSync(cacheFile)) {
+          const stats = fs.statSync(cacheFile);
+          lastUpdate = Math.floor(stats.mtimeMs / 1000);
+        }
 
-      const interval = provider.epg_update_interval || 86400;
+        const interval = provider.epg_update_interval || 86400;
 
-      // Check if recently failed (Backoff: 15 minutes)
-      const lastFail = failedUpdates.get(provider.id) || 0;
-      if (lastFail && (lastFail + 900 > now)) continue;
+        // Check if recently failed (Backoff: 15 minutes)
+        const lastFail = failedUpdates.get(provider.id) || 0;
+        if (lastFail && (lastFail + 900 > now)) continue;
 
-      if (lastUpdate + interval <= now) {
-        try {
-          console.log(`🔄 Starting scheduled EPG update for provider ${provider.name}`);
+        if (lastUpdate + interval <= now) {
+          try {
+            console.log(`🔄 Starting scheduled EPG update for provider ${provider.name}`);
 
-          if (!(await isSafeUrl(provider.epg_url))) {
-             console.error(`Unsafe EPG URL for provider ${provider.name}`);
-             failedUpdates.set(provider.id, now);
-             continue;
-          }
+            if (!(await isSafeUrl(provider.epg_url))) {
+              console.error(`Unsafe EPG URL for provider ${provider.name}`);
+              failedUpdates.set(provider.id, now);
+              continue;
+            }
 
-          const response = await fetch(provider.epg_url);
-          if (response.ok) {
-            const epgData = await response.text();
-            await fs.promises.writeFile(cacheFile, epgData, 'utf8');
-            console.log(`✅ Scheduled EPG update success: ${provider.name}`);
-            failedUpdates.delete(provider.id);
-            await generateConsolidatedEpg();
-          } else {
-            console.error(`Scheduled EPG update HTTP error ${response.status} for ${provider.name}`);
+            const response = await fetch(provider.epg_url);
+            if (response.ok) {
+              const epgData = await response.text();
+              await fs.promises.writeFile(cacheFile, epgData, 'utf8');
+              console.log(`✅ Scheduled EPG update success: ${provider.name}`);
+              failedUpdates.delete(provider.id);
+              await generateConsolidatedEpg();
+            } else {
+              console.error(`Scheduled EPG update HTTP error ${response.status} for ${provider.name}`);
+              failedUpdates.set(provider.id, now);
+            }
+          } catch (e) {
+            console.error(`Scheduled EPG update failed for ${provider.name}:`, e.message);
             failedUpdates.set(provider.id, now);
           }
-        } catch (e) {
-          console.error(`Scheduled EPG update failed for ${provider.name}:`, e.message);
-          failedUpdates.set(provider.id, now);
         }
       }
-    }
+    } catch (e) { console.error('EPG Scheduler (Provider) error:', e); }
   }, 60000);
   console.log('📅 EPG Scheduler started');
 }

--- a/tests/scheduler/sync_scheduler.test.js
+++ b/tests/scheduler/sync_scheduler.test.js
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Use vi.hoisted to ensure mockDb is available for mocking
+const { mockDb } = vi.hoisted(() => ({
+  mockDb: {
+    prepare: vi.fn(),
+    transaction: vi.fn(cb => cb()),
+  },
+}));
+
+// Mock node-fetch to prevent resolution errors
+vi.mock('node-fetch', () => ({
+  default: vi.fn(),
+}));
+
+// Mock dotenv
+vi.mock('dotenv', () => ({
+  default: {
+    config: vi.fn(),
+  },
+}));
+
+// Mock DB module
+vi.mock('../../src/database/db.js', () => ({
+  default: mockDb,
+}));
+
+// Mock syncService
+vi.mock('../../src/services/syncService.js', () => ({
+  performSync: vi.fn().mockResolvedValue({}),
+}));
+
+// Import after mocking
+import { startSyncScheduler } from '../../src/services/schedulerService.js';
+import * as syncService from '../../src/services/syncService.js';
+
+describe('Sync Scheduler', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mockDb.prepare.mockReturnValue({
+      all: vi.fn().mockReturnValue([]),
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should schedule syncs for due configs', async () => {
+    const config = { id: 1, provider_id: 101, user_id: 201, enabled: 1, next_sync: 0 };
+
+    mockDb.prepare.mockReturnValue({
+      all: vi.fn().mockReturnValue([config]),
+    });
+
+    // Start the scheduler
+    startSyncScheduler();
+
+    // Advance time by 60 seconds (check interval)
+    await vi.advanceTimersByTimeAsync(60000);
+
+    expect(mockDb.prepare).toHaveBeenCalledWith(expect.stringContaining('SELECT * FROM sync_configs'));
+    expect(syncService.performSync).toHaveBeenCalledWith(101, 201, false);
+  });
+
+  it('should not schedule concurrent syncs for the same config', async () => {
+    const config = { id: 2, provider_id: 102, user_id: 202, enabled: 1, next_sync: 0 };
+
+    mockDb.prepare.mockReturnValue({
+      all: vi.fn().mockReturnValue([config]),
+    });
+
+    let resolveSync;
+    const syncPromise = new Promise(resolve => { resolveSync = resolve; });
+
+    vi.mocked(syncService.performSync).mockReturnValue(syncPromise);
+
+    startSyncScheduler();
+
+    // First tick
+    await vi.advanceTimersByTimeAsync(60000);
+    expect(syncService.performSync).toHaveBeenCalledTimes(1);
+
+    // Second tick - sync still running
+    await vi.advanceTimersByTimeAsync(60000);
+    expect(syncService.performSync).toHaveBeenCalledTimes(1); // Should not increase
+
+    // Resolve sync
+    resolveSync({});
+    // Wait for promise resolution
+    await vi.advanceTimersByTimeAsync(1);
+
+    // Third tick - sync finished
+    await vi.advanceTimersByTimeAsync(60000);
+    expect(syncService.performSync).toHaveBeenCalledTimes(2); // Should trigger again
+  });
+});


### PR DESCRIPTION
Refactored `startSyncScheduler` in `src/services/schedulerService.js` to use a polling mechanism (every 60s) instead of creating individual intervals for each sync configuration. This ensures that all enabled sync configurations are checked and executed reliably, regardless of when they were added or modified.

Also removed calls to `startSyncScheduler` from `src/controllers/systemController.js` to prevent HTTP worker processes from erroneously starting their own schedulers, which caused race conditions and incomplete scheduling.

Added `tests/scheduler/sync_scheduler.test.js` to verify the new polling logic and concurrency handling.

---
*PR created automatically by Jules for task [8825945186575079130](https://jules.google.com/task/8825945186575079130) started by @Bladestar2105*