### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix incomplete SSRF protection in isUnsafeIP

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The `/api/proxy/image` endpoint used `await response.arrayBuffer()` to download images for caching, loading the entire file into memory without size limits. This allowed authenticated users to crash the server (Memory Exhaustion) by requesting a large file.
 **Learning:** `fetch` response methods like `arrayBuffer()`, `text()`, and `json()` buffer the entire response body. When handling user-controlled URLs (like in a proxy), always use streams and enforce a size limit to prevent memory exhaustion.
 **Prevention:** Check `Content-Length` headers first (if available), and process the response body as a stream, counting bytes and aborting if a threshold (e.g., 5MB) is exceeded.
+
+## 2024-05-25 - Incomplete SSRF Protection in Helper
+**Vulnerability:** The `isUnsafeIP` utility function only blocked a subset of private IP ranges, missing critical RFC 1918 ranges like `10.0.0.0/8`, `172.16.0.0/12`, and `192.168.0.0/16`. This allowed attackers to bypass SSRF protections by using these unblocked private IPs.
+**Learning:** Blacklisting specific IPs manually is error-prone. It's easy to miss ranges or forget edge cases (like IPv6 ULA or mapped addresses).
+**Prevention:** Use a comprehensive, standard library or a well-maintained list of all reserved IP ranges (RFC 1918, RFC 4193, RFC 6598) for SSRF protection. Regularly audit network validation logic against known reserved ranges.

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -23,15 +23,41 @@ export function isUnsafeIP(ip) {
     if (ipVer === 4) {
         if (ip === '0.0.0.0' ||
             ip.startsWith('127.') ||
+            ip.startsWith('10.') || // Private
             ip.startsWith('169.254.') ||
+            ip.startsWith('192.168.') || // Private
             ip.startsWith('192.0.0.') || // IETF Protocol Assignments
             ip.startsWith('192.0.2.') || // TEST-NET-1
             ip.startsWith('198.51.100.') || // TEST-NET-2
             ip.startsWith('203.0.113.') || // TEST-NET-3
             ip.startsWith('240.')) return true; // Class E (Reserved)
 
+        // 172.16.0.0 - 172.31.255.255 (Private)
+        if (ip.startsWith('172.')) {
+            const parts = ip.split('.');
+            const second = parseInt(parts[1], 10);
+            if (second >= 16 && second <= 31) return true;
+        }
+
+        // 100.64.0.0 - 100.127.255.255 (CGNAT)
+        if (ip.startsWith('100.')) {
+            const parts = ip.split('.');
+            const second = parseInt(parts[1], 10);
+            if (second >= 64 && second <= 127) return true;
+        }
+
+        // 198.18.0.0 - 198.19.255.255 (Benchmarking)
+        if (ip.startsWith('198.')) {
+            const parts = ip.split('.');
+            const second = parseInt(parts[1], 10);
+            if (second >= 18 && second <= 19) return true;
+        }
+
     } else if (ipVer === 6) {
-         if (ip === '::' || ip === '::1' || ip.startsWith('fe80:')) return true;
+         if (ip === '::' || ip === '::1' ||
+             ip.startsWith('fe80:') || // Link-local
+             ip.startsWith('fc') || ip.startsWith('fd') // Unique Local
+         ) return true;
 
          // Check for IPv4 mapped address ::ffff:127.0.0.1
          if (ip.includes('::ffff:')) {

--- a/tests/security/is_safe_url.test.js
+++ b/tests/security/is_safe_url.test.js
@@ -37,9 +37,34 @@ describe('isSafeUrl Security Checks', () => {
     expect(safe).toBe(false);
   });
 
-  it('should allow CGNAT range (100.64.0.1)', async () => {
+  it('should block CGNAT range (100.64.0.1)', async () => {
     const safe = await isSafeUrl('http://100.64.0.1');
-    expect(safe).toBe(true);
+    expect(safe).toBe(false);
+  });
+
+  it('should block Private 10.x.x.x', async () => {
+    const safe = await isSafeUrl('http://10.0.0.1');
+    expect(safe).toBe(false);
+  });
+
+  it('should block Private 172.16.x.x', async () => {
+    const safe = await isSafeUrl('http://172.16.0.1');
+    expect(safe).toBe(false);
+  });
+
+  it('should block Private 192.168.x.x', async () => {
+    const safe = await isSafeUrl('http://192.168.1.1');
+    expect(safe).toBe(false);
+  });
+
+  it('should block Benchmarking 198.18.x.x', async () => {
+    const safe = await isSafeUrl('http://198.18.0.1');
+    expect(safe).toBe(false);
+  });
+
+  it('should block IPv6 Unique Local', async () => {
+    const safe = await isSafeUrl('http://[fc00::1]');
+    expect(safe).toBe(false);
   });
 
   it('should block TEST-NET-1 (192.0.2.1)', async () => {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `isUnsafeIP` utility function failed to block critical private IP ranges (RFC 1918) including `10.0.0.0/8`, `172.16.0.0/12`, and `192.168.0.0/16`. It also missed CGNAT (`100.64.0.0/10`), Benchmarking (`198.18.0.0/15`), and IPv6 ULA (`fc00::/7`).
🎯 Impact: An attacker (with admin access to add providers) could bypass SSRF protections and access internal network services by using these unblocked IP ranges in provider URLs.
🔧 Fix: Updated `isUnsafeIP` in `src/utils/helpers.js` to explicitly block these ranges.
✅ Verification: Updated `tests/security/is_safe_url.test.js` to include test cases for all these ranges and verified that they are now correctly blocked.

---
*PR created automatically by Jules for task [4890157601984520199](https://jules.google.com/task/4890157601984520199) started by @Bladestar2105*