### PR TITLE
🧹 chore: replace magic number with AUTH_CACHE_CLEANUP_INTERVAL constant

### DIFF
--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -18,3 +18,4 @@ export const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || '30d';
 export const BCRYPT_ROUNDS = parseInt(process.env.BCRYPT_ROUNDS) || 10;
 export const AUTH_CACHE_TTL = 60000;
 export const AUTH_CACHE_MAX_SIZE = 10000;
+export const AUTH_CACHE_CLEANUP_INTERVAL = 300000; // 5 minutes

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -4,7 +4,7 @@ import crypto from 'crypto';
 import db from '../database/db.js';
 import { decrypt, JWT_SECRET } from '../utils/crypto.js';
 import { getSetting, getCookie } from '../utils/helpers.js';
-import { JWT_EXPIRES_IN, BCRYPT_ROUNDS, AUTH_CACHE_TTL, AUTH_CACHE_MAX_SIZE } from '../config/constants.js';
+import { JWT_EXPIRES_IN, BCRYPT_ROUNDS, AUTH_CACHE_TTL, AUTH_CACHE_MAX_SIZE, AUTH_CACHE_CLEANUP_INTERVAL } from '../config/constants.js';
 
 // Authentication Cache
 export const authCache = new Map();
@@ -42,7 +42,7 @@ setInterval(() => {
       if (now > value.expiry) authCache.delete(key);
     }
   }
-}, 300000).unref();
+}, AUTH_CACHE_CLEANUP_INTERVAL).unref();
 
 export async function authUser(username, password) {
   try {


### PR DESCRIPTION
Improved code health by replacing a magic number in `src/services/authService.js` with a named constant `AUTH_CACHE_CLEANUP_INTERVAL` in `src/config/constants.js`.

🎯 **What:** The magic number `300000` (5 minutes) in the authentication cache cleanup logic was replaced by a named constant.
💡 **Why:** This improves maintainability and readability by giving the value a descriptive name and centralizing its configuration.
✅ **Verification:** Verified that the constant was correctly added to `src/config/constants.js` and imported/used in `src/services/authService.js`. Performed syntax checks using `node -c`.
✨ **Result:** Cleaned up the code in `src/services/authService.js`.

---
*PR created automatically by Jules for task [8905149737717181862](https://jules.google.com/task/8905149737717181862) started by @Bladestar2105*