### PR TITLE
Relax isSafeUrl check and fix provider limits for VOD

### DIFF
--- a/src/controllers/streamController.js
+++ b/src/controllers/streamController.js
@@ -194,14 +194,17 @@ export const proxyMpd = async (req, res) => {
     }
 
     if (relativePath.endsWith('.mpd')) {
-        if (user.max_connections > 0) {
-            const active = await streamManager.getUserConnectionCount(user.id);
-            if (active >= user.max_connections) return res.status(403).send('Max connections reached');
-        }
+        const isSessionActive = await streamManager.isSessionActive(user.id, req.ip, `${channel.name} (DASH)`, channel.provider_id);
+        if (!isSessionActive) {
+            if (user.max_connections > 0) {
+                const active = await streamManager.getUserConnectionCount(user.id);
+                if (active >= user.max_connections) return res.status(403).send('Max connections reached');
+            }
 
-        if (channel.provider_max_connections > 0) {
-            const active = await streamManager.getProviderConnectionCount(channel.provider_id);
-            if (active >= channel.provider_max_connections) return res.status(403).send('Provider max connections reached');
+            if (channel.provider_max_connections > 0) {
+                const active = await streamManager.getProviderConnectionCount(channel.provider_id);
+                if (active >= channel.provider_max_connections) return res.status(403).send('Provider max connections reached');
+            }
         }
 
         await streamManager.add(connectionId, user, `${channel.name} (DASH)`, req.ip, res, channel.provider_id);
@@ -611,14 +614,17 @@ export const proxyMovie = async (req, res) => {
         if ((user.share_start && nowSec < user.share_start) || (user.share_end && nowSec > user.share_end)) return res.sendStatus(403);
     }
 
-    if (user.max_connections > 0) {
-        const active = await streamManager.getUserConnectionCount(user.id);
-        if (active >= user.max_connections) return res.status(403).send('Max connections reached');
-    }
+    const isSessionActive = await streamManager.isSessionActive(user.id, req.ip, `${channel.name} (VOD)`, channel.provider_id);
+    if (!isSessionActive) {
+        if (user.max_connections > 0) {
+            const active = await streamManager.getUserConnectionCount(user.id);
+            if (active >= user.max_connections) return res.status(403).send('Max connections reached');
+        }
 
-    if (channel.provider_max_connections > 0) {
-        const active = await streamManager.getProviderConnectionCount(channel.provider_id);
-        if (active >= channel.provider_max_connections) return res.status(403).send('Provider max connections reached');
+        if (channel.provider_max_connections > 0) {
+            const active = await streamManager.getProviderConnectionCount(channel.provider_id);
+            if (active >= channel.provider_max_connections) return res.status(403).send('Provider max connections reached');
+        }
     }
 
     await streamManager.add(connectionId, user, `${channel.name} (VOD)`, req.ip, res, channel.provider_id);
@@ -780,14 +786,17 @@ export const proxySeries = async (req, res) => {
 
     if (user.is_share_guest) return res.sendStatus(403);
 
-    if (user.max_connections > 0) {
-        const active = await streamManager.getUserConnectionCount(user.id);
-        if (active >= user.max_connections) return res.status(403).send('Max connections reached');
-    }
+    const isSessionActive = await streamManager.isSessionActive(user.id, req.ip, `Series Episode ${remoteEpisodeId}`, provider.id);
+    if (!isSessionActive) {
+        if (user.max_connections > 0) {
+            const active = await streamManager.getUserConnectionCount(user.id);
+            if (active >= user.max_connections) return res.status(403).send('Max connections reached');
+        }
 
-    if (provider.max_connections > 0) {
-        const active = await streamManager.getProviderConnectionCount(provider.id);
-        if (active >= provider.max_connections) return res.status(403).send('Provider max connections reached');
+        if (provider.max_connections > 0) {
+            const active = await streamManager.getProviderConnectionCount(provider.id);
+            if (active >= provider.max_connections) return res.status(403).send('Provider max connections reached');
+        }
     }
 
     await streamManager.add(connectionId, user, `Series Episode ${remoteEpisodeId}`, req.ip, res, provider.id);
@@ -885,14 +894,17 @@ export const proxyTimeshift = async (req, res) => {
         if ((user.share_start && nowSec < user.share_start) || (user.share_end && nowSec > user.share_end)) return res.sendStatus(403);
     }
 
-    if (user.max_connections > 0) {
-        const active = await streamManager.getUserConnectionCount(user.id);
-        if (active >= user.max_connections) return res.status(403).send('Max connections reached');
-    }
+    const isSessionActive = await streamManager.isSessionActive(user.id, req.ip, `${channel.name} (Timeshift)`, channel.provider_id);
+    if (!isSessionActive) {
+        if (user.max_connections > 0) {
+            const active = await streamManager.getUserConnectionCount(user.id);
+            if (active >= user.max_connections) return res.status(403).send('Max connections reached');
+        }
 
-    if (channel.provider_max_connections > 0) {
-        const active = await streamManager.getProviderConnectionCount(channel.provider_id);
-        if (active >= channel.provider_max_connections) return res.status(403).send('Provider max connections reached');
+        if (channel.provider_max_connections > 0) {
+            const active = await streamManager.getProviderConnectionCount(channel.provider_id);
+            if (active >= channel.provider_max_connections) return res.status(403).send('Provider max connections reached');
+        }
     }
 
     await streamManager.add(connectionId, user, `${channel.name} (Timeshift)`, req.ip, res, channel.provider_id);

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -57,11 +57,13 @@ export async function isSafeUrl(urlStr) {
     if (hostname === 'localhost' || hostname === '0.0.0.0' || hostname === '::1') return false;
     if (hostname === 'metadata.google.internal') return false;
 
-    // Resolve DNS
-    const { address } = await dns.promises.lookup(hostname);
+    // Check if hostname is an IP address
+    if (isIP(hostname)) {
+      return !isUnsafeIP(hostname);
+    }
 
-    // Check resolved IP
-    return !isUnsafeIP(address);
+    // Allow domain names (DNS resolution happens later in fetchSafe via httpAgent)
+    return true;
   } catch (e) {
     return false;
   }

--- a/tests/managers/stream_manager_smart.test.js
+++ b/tests/managers/stream_manager_smart.test.js
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import streamManager from '../../src/services/streamManager.js';
+
+describe('StreamManager Smart Limits', () => {
+  describe('DB Implementation (SQL Verification)', () => {
+    let mockDb;
+    let mockStmt;
+
+    beforeEach(() => {
+      mockStmt = {
+        get: vi.fn(),
+        run: vi.fn(),
+        all: vi.fn()
+      };
+      mockDb = {
+        prepare: vi.fn().mockReturnValue(mockStmt)
+      };
+      streamManager.init(mockDb, null);
+    });
+
+    it('should use correct SQL for provider connection count', async () => {
+      mockStmt.get.mockReturnValue({ count: 5 });
+
+      const count = await streamManager.getProviderConnectionCount(123);
+
+      expect(mockDb.prepare).toHaveBeenCalledWith(
+        expect.stringContaining('SELECT DISTINCT channel_name, ip, user_id')
+      );
+      expect(mockStmt.get).toHaveBeenCalledWith(123);
+      expect(count).toBe(5);
+    });
+
+    it('should use correct SQL for checking active session', async () => {
+      mockStmt.get.mockReturnValue(1);
+
+      const isActive = await streamManager.isSessionActive(1, '1.1.1.1', 'Channel A', 100);
+
+      expect(mockDb.prepare).toHaveBeenCalledWith(
+        expect.stringContaining('SELECT 1 FROM current_streams WHERE user_id = ? AND ip = ? AND channel_name = ? AND provider_id = ? LIMIT 1')
+      );
+      expect(mockStmt.get).toHaveBeenCalledWith(1, '1.1.1.1', 'Channel A', 100);
+      expect(isActive).toBe(true);
+    });
+  });
+
+  describe('Redis Implementation (Logic Verification)', () => {
+    let mockRedis;
+
+    beforeEach(() => {
+      mockRedis = {
+        hSet: vi.fn(),
+        set: vi.fn(),
+        hGet: vi.fn(),
+        del: vi.fn(),
+        hDel: vi.fn(),
+        hGetAll: vi.fn(),
+        get: vi.fn()
+      };
+      streamManager.init(null, mockRedis);
+    });
+
+    it('should count unique sessions correctly for provider limits', async () => {
+      const streams = {
+        '1': JSON.stringify({ user_id: 1, channel_name: 'Channel A', ip: '1.1.1.1', provider_id: 100 }),
+        '2': JSON.stringify({ user_id: 1, channel_name: 'Channel A', ip: '1.1.1.1', provider_id: 100 }), // Same session
+        '3': JSON.stringify({ user_id: 2, channel_name: 'Channel A', ip: '2.2.2.2', provider_id: 100 }), // Different user/ip
+        '4': JSON.stringify({ user_id: 1, channel_name: 'Channel B', ip: '1.1.1.1', provider_id: 100 }), // Different channel
+        '5': JSON.stringify({ user_id: 3, channel_name: 'Channel X', ip: '3.3.3.3', provider_id: 200 })  // Different provider
+      };
+      mockRedis.hGetAll.mockResolvedValue(streams);
+
+      const count = await streamManager.getProviderConnectionCount(100);
+
+      // Expected:
+      // 1. User 1, Channel A, 1.1.1.1 (from '1' and '2')
+      // 2. User 2, Channel A, 2.2.2.2 (from '3')
+      // 3. User 1, Channel B, 1.1.1.1 (from '4')
+      // Total 3
+      expect(count).toBe(3);
+    });
+
+    it('should identify active sessions correctly', async () => {
+       const streams = {
+        '1': JSON.stringify({ user_id: 1, channel_name: 'Channel A', ip: '1.1.1.1', provider_id: 100 })
+      };
+      mockRedis.hGetAll.mockResolvedValue(streams);
+
+      expect(await streamManager.isSessionActive(1, '1.1.1.1', 'Channel A', 100)).toBe(true);
+      expect(await streamManager.isSessionActive(1, '1.1.1.1', 'Channel B', 100)).toBe(false);
+      expect(await streamManager.isSessionActive(2, '1.1.1.1', 'Channel A', 100)).toBe(false);
+    });
+  });
+});

--- a/tests/security/provider_limit.test.js
+++ b/tests/security/provider_limit.test.js
@@ -86,6 +86,7 @@ vi.mock('../../src/services/streamManager.js', () => ({
         add: vi.fn(),
         remove: vi.fn(),
         cleanupUser: vi.fn(),
+        isSessionActive: vi.fn().mockResolvedValue(false),
         getUserConnectionCount: vi.fn().mockResolvedValue(0),
         getProviderConnectionCount: vi.fn().mockResolvedValue(0),
         localStreams: new Map()

--- a/tests/security/relaxed_url.test.js
+++ b/tests/security/relaxed_url.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest';
+import { isSafeUrl } from '../../src/utils/helpers.js';
+
+describe('Relaxed isSafeUrl Checks', () => {
+  it('should allow non-resolving domains (DNS check skipped)', async () => {
+    // previously this would fail if DNS lookup failed
+    const safe = await isSafeUrl('http://non-existent-domain.test');
+    expect(safe).toBe(true);
+  });
+
+  it('should allow domains that resolve to unsafe IPs (DNS check deferred to agent)', async () => {
+    // previously this would fail if it resolved to 127.0.0.1
+    // now we rely on httpAgent to block it
+    const safe = await isSafeUrl('http://local.test');
+    expect(safe).toBe(true);
+  });
+
+  it('should still block explicit unsafe IPs', async () => {
+    expect(await isSafeUrl('http://127.0.0.1')).toBe(false);
+    expect(await isSafeUrl('http://0.0.0.0')).toBe(false);
+  });
+
+  it('should still block blacklisted hostnames', async () => {
+    expect(await isSafeUrl('http://localhost')).toBe(false);
+    expect(await isSafeUrl('http://metadata.google.internal')).toBe(false);
+  });
+});

--- a/tests/security/stream_controller_agent.test.js
+++ b/tests/security/stream_controller_agent.test.js
@@ -90,6 +90,9 @@ vi.mock('../../src/services/streamManager.js', () => ({
         add: vi.fn(),
         remove: vi.fn(),
         cleanupUser: vi.fn(),
+        isSessionActive: vi.fn().mockResolvedValue(false),
+        getUserConnectionCount: vi.fn().mockResolvedValue(0),
+        getProviderConnectionCount: vi.fn().mockResolvedValue(0),
         localStreams: new Map()
     }
 }));

--- a/tests/security/user_connection_limit.test.js
+++ b/tests/security/user_connection_limit.test.js
@@ -77,7 +77,9 @@ vi.mock('../../src/services/streamManager.js', () => ({
         add: vi.fn(),
         remove: vi.fn(),
         cleanupUser: vi.fn(),
+        isSessionActive: vi.fn().mockResolvedValue(false),
         getUserConnectionCount: vi.fn(),
+        getProviderConnectionCount: vi.fn().mockResolvedValue(0),
         localStreams: new Map()
     }
 }));


### PR DESCRIPTION
- Modified `isSafeUrl` to skip DNS resolution for domains, relying on `httpAgent`'s `safeLookup` for security.
- Implemented `isSessionActive` and smart counting in `StreamManager` to allow multiple connections for the same session (fixing VOD playback).
- Updated `StreamController` to bypass connection limits if a session is already active.
- Added and updated tests.

---
*PR created automatically by Jules for task [1576686384900185190](https://jules.google.com/task/1576686384900185190) started by @Bladestar2105*