### PR TITLE
🎨 Palette: Add auto-focus to modal inputs

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2696,6 +2696,21 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
+  // Global Modal Autofocus
+  document.addEventListener('shown.bs.modal', function (event) {
+    const modal = event.target;
+    // Prioritize [autofocus], then first visible input
+    const input = modal.querySelector('[autofocus]') ||
+                  modal.querySelector('input:not([type="hidden"]):not([disabled]), textarea:not([disabled]), select:not([disabled])');
+    if (input) {
+      input.focus();
+      // Select text if it's a text input
+      if (input.tagName === 'INPUT' && (input.type === 'text' || input.type === 'password' || input.type === 'number')) {
+          input.select();
+      }
+    }
+  });
+
   console.log('✅ IPTV-Manager loaded with i18n & local assets');
 });
 

--- a/public/index.html
+++ b/public/index.html
@@ -919,7 +919,7 @@
           <form id="login-form" >
             <div class="mb-3">
               <label for="login-username" class="form-label" data-i18n="username">Username</label>
-              <input type="text" class="form-control" id="login-username" required>
+              <input type="text" class="form-control" id="login-username" required autofocus>
             </div>
             <div class="mb-3">
               <label for="login-password" class="form-label" data-i18n="password">Password</label>


### PR DESCRIPTION
Implemented a global improved focus management for Bootstrap modals. Since native HTML `autofocus` does not work reliably within dynamically shown Bootstrap modals, a global JavaScript event listener was added to `public/app.js`. This listener detects when any modal is shown and shifts focus to the first appropriate input field, prioritizing those with the `autofocus` attribute. Additionally, the login username field in `public/index.html` was explicitly marked with `autofocus`. This micro-UX improvement reduces friction for keyboard and mouse users alike.

---
*PR created automatically by Jules for task [10639691996657306266](https://jules.google.com/task/10639691996657306266) started by @Bladestar2105*