### PR TITLE
🎨 Palette: Improve drag handle visibility and interaction

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -562,12 +562,21 @@ span {
   opacity: 0.8;
 }
 .drag-handle {
-  cursor: move;
+  cursor: grab;
   padding: 0 8px;
-  color: #999;
+  color: var(--tv-text-muted);
+  transition: all 0.2s ease;
+  font-size: 1.2em;
 }
 .drag-handle:hover {
-  color: #333;
+  color: var(--tv-blue-light);
+  cursor: grab;
+  transform: scale(1.1);
+}
+.drag-handle:active {
+  cursor: grabbing;
+  color: var(--tv-cyan);
+  transform: scale(0.95);
 }
 .lang-switcher {
   position: fixed;


### PR DESCRIPTION
💡 What: Improved the visual and interactive design of the drag-and-drop handles in the UI.
🎯 Why: The previous hover color (`#333`) was invisible against the dark theme background, and the `move` cursor was less intuitive than the modern `grab` standard.
📸 Before/After: Drag handles now glow blue on hover and scale down slightly when pressed, providing clear visual and tactile feedback.
♿ Accessibility: Improved contrast ratio for interactive elements in dark mode.

---
*PR created automatically by Jules for task [9927742209560296687](https://jules.google.com/task/9927742209560296687) started by @Bladestar2105*