### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing input validation on auth forms

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       redis:
         specifier: ^5.10.0
         version: 5.11.0
+      sax:
+        specifier: ^1.4.4
+        version: 1.4.4
       sortablejs:
         specifier: ^1.15.0
         version: 1.15.7
@@ -1454,6 +1457,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sax@1.4.4:
+    resolution: {integrity: sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==}
+    engines: {node: '>=11.0.0'}
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -3015,6 +3022,8 @@ snapshots:
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
+
+  sax@1.4.4: {}
 
   semver@7.7.4: {}
 

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -22,6 +22,14 @@ export const login = async (req, res) => {
       return res.status(400).json({error: 'missing_credentials'});
     }
 
+    if (typeof username !== 'string' || typeof password !== 'string') {
+        return res.status(400).json({error: 'invalid_input_type'});
+    }
+
+    if (otp_code !== undefined && typeof otp_code !== 'string' && typeof otp_code !== 'number') {
+        return res.status(400).json({error: 'invalid_input_type'});
+    }
+
     // 1. Check admin_users
     let user = db.prepare('SELECT *, 1 as is_admin FROM admin_users WHERE username = ? AND is_active = 1').get(username);
     let table = 'admin_users';
@@ -193,6 +201,10 @@ export const changePassword = async (req, res) => {
     // Validation
     if (!oldPassword || !newPassword || !confirmPassword) {
       return res.status(400).json({error: 'missing_fields'});
+    }
+
+    if (typeof oldPassword !== 'string' || typeof newPassword !== 'string' || typeof confirmPassword !== 'string') {
+        return res.status(400).json({error: 'invalid_input_type'});
     }
 
     if (newPassword !== confirmPassword) {

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -36,6 +36,13 @@ export const createUser = async (req, res) => {
       });
     }
 
+    if (typeof username !== 'string' || typeof password !== 'string') {
+        return res.status(400).json({
+            error: 'invalid_input_type',
+            message: 'Username and password must be strings'
+        });
+    }
+
     const u = username.trim();
     const p = password.trim();
 
@@ -297,6 +304,9 @@ export const updateUser = async (req, res) => {
     const params = [];
 
     if (username) {
+        if (typeof username !== 'string') {
+             return res.status(400).json({ error: 'invalid_input_type' });
+        }
         const u = username.trim();
         if (u.length < 3 || u.length > 50) {
             return res.status(400).json({ error: 'invalid_username_length' });
@@ -314,6 +324,9 @@ export const updateUser = async (req, res) => {
     }
 
     if (password) {
+        if (typeof password !== 'string') {
+             return res.status(400).json({ error: 'invalid_input_type' });
+        }
         const p = password.trim();
         if (p.length < 8) {
             return res.status(400).json({ error: 'password_too_short' });


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Missing input type validation on authentication and user management endpoints. 
🎯 **Impact:** Sending non-string payloads (e.g., objects or arrays) to properties like `username` or `password` could trigger unhandled `TypeError` exceptions when string methods like `.trim()`, `.length`, or `.startsWith()` are invoked, potentially leading to application instability or error leakage (Denial of Service).
🔧 **Fix:** Added explicit `typeof !== 'string'` checks in `authController.login`, `authController.changePassword`, `userController.createUser`, and `userController.updateUser`. Invalid types now return a structured `400 Bad Request` with an `invalid_input_type` error.
✅ **Verification:** Verified via `pnpm test` (specifically unit tests mocking auth endpoints) and a manual `curl` request passing an object as the password, which now correctly receives a 400 response.

---
*PR created automatically by Jules for task [7094614186926190590](https://jules.google.com/task/7094614186926190590) started by @Bladestar2105*