### PR TITLE
Populate EPG channels from provider channels for mapping when XMLTV is missing

### DIFF
--- a/src/controllers/epgController.js
+++ b/src/controllers/epgController.js
@@ -97,7 +97,7 @@ export const getEpgSources = (req, res) => {
     if (!req.user.is_admin) return res.status(403).json({error: 'Access denied'});
     const sources = db.prepare('SELECT * FROM epg_sources ORDER BY name').all();
 
-    const providers = db.prepare("SELECT id, name, epg_url, epg_update_interval, epg_enabled FROM providers WHERE epg_url IS NOT NULL AND TRIM(epg_url) != ''").all();
+    const providers = db.prepare("SELECT id, name, epg_url, epg_update_interval, epg_enabled FROM providers").all();
 
     // Check main DB for provider status?
     // Actually epg_sources table tracks custom sources status.
@@ -246,7 +246,7 @@ export const updateAllEpgSources = async (req, res) => {
   try {
     if (!req.user.is_admin) return res.status(403).json({error: 'Access denied'});
     const sources = db.prepare('SELECT id FROM epg_sources WHERE enabled = 1').all();
-    const providers = db.prepare("SELECT id FROM providers WHERE epg_url IS NOT NULL AND TRIM(epg_url) != '' AND epg_enabled = 1").all();
+    const providers = db.prepare("SELECT id FROM providers WHERE epg_enabled = 1").all();
 
     const providerPromises = providers.map(async (provider) => {
       try {

--- a/src/controllers/providerController.js
+++ b/src/controllers/providerController.js
@@ -148,7 +148,7 @@ export const createProvider = async (req, res) => {
     await checkProviderExpiry(info.lastInsertRowid);
 
     // Trigger EPG update if enabled
-    if (finalEpgUrl && (epg_enabled === undefined || epg_enabled)) {
+    if (epg_enabled === undefined || epg_enabled) {
       updateProviderEpg(info.lastInsertRowid).catch(err => console.error(`Initial EPG update failed for provider ${info.lastInsertRowid}:`, err.message));
     }
 
@@ -249,9 +249,8 @@ export const updateProvider = async (req, res) => {
 
     // Trigger EPG update if enabled
     const isEpgEnabled = epg_enabled !== undefined ? epg_enabled : existing.epg_enabled;
-    const hasEpgUrl = finalEpgUrl && finalEpgUrl.length > 0;
 
-    if (hasEpgUrl && isEpgEnabled) {
+    if (isEpgEnabled) {
       updateProviderEpg(id).catch(err => console.error(`EPG update failed for provider ${id}:`, err.message));
     }
 

--- a/tests/epg/provider_epg_fallback.test.js
+++ b/tests/epg/provider_epg_fallback.test.js
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Readable } from 'stream';
+
+// Use vi.hoisted to ensure mock objects are available for mocking
+const { mockMainDb, mockImportDb } = vi.hoisted(() => {
+    const mockMainDb = {
+        prepare: vi.fn(),
+        transaction: vi.fn((cb) => cb),
+    };
+    const mockImportDb = {
+        pragma: vi.fn(),
+        prepare: vi.fn(),
+        transaction: vi.fn((cb) => cb),
+        close: vi.fn(),
+    };
+    return { mockMainDb, mockImportDb };
+});
+
+// Mock better-sqlite3 constructor
+vi.mock('better-sqlite3', () => {
+    return {
+        default: class {
+            constructor() {
+                return mockImportDb;
+            }
+        }
+    };
+});
+
+// Mock main DB
+vi.mock('../../src/database/db.js', () => ({
+    default: mockMainDb
+}));
+
+// Mock EPG DB
+vi.mock('../../src/database/epgDb.js', () => ({
+    default: {
+        prepare: vi.fn(),
+    }
+}));
+
+// Mock node-fetch
+vi.mock('node-fetch', () => ({
+    default: vi.fn(() => Promise.resolve({
+        ok: true,
+        body: Readable.from(['<tv>\n', '</tv>'])
+    }))
+}));
+
+// Mock dotenv
+vi.mock('dotenv', () => ({
+    default: {
+        config: vi.fn(),
+    }
+}));
+
+// Import subject under test
+import { updateProviderEpg } from '../../src/services/epgService.js';
+
+describe('updateProviderEpg', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        // Default mocks
+        mockMainDb.prepare.mockReturnValue({
+            get: vi.fn(),
+            all: vi.fn(),
+            run: vi.fn(),
+        });
+        mockImportDb.prepare.mockReturnValue({
+            run: vi.fn(),
+        });
+    });
+
+    it('should use importChannelsFromProvider when epg_url is missing', async () => {
+        const providerId = 1;
+
+        // Mock provider fetch
+        const mockGetProvider = vi.fn().mockReturnValue({ id: providerId, epg_url: null });
+        // Mock channels fetch
+        const mockGetChannels = vi.fn().mockReturnValue([
+            { epg_channel_id: 'ch1', name: 'Channel 1', logo: 'logo1.png' }
+        ]);
+
+        mockMainDb.prepare.mockImplementation((query) => {
+            if (query.includes('FROM providers')) return { get: mockGetProvider };
+            if (query.includes('FROM provider_channels')) return { all: mockGetChannels };
+            return { run: vi.fn() };
+        });
+
+        await updateProviderEpg(providerId, true);
+
+        // Verify fallback logic
+        expect(mockGetProvider).toHaveBeenCalled();
+        expect(mockGetChannels).toHaveBeenCalledWith(providerId);
+
+        // Verify insertion into EPG DB
+        const calls = mockImportDb.prepare.mock.calls.map(c => c[0]);
+        const hasInsert = calls.some(sql => sql.includes('INSERT OR REPLACE INTO epg_channels'));
+        expect(hasInsert).toBe(true);
+    });
+
+    it('should use importEpgFromUrl when epg_url is present', async () => {
+        const providerId = 2;
+        const epgUrl = 'http://example.com/xmltv';
+
+        // Mock provider fetch
+        const mockGetProvider = vi.fn().mockReturnValue({ id: providerId, epg_url: epgUrl });
+        const mockGetChannels = vi.fn(); // Should not be called
+
+        mockMainDb.prepare.mockImplementation((query) => {
+            if (query.includes('FROM providers')) return { get: mockGetProvider };
+            if (query.includes('FROM provider_channels')) return { all: mockGetChannels };
+            return { run: vi.fn() };
+        });
+
+        await updateProviderEpg(providerId, true);
+
+        expect(mockGetProvider).toHaveBeenCalled();
+        expect(mockGetChannels).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
This PR addresses the issue where providers without an explicit XMLTV URL (e.g., using Xtream Codes API) would not have their channels available in the EPG mapping interface. By populating the `epg.db` with channels derived from the provider sync (using `epg_channel_id`), users can now map channels even without a full XMLTV file.

---
*PR created automatically by Jules for task [13960150485445495450](https://jules.google.com/task/13960150485445495450) started by @Bladestar2105*