### PR TITLE
Fix provider last EPG update timestamp display

### DIFF
--- a/src/controllers/providerController.js
+++ b/src/controllers/providerController.js
@@ -5,7 +5,7 @@ import db from '../database/db.js';
 import { encrypt, decrypt } from '../utils/crypto.js';
 import { isSafeUrl, isAdultCategory } from '../utils/helpers.js';
 import { performSync, checkProviderExpiry } from '../services/syncService.js';
-import { updateProviderEpg, getLastEpgUpdate } from '../services/epgService.js';
+import { updateProviderEpg } from '../services/epgService.js';
 import { EPG_CACHE_DIR } from '../config/constants.js';
 
 const fetchProviderDetails = async (url, username, password) => {
@@ -56,10 +56,7 @@ export const getProviders = (req, res) => {
 
     const providers = db.prepare(query).all(...params);
     const safeProviders = providers.map(p => {
-      let lastUpdate = 0;
-      if (p.epg_url) {
-         lastUpdate = getLastEpgUpdate('provider', p.id);
-      }
+      let lastUpdate = p.last_epg_update || 0;
 
       let plainPassword = null;
       if (req.user.is_admin) {

--- a/src/services/schedulerService.js
+++ b/src/services/schedulerService.js
@@ -1,7 +1,7 @@
 import fetch from 'node-fetch';
 import db from '../database/db.js';
 import { performSync } from './syncService.js';
-import { updateEpgSource, updateProviderEpg, pruneOldEpgData, getLastEpgUpdate } from './epgService.js';
+import { updateEpgSource, updateProviderEpg, pruneOldEpgData } from './epgService.js';
 import { isSafeUrl } from '../utils/helpers.js';
 
 let syncInterval = null;


### PR DESCRIPTION
The "Last EPG Update" field in the provider list was showing "Never" because the controller was querying the ephemeral EPG database (which might be empty or pruned) instead of using the persistent `last_epg_update` timestamp stored in the main `providers` table. This change ensures the timestamp reflects the last successful update attempt recorded in the main database.

---
*PR created automatically by Jules for task [17491217114838867616](https://jules.google.com/task/17491217114838867616) started by @Bladestar2105*