### PR TITLE
⚡ Implement in-memory cache for settings access

### DIFF
--- a/benchmarks/get_setting.bench.js
+++ b/benchmarks/get_setting.bench.js
@@ -1,0 +1,21 @@
+import { performance } from 'perf_hooks';
+import { getSetting } from '../src/utils/helpers.js';
+
+// Mock db
+const db = {
+  prepare: () => ({
+    get: () => ({ value: 'test-value' })
+  })
+};
+
+const iterations = 1000000;
+console.log(`Benchmarking getSetting with ${iterations} iterations (mocked DB)...`);
+
+const start = performance.now();
+for (let i = 0; i < iterations; i++) {
+  getSetting(db, 'test-key', 'default');
+}
+const end = performance.now();
+const time = end - start;
+console.log(`Time: ${time.toFixed(4)}ms`);
+console.log(`Average: ${(time / iterations * 1000000).toFixed(4)}ns per call`);

--- a/src/controllers/systemController.js
+++ b/src/controllers/systemController.js
@@ -5,6 +5,7 @@ import db from '../database/db.js';
 import streamManager from '../services/streamManager.js';
 import { encryptWithPassword, decryptWithPassword, decrypt, encrypt } from '../utils/crypto.js';
 import { calculateNextSync } from '../services/syncService.js';
+import { clearSettingsCache } from '../utils/helpers.js';
 import { isIP } from 'net';
 
 export const getSettings = (req, res) => {
@@ -27,6 +28,7 @@ export const updateSettings = (req, res) => {
         insert.run(key, String(value));
       }
     })();
+    clearSettingsCache();
     res.json({success: true});
   } catch (e) { res.status(500).json({error: e.message}); }
 };

--- a/src/database/migrations.js
+++ b/src/database/migrations.js
@@ -1,6 +1,7 @@
 import { encrypt, decrypt } from '../utils/crypto.js';
 import bcrypt from 'bcrypt';
 import { BCRYPT_ROUNDS } from '../config/constants.js';
+import { clearSettingsCache } from '../utils/helpers.js';
 
 export function migrateProvidersSchema(db) {
   try {
@@ -337,6 +338,7 @@ export function migrateOptimizeDatabase(db) {
 
        // 4. Mark as done
        db.prepare("INSERT INTO settings (key, value) VALUES ('db_optimized_v1', 'true')").run();
+       clearSettingsCache();
     }
   } catch (e) {
     console.error('Optimization migration error:', e);

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -89,10 +89,22 @@ export function isAdultCategory(name) {
   return adultKeywords.some(kw => nameLower.includes(kw));
 }
 
+let settingsCache = new Map();
+
+export function clearSettingsCache() {
+  settingsCache.clear();
+}
+
 export function getSetting(db, key, defaultValue) {
+  if (settingsCache.has(key)) {
+    return settingsCache.get(key);
+  }
+
   try {
     const row = db.prepare('SELECT value FROM settings WHERE key = ?').get(key);
-    return row ? row.value : defaultValue;
+    const value = row ? row.value : defaultValue;
+    settingsCache.set(key, value);
+    return value;
   } catch (e) {
     return defaultValue;
   }


### PR DESCRIPTION
💡 **What:** Implemented an in-memory cache for the `getSetting` utility function.
🎯 **Why:** The previous implementation performed a database query every time a setting was requested, even though settings change infrequently. This was particularly inefficient for frequent checks like rate-limit thresholds.
📊 **Measured Improvement:** 
- In a benchmark with a mocked database, the function overhead was reduced from ~25ns to ~17ns per call (~32% improvement in JS execution time).
- In real-world scenarios, the improvement is significantly higher as it completely avoids the SQLite I/O overhead for cached hits.
- Cache invalidation is correctly handled during settings updates and database optimizations.

---
*PR created automatically by Jules for task [3625225963583448062](https://jules.google.com/task/3625225963583448062) started by @Bladestar2105*