### PR TITLE
Allow private LAN IPs for provider URLs

### DIFF
--- a/tests/security/is_safe_url.test.js
+++ b/tests/security/is_safe_url.test.js
@@ -37,9 +37,9 @@ describe('isSafeUrl Security Checks', () => {
     expect(safe).toBe(false);
   });
 
-  it('should block CGNAT range (100.64.0.1)', async () => {
+  it('should allow CGNAT range (100.64.0.1)', async () => {
     const safe = await isSafeUrl('http://100.64.0.1');
-    expect(safe).toBe(false);
+    expect(safe).toBe(true);
   });
 
   it('should block TEST-NET-1 (192.0.2.1)', async () => {

--- a/tests/share_slug.test.js
+++ b/tests/share_slug.test.js
@@ -18,7 +18,7 @@ vi.mock('../src/database/db.js', () => ({
 
 vi.mock('../src/utils/helpers.js', () => ({
     getBaseUrl: vi.fn(() => 'http://localhost:3000'),
-    isPrivateIP: vi.fn(() => false),
+    isUnsafeIP: vi.fn(() => false),
     isSafeUrl: vi.fn(async () => true),
     isAdultCategory: vi.fn(() => false)
 }));


### PR DESCRIPTION
This PR addresses an issue where legitimate provider URLs hosted on private networks (e.g., local IPTV servers, providers over VPN) were being blocked by the application's SSRF protection mechanism.

Changes:
- Renamed `isPrivateIP` to `isUnsafeIP` in `src/utils/helpers.js` to better reflect its purpose.
- Modified the IP validation logic to **allow** standard private LAN ranges (RFC 1918: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) and CGNAT (100.64.0.0/10).
- Maintained blocks on **unsafe** ranges: Loopback (127.0.0.0/8, ::1), Link-Local (169.254.0.0/16), and 0.0.0.0.
- Updated `isSafeUrl` and `safeLookup` to use the new `isUnsafeIP` function.
- Updated `tests/security/proxy_ssrf.test.js` to verify that private LAN IPs are now considered safe while loopback addresses remain blocked.
- Updated `tests/security/is_safe_url.test.js` to reflect that CGNAT is now allowed.
- Updated `tests/share_slug.test.js` to mock `isUnsafeIP` instead of `isPrivateIP`.

This ensures that self-hosted users can connect to local resources while still protecting the server from SSRF attacks targeting localhost or cloud metadata services.

---
*PR created automatically by Jules for task [13569054214016640785](https://jules.google.com/task/13569054214016640785) started by @Bladestar2105*