### PR TITLE
Fix manual EPG mapping missing provider channels

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -3521,10 +3521,12 @@ function filterEpgSelectionList() {
     li.style.cursor = 'pointer';
     const safeName = escapeHtml(epg.name);
     const safeId = escapeHtml(epg.id);
+    const safeSource = epg.source_type ? `<span class="badge bg-secondary ms-2">${escapeHtml(epg.source_type)}</span>` : '';
+
     li.innerHTML = `
       <div class="d-flex justify-content-between align-items-center">
         <div>
-          <strong>${safeName}</strong> <br>
+          <strong>${safeName}</strong> ${safeSource} <br>
           <small class="text-muted">${safeId}</small>
         </div>
         ${epg.logo ? `<img src="${getProxiedUrl(epg.logo)}" alt="${safeName}" height="30" data-on-error="hide">` : ''}

--- a/src/services/epgService.js
+++ b/src/services/epgService.js
@@ -217,15 +217,11 @@ export function deleteEpgSourceData(sourceId, sourceType) {
 }
 
 export async function loadAllEpgChannels() {
-    // Return distinct channels by ID (preferring provider source if duplicate?)
-    // Actually just return all unique IDs.
-    // epg_channels PK is (id, source_type, source_id).
-    // Use GROUP BY id to get unique channels list for mapping.
+    // Return all channels including source info
     const channels = db.prepare(`
-        SELECT id, name, logo
+        SELECT id, name, logo, source_type
         FROM epg_channels
-        GROUP BY id
-        ORDER BY name
+        ORDER BY name ASC
     `).all();
     return channels;
 }


### PR DESCRIPTION
- Updated `loadAllEpgChannels` in `src/services/epgService.js` to return all channels (including duplicates with different sources) by removing `GROUP BY id`, and included `source_type`.
- Modified `src/controllers/providerController.js` to trigger `updateProviderEpg` asynchronously on provider creation, update, and manual sync, ensuring EPG data is populated immediately.
- Updated `src/controllers/providerController.js` to use `getLastEpgUpdate` from database instead of legacy file checks for accurate status.
- Updated `public/app.js` to display `source_type` badge in the EPG selection modal to distinguish between sources.


---
*PR created automatically by Jules for task [6291943833765848288](https://jules.google.com/task/6291943833765848288) started by @Bladestar2105*