### PR TITLE
Improve client-side logging for Script Errors

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -4,7 +4,10 @@
  */
 
 window.onerror = function(msg, url, line, col, error) {
-   const stack = error ? error.stack : '';
+   let stack = error ? error.stack : '';
+   if (!stack) {
+       stack = `URL: ${url}\nLine: ${line}\nCol: ${col}`;
+   }
    logToBackend('error', msg, stack);
 };
 
@@ -20,13 +23,16 @@ async function logToBackend(level, message, stack) {
       const headers = {'Content-Type': 'application/json'};
       if (token) headers['Authorization'] = `Bearer ${token}`;
 
+      // Enrich stack with current page URL for context
+      const enhancedStack = `${stack || ''}\nLocation: ${window.location.href}`;
+
       await fetch('/api/client-logs', {
          method: 'POST',
          headers: headers,
          body: JSON.stringify({
             level,
             message,
-            stack,
+            stack: enhancedStack,
             user_agent: navigator.userAgent
          })
       });


### PR DESCRIPTION
This PR improves client-side error logging to address the issue of vague "Script error." logs which typically lack stack traces.

Changes:
1.  **Manual Stack Construction:** In `window.onerror`, if the `error` object is missing or lacks a stack trace (common with cross-origin script errors), a stack string is manually constructed using the `url`, `line`, and `col` arguments.
2.  **Context Enrichment:** The `logToBackend` function now appends the current page URL (`Location: ...`) to the stack trace. This provides crucial context about where the user was in the application when the error occurred.

These changes allow for better diagnosis of client-side issues by providing actionable location information even when the browser security model suppresses detailed error objects.

---
*PR created automatically by Jules for task [15694100674716826134](https://jules.google.com/task/15694100674716826134) started by @Bladestar2105*