### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix SSDP public exposure vulnerability

### DIFF
--- a/src/services/ssdpService.js
+++ b/src/services/ssdpService.js
@@ -2,6 +2,7 @@ import dgram from 'dgram';
 import os from 'os';
 import db from '../database/db.js';
 import { PORT } from '../config/constants.js';
+import { isUnsafeIP } from '../utils/helpers.js';
 
 const SSDP_ADDRESS = '239.255.255.250';
 const SSDP_PORT = 1900;
@@ -130,6 +131,13 @@ export function startSSDP() {
         });
 
         socket.on('message', (msg, rinfo) => {
+            // 🛡️ Security: Only respond to local/private IPs (SSRF protection reused)
+            // isUnsafeIP returns true for private IPs (10.*, 192.168.*, 127.*, etc.)
+            // We want to allow these and block public IPs.
+            if (!isUnsafeIP(rinfo.address)) {
+                return;
+            }
+
             const message = msg.toString();
             const headers = {};
 

--- a/tests/security/ssdp_exposure.test.js
+++ b/tests/security/ssdp_exposure.test.js
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { startSSDP } from '../../src/services/ssdpService.js';
+import dgram from 'dgram';
+import db from '../../src/database/db.js';
+
+// Mock dependencies
+vi.mock('dgram');
+vi.mock('../../src/database/db.js');
+vi.mock('os', () => ({
+    default: {
+        networkInterfaces: () => ({
+            'eth0': [{ family: 'IPv4', internal: false, address: '192.168.1.5' }]
+        })
+    }
+}));
+
+// We need to mock the helpers to control isUnsafeIP behavior if we were using it,
+// but currently the code doesn't use it, so it's not strictly necessary to mock it
+// for the "Fail" state, but we will need it for the "Pass" state.
+// To avoid module hoisting issues, we mock it globally.
+vi.mock('../../src/utils/helpers.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    isUnsafeIP: vi.fn((ip) => {
+        // Simple mock: 192.168.* and 10.* are unsafe (private)
+        if (ip.startsWith('192.168.') || ip.startsWith('10.') || ip === '127.0.0.1') return true;
+        return false;
+    })
+  };
+});
+
+describe('SSDP Security', () => {
+    let socketMock;
+    let messageHandler;
+
+    beforeEach(() => {
+        socketMock = {
+            on: vi.fn((event, handler) => {
+                if (event === 'message') messageHandler = handler;
+            }),
+            bind: vi.fn(),
+            send: vi.fn(),
+            address: vi.fn(() => ({ address: '0.0.0.0', port: 1900 })),
+            setMulticastTTL: vi.fn(),
+            addMembership: vi.fn(),
+            close: vi.fn()
+        };
+        dgram.createSocket.mockReturnValue(socketMock);
+
+        // Mock DB users
+        db.prepare.mockReturnValue({
+            all: vi.fn().mockReturnValue([
+                { id: 1, username: 'user1', hdhr_token: 'token123' }
+            ])
+        });
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should respond to M-SEARCH from private IP', () => {
+        startSSDP();
+
+        // Ensure message handler was registered
+        expect(messageHandler).toBeDefined();
+
+        const msg = Buffer.from('M-SEARCH * HTTP/1.1\r\nMAN: "ssdp:discover"\r\nST: ssdp:all\r\n\r\n');
+        const rinfo = { address: '192.168.1.100', port: 12345 };
+
+        messageHandler(msg, rinfo);
+
+        expect(socketMock.send).toHaveBeenCalled();
+    });
+
+    it('should NOT respond to M-SEARCH from public IP', () => {
+        startSSDP();
+
+        expect(messageHandler).toBeDefined();
+
+        const msg = Buffer.from('M-SEARCH * HTTP/1.1\r\nMAN: "ssdp:discover"\r\nST: ssdp:all\r\n\r\n');
+        const rinfo = { address: '8.8.8.8', port: 12345 };
+
+        messageHandler(msg, rinfo);
+
+        // This expectation is for the FIXED version.
+        // Currently, it WILL call send, so we expect this test to FAIL initially.
+        expect(socketMock.send).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
This PR addresses a security vulnerability where the SSDP (Simple Service Discovery Protocol) service was responding to discovery requests (M-SEARCH) from any IP address, including public IPs. This behavior could potentially be exploited for UDP amplification attacks or leak internal network information.

**Changes:**
- Updated `src/services/ssdpService.js`:
    - Imported `isUnsafeIP` from `src/utils/helpers.js`.
    - Added a check in the socket message handler: `if (!isUnsafeIP(rinfo.address)) { return; }`. This ensures that only requests from private/local IP ranges (as defined in `isUnsafeIP`) are processed.
- Added `tests/security/ssdp_exposure.test.js`:
    - A new test suite that mocks `dgram` and simulates M-SEARCH requests from both private (192.168.1.100) and public (8.8.8.8) IPs.
    - Verifies that responses are sent to private IPs and suppressed for public IPs.

**Verification:**
- Ran `npm test tests/security/ssdp_exposure.test.js`.
- Confirmed that the test fails without the fix (response sent to 8.8.8.8) and passes with the fix (no response sent).

**Risk:**
- Low. This change restricts SSDP functionality to its intended scope (local network discovery). Legitimate local clients (like Plex/Emby on the same LAN) should continue to work normally.

---
*PR created automatically by Jules for task [6453927413838546481](https://jules.google.com/task/6453927413838546481) started by @Bladestar2105*