### PR TITLE
fix(stream-manager): Smart counting for user connection limits

### DIFF
--- a/tests/security/user_connection_limit_smart.test.js
+++ b/tests/security/user_connection_limit_smart.test.js
@@ -1,0 +1,69 @@
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import streamManager from '../../src/services/streamManager.js';
+
+describe('Smart Stream Counting Logic', () => {
+    let mockDb;
+    let mockPrepare;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockPrepare = vi.fn(() => ({ run: vi.fn(), get: vi.fn(), all: vi.fn() }));
+        mockDb = { prepare: mockPrepare };
+
+        // Reset streamManager internal state
+        streamManager.db = null;
+        streamManager.redis = null;
+        streamManager.stmtCountUser = null;
+        streamManager.stmtAdd = null;
+        streamManager.stmtRemove = null;
+        streamManager.stmtCleanup = null;
+        streamManager.stmtGetAll = null;
+        streamManager.stmtCountProvider = null;
+    });
+
+    it('should use DISTINCT query for user connection count in SQLite mode', () => {
+        streamManager.init(mockDb, null);
+
+        // Check calls to prepare
+        const calls = mockPrepare.mock.calls.map(c => c[0]);
+        // We look for the query that counts user streams
+        const countQuery = calls.find(sql => sql.includes('SELECT COUNT(*) as count FROM') && sql.includes('user_id = ?'));
+
+        expect(countQuery).toBeDefined();
+        // This expectation will fail BEFORE the fix, confirming reproduction
+        // We expect it to count distinct sessions
+        expect(countQuery).toContain('DISTINCT channel_name, ip, provider_id');
+    });
+
+    it('should filter unique sessions correctly in Redis mode', async () => {
+        const mockRedis = {
+            hSet: vi.fn(),
+            set: vi.fn(),
+            hGetAll: vi.fn().mockResolvedValue({
+                'conn1': JSON.stringify({ user_id: 1, channel_name: 'Movie A', ip: '1.2.3.4', provider_id: 100 }),
+                'conn2': JSON.stringify({ user_id: 1, channel_name: 'Movie A', ip: '1.2.3.4', provider_id: 100 }), // Duplicate session (same user, movie, ip)
+                'conn3': JSON.stringify({ user_id: 1, channel_name: 'Movie B', ip: '1.2.3.4', provider_id: 100 }), // Different movie
+                'conn4': JSON.stringify({ user_id: 2, channel_name: 'Movie A', ip: '1.2.3.4', provider_id: 100 }), // Different user
+                'conn5': JSON.stringify({ user_id: 1, channel_name: 'Movie A', ip: '5.6.7.8', provider_id: 100 }), // Different IP
+            }),
+            on: vi.fn(),
+            connect: vi.fn()
+        };
+
+        streamManager.init(null, mockRedis);
+
+        const count = await streamManager.getUserConnectionCount(1);
+
+        // Expected unique sessions for user 1:
+        // 1. (Movie A, 1.2.3.4, 100) - from conn1 and conn2
+        // 2. (Movie B, 1.2.3.4, 100) - from conn3
+        // 3. (Movie A, 5.6.7.8, 100) - from conn5
+        // Total: 3
+
+        // Before fix: returns 4 (conn1, conn2, conn3, conn5).
+        // After fix: returns 3.
+
+        expect(count).toBe(3);
+    });
+});


### PR DESCRIPTION
This PR addresses the issue where VOD playback fails with 403 Forbidden errors when a user has a strict `max_connections` limit (e.g., 1). Modern VOD players often open multiple concurrent connections to the same stream for buffering or seeking. The previous logic counted each TCP connection as a separate "active stream," causing the limit to be exceeded immediately.

The fix implements "Smart Counting" in `streamManager.js`:
- For SQLite: Uses a `DISTINCT` query to count unique `(channel_name, ip, provider_id)` combinations.
- For Redis: Filters retrieved streams to count unique sessions in memory.

This ensures that multiple connections to the same content from the same IP are treated as a single active session, while still enforcing limits against multiple devices or different content.

A reproduction test `tests/security/user_connection_limit_smart.test.js` was added to verify the fix.

---
*PR created automatically by Jules for task [14039294249288777228](https://jules.google.com/task/14039294249288777228) started by @Bladestar2105*