### PR TITLE
⚡ Bolt: Optimize stream counting and timestamp stringifications

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,6 @@
 ## 2026-02-21 - [Symmetric Sparse Intersection & Popcount Proxy]
 **Learning:** When calculating Dice coefficient between two Bit Signatures (Bloom filters), the intersection loop can be optimized by iterating over the *sparser* of the two bitsets (min(popcountA, popcountB)). This provides a massive speedup (up to 9x) for "Dense Search vs Sparse Candidate" scenarios. Also, using signature `popcount` as a proxy for `bigramCount` eliminates the need to allocate intermediate `Set` objects during fuzzy matching, yielding ~20% speedup for common queries.
 **Action:** Always pre-compute sparse indices for bitsets on creation and pick the shortest list for intersection loops. Avoid allocating Sets for length/count proxies if a bitset signature is already available.
+## 2026-02-27 - Optimize JSON.stringify and toString stringifications
+**Learning:** Using `JSON.stringify` in hot loops like mapping stream instances or using `now.toString()` across large sets is slower and increases memory footprint compared to template strings and variable extraction.
+**Action:** Replaced `JSON.stringify` with template strings in `streamManager.js` and precomputed `now.toString()` in `xtreamController.js`.

--- a/src/controllers/xtreamController.js
+++ b/src/controllers/xtreamController.js
@@ -108,6 +108,7 @@ export const playerApi = async (req, res) => {
         ORDER BY uc.sort_order
       `).all(user.id);
 
+      const nowStr = now.toString();
       const result = rows.map((ch, i) => {
         let iconUrl = ch.logo || '';
         return {
@@ -117,7 +118,7 @@ export const playerApi = async (req, res) => {
           stream_id: Number(ch.user_channel_id),
           stream_icon: iconUrl,
           epg_channel_id: ch.manual_epg_id || ch.epg_channel_id || '',
-          added: now.toString(),
+          added: nowStr,
           is_adult: ch.category_is_adult || 0,
           category_id: String(ch.user_category_id),
           category_ids: [Number(ch.user_category_id)],
@@ -140,6 +141,7 @@ export const playerApi = async (req, res) => {
         ORDER BY uc.sort_order
       `).all(user.id);
 
+      const nowStr = now.toString();
       const result = rows.map((ch, i) => {
         return {
           num: i + 1,
@@ -149,7 +151,7 @@ export const playerApi = async (req, res) => {
           stream_icon: ch.logo || '',
           rating: ch.rating || '',
           rating_5based: ch.rating_5based || 0,
-          added: ch.added || now.toString(),
+          added: ch.added || nowStr,
           category_id: String(ch.user_category_id),
           container_extension: ch.mime_type || 'mp4',
           custom_sid: null,
@@ -169,6 +171,7 @@ export const playerApi = async (req, res) => {
         ORDER BY uc.sort_order
       `).all(user.id);
 
+      const nowStr = now.toString();
       const result = rows.map((ch, i) => {
         let backdrop_path = [];
         if (ch.metadata) {
@@ -188,7 +191,7 @@ export const playerApi = async (req, res) => {
           director: ch.director || '',
           genre: ch.genre || '',
           releaseDate: ch.releaseDate || '',
-          last_modified: ch.added || now.toString(),
+          last_modified: ch.added || nowStr,
           rating: ch.rating || '',
           rating_5based: ch.rating_5based || 0,
           backdrop_path: backdrop_path,

--- a/src/services/streamManager.js
+++ b/src/services/streamManager.js
@@ -160,8 +160,9 @@ class StreamManager {
         // Smart Counting: Count unique sessions (Content + IP + Provider)
         // This allows a single user to open multiple connections (sockets) for the same content
         // on the same IP without consuming multiple "slots".
+        // Optimization: Use template strings instead of JSON.stringify for significantly faster Set operations
         const uniqueSessions = new Set(userStreams.map(s =>
-          JSON.stringify({ c: s.channel_name, i: s.ip, p: s.provider_id })
+          `${s.channel_name}|${s.ip}|${s.provider_id}`
         ));
 
         return uniqueSessions.size;
@@ -189,8 +190,9 @@ class StreamManager {
         const all = await this.getAll();
         const providerStreams = all.filter(s => s.provider_id === providerId);
         // Smart Counting: Count unique sessions (Channel + IP + User)
+        // Optimization: Use template strings instead of JSON.stringify for significantly faster Set operations
         const uniqueSessions = new Set(providerStreams.map(s =>
-          JSON.stringify({ c: s.channel_name, i: s.ip, u: s.user_id })
+          `${s.channel_name}|${s.ip}|${s.user_id}`
         ));
         return uniqueSessions.size;
       } catch (e) {


### PR DESCRIPTION
💡 **What**:
- Replaced slow `JSON.stringify` with fast template literals inside `getUserConnectionCount` and `getProviderConnectionCount` sets in `src/services/streamManager.js`.
- Extracted redundant `now.toString()` calls out of `rows.map()` loops in `src/controllers/xtreamController.js` to reduce memory allocations and GC pressure.

🎯 **Why**:
- `JSON.stringify` is very slow to be used in hot paths like counting streams, which happens on every segment request.
- `now.toString()` was being evaluated repeatedly for potentially 10,000s of channels, causing unnecessary memory allocation and GC pressure.

📊 **Impact**:
- Drastically reduces CPU cycles spent parsing strings for uniqueness checks and memory footprint when generating API responses for massive numbers of channels.

🔬 **Measurement**:
- Run `pnpm test` and ensure all related tests pass. Observe lower CPU and memory overhead during large streaming operations or full library syncs.

---
*PR created automatically by Jules for task [16942779379247672046](https://jules.google.com/task/16942779379247672046) started by @Bladestar2105*