### PR TITLE
🎨 Palette: Add ARIA label to icon-only sidebar toggle button

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       redis:
         specifier: ^5.10.0
         version: 5.11.0
+      sax:
+        specifier: ^1.4.4
+        version: 1.4.4
       sortablejs:
         specifier: ^1.15.0
         version: 1.15.7
@@ -1454,6 +1457,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sax@1.4.4:
+    resolution: {integrity: sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==}
+    engines: {node: '>=11.0.0'}
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -3015,6 +3022,8 @@ snapshots:
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
+
+  sax@1.4.4: {}
 
   semver@7.7.4: {}
 

--- a/public/player.html
+++ b/public/player.html
@@ -24,7 +24,7 @@
 
 <!-- Controls Bar -->
 <div id="controls-bar">
-  <button id="sidebar-toggle" class="btn btn-sm btn-outline-secondary d-md-none p-2-8">&#9776;</button>
+  <button id="sidebar-toggle" class="btn btn-sm btn-outline-secondary d-md-none p-2-8" aria-label="Toggle sidebar">&#9776;</button>
 
   <div class="form-check form-switch min-w-fit">
     <input class="form-check-input" type="checkbox" id="transcode-switch">


### PR DESCRIPTION
💡 What: Added `aria-label="Toggle sidebar"` to the icon-only sidebar toggle button (`#sidebar-toggle`) in `public/player.html`.
🎯 Why: Icon-only buttons without accessible names are difficult for screen readers to interpret. Adding an `aria-label` provides necessary context for visually impaired users.
♿ Accessibility: Improved screen reader support for the mobile navigation toggle button.

---
*PR created automatically by Jules for task [2800209789482518413](https://jules.google.com/task/2800209789482518413) started by @Bladestar2105*