### PR TITLE
⚡ Make importData controller non-blocking

### DIFF
--- a/benchmarks/import_blocking_bench.js
+++ b/benchmarks/import_blocking_bench.js
@@ -1,0 +1,65 @@
+import fs from 'fs';
+import { performance } from 'perf_hooks';
+
+const FILE_SIZE = 50 * 1024 * 1024; // 50MB to ensure it takes some time
+const TEMP_FILE = 'temp_bench_file.bin';
+
+function createLargeFile() {
+    const buffer = Buffer.alloc(FILE_SIZE, 'a');
+    fs.writeFileSync(TEMP_FILE, buffer);
+}
+
+function cleanup() {
+    if (fs.existsSync(TEMP_FILE)) fs.unlinkSync(TEMP_FILE);
+}
+
+async function run() {
+    createLargeFile();
+
+    console.log(`File size: ${FILE_SIZE / 1024 / 1024} MB`);
+
+    // --- Sync Benchmark ---
+    console.log('\n--- Sync Read ---');
+    let start = performance.now();
+
+    // Schedule a timer. If code blocks, this won't run until after.
+    let timerRunSync = false;
+    const tSync = setTimeout(() => {
+        timerRunSync = true;
+        console.log('  [Timer] Timer fired during Sync operation (Unexpected!)');
+    }, 1);
+
+    const dataSync = fs.readFileSync(TEMP_FILE);
+
+    // Clear timer if it hasn't run
+    clearTimeout(tSync);
+
+    let end = performance.now();
+    console.log(`Sync Read Time: ${(end - start).toFixed(2)}ms`);
+    console.log(`Did timer fire during operation? ${timerRunSync ? 'YES' : 'NO (BLOCKED)'}`);
+
+
+    // --- Async Benchmark ---
+    // Wait a bit
+    await new Promise(r => setTimeout(r, 100));
+
+    console.log('\n--- Async Read ---');
+    start = performance.now();
+
+    let timerRunAsync = false;
+    // We expect this timer to fire WHILE the file is being read
+    const tAsync = setTimeout(() => {
+        timerRunAsync = true;
+        console.log('  [Timer] Timer fired during Async operation');
+    }, 1);
+
+    const dataAsync = await fs.promises.readFile(TEMP_FILE);
+
+    end = performance.now();
+    console.log(`Async Read Time: ${(end - start).toFixed(2)}ms`);
+    console.log(`Did timer fire during operation? ${timerRunAsync ? 'YES (NON-BLOCKING)' : 'NO'}`);
+
+    cleanup();
+}
+
+run().catch(console.error);

--- a/src/controllers/systemController.js
+++ b/src/controllers/systemController.js
@@ -282,7 +282,7 @@ export const importData = async (req, res) => {
     }
 
     tempPath = req.file.path;
-    const encryptedData = fs.readFileSync(tempPath);
+    const encryptedData = await fs.promises.readFile(tempPath);
 
     let compressed;
     try {
@@ -506,8 +506,8 @@ export const importData = async (req, res) => {
     console.error('Import error:', e);
     res.status(500).json({error: e.message});
   } finally {
-    if (tempPath && fs.existsSync(tempPath)) {
-      try { fs.unlinkSync(tempPath); } catch(e) {}
+    if (tempPath) {
+      try { await fs.promises.unlink(tempPath); } catch(e) {}
     }
   }
 };

--- a/tests/system/provider_data_integrity.test.js
+++ b/tests/system/provider_data_integrity.test.js
@@ -193,8 +193,10 @@ describe('System - Provider Data Integrity', () => {
 
         // Mock fs.readFileSync to return encrypted buffer
         vi.spyOn(fs, 'readFileSync').mockReturnValue(encrypted);
+        vi.spyOn(fs.promises, 'readFile').mockResolvedValue(encrypted);
         vi.spyOn(fs, 'existsSync').mockReturnValue(true); // for unlink
         vi.spyOn(fs, 'unlinkSync').mockImplementation(() => {});
+        vi.spyOn(fs.promises, 'unlink').mockResolvedValue();
 
         // Run Import
         await systemController.importData(req, res);


### PR DESCRIPTION
💡 **What:**
Replaced the synchronous file read (`fs.readFileSync`) and file deletion (`fs.unlinkSync`) operations in the `importData` controller with their asynchronous counterparts (`fs.promises.readFile` and `fs.promises.unlink`).

🎯 **Why:**
Synchronous I/O operations block the Node.js event loop, preventing the server from handling other requests while the file is being read or deleted. For large import files, this can cause noticeable latency for other users. Using asynchronous methods allows the event loop to continue processing other tasks while the I/O operation completes.

📊 **Measured Improvement:**
A benchmark script `benchmarks/import_blocking_bench.js` was created to simulate reading a 50MB file.
- **Sync Read:** Blocked the event loop (timers did not fire during the operation).
- **Async Read:** Did **not** block the event loop (timers fired successfully during the operation).

This confirms that the refactor effectively unblocks the event loop during file imports.

---
*PR created automatically by Jules for task [10721254205703289435](https://jules.google.com/task/10721254205703289435) started by @Bladestar2105*