### PR TITLE
🎨 Palette: Add Skip to Content link and improve ARIA labels

### DIFF
--- a/public/i18n.js
+++ b/public/i18n.js
@@ -4,6 +4,11 @@
  */
 const translations = {
   en: {
+    // Accessibility
+    skipToContent: 'Skip to content',
+    selectLanguage: 'Select Language',
+    toggleNavigation: 'Toggle Navigation',
+
     // Title & Headers
     title: 'IPTV-Manager',
     userManagement: 'User Management',
@@ -424,6 +429,11 @@ const translations = {
   },
   
   de: {
+    // Accessibility
+    skipToContent: 'Zum Inhalt springen',
+    selectLanguage: 'Sprache wählen',
+    toggleNavigation: 'Navigation umschalten',
+
     // Title & Headers
     title: 'IPTV-Manager',
     userManagement: 'User-Verwaltung',
@@ -844,6 +854,11 @@ const translations = {
   },
 
   fr: {
+    // Accessibility
+    skipToContent: 'Aller au contenu',
+    selectLanguage: 'Choisir la langue',
+    toggleNavigation: 'Basculer la navigation',
+
     // Title & Headers
     title: 'IPTV-Manager',
     userManagement: 'Gestion des Utilisateurs',
@@ -1264,6 +1279,11 @@ const translations = {
   },
 
   el: {
+    // Accessibility
+    skipToContent: 'Μετάβαση στο περιεχόμενο',
+    selectLanguage: 'Επιλογή Γλώσσας',
+    toggleNavigation: 'Εναλλαγή πλοήγησης',
+
     // Title & Headers
     title: 'IPTV-Manager',
     userManagement: 'Διαχείριση Χρηστών',

--- a/public/index.html
+++ b/public/index.html
@@ -13,15 +13,16 @@
   <link href="style.css" rel="stylesheet">
 </head>
 <body>
+  <a class="visually-hidden-focusable p-2 bg-white text-dark position-absolute start-0 top-0 z-3" href="#main-content" data-i18n="skipToContent">Skip to content</a>
 
   <!-- Navbar -->
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4 d-none" id="main-navbar">
     <div class="container">
       <a class="navbar-brand d-flex align-items-center gap-2" href="#">
-        <img src="logo.png" alt="Logo" width="30" height="30" class="d-inline-block align-text-top">
+        <img src="logo.png" alt="IPTV-Manager Logo" width="30" height="30" class="d-inline-block align-text-top">
         IPTV-Manager
       </a>
-      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" data-i18n-label="toggleNavigation">
         <span class="navbar-toggler-icon"></span>
       </button>
       <div class="collapse navbar-collapse" id="navbarNav">
@@ -43,7 +44,7 @@
           </li>
         </ul>
         <div class="d-flex align-items-center gap-2">
-          <select id="language-selector" class="form-select form-select-sm bg-dark text-light border-secondary w-auto">
+          <select id="language-selector" class="form-select form-select-sm bg-dark text-light border-secondary w-auto" data-i18n-label="selectLanguage">
             <option value="en">🇬🇧 English</option>
             <option value="de">🇩🇪 Deutsch</option>
             <option value="fr">🇫🇷 Français</option>


### PR DESCRIPTION
This PR enhances the accessibility of the main dashboard by adding a "Skip to content" link, improving keyboard navigation for screen reader users. It also adds missing ARIA labels to the language selector and navbar toggler, and updates the logo's alternative text. All new strings are localized.

---
*PR created automatically by Jules for task [14478317858895479970](https://jules.google.com/task/14478317858895479970) started by @Bladestar2105*