### PR TITLE
🎨 Palette: Add clear button to player search input

### DIFF
--- a/public/player.html
+++ b/public/player.html
@@ -40,7 +40,10 @@
     <option value="" data-i18n="allCategories">All Categories</option>
   </select>
 
-  <input type="text" id="search-input" class="form-control form-control-sm bg-dark text-light border-secondary w-140px" placeholder="Search..." data-i18n-placeholder="searchPlaceholder">
+  <div class="input-group input-group-sm w-140px">
+    <input type="text" id="search-input" class="form-control bg-dark text-light border-secondary" placeholder="Search..." data-i18n-placeholder="searchPlaceholder">
+    <button class="btn btn-outline-secondary d-none border-secondary text-light" type="button" id="search-input-clear" aria-label="Clear search">✕</button>
+  </div>
 
   <div class="ms-auto d-flex align-items-center">
     <google-cast-launcher id="cast-button" class="cast-button-style"></google-cast-launcher>

--- a/public/player.js
+++ b/public/player.js
@@ -38,6 +38,7 @@
   // ─── DOM Elements ───
   const catSelect = document.getElementById('category-select');
   const searchInput = document.getElementById('search-input');
+  const searchInputClear = document.getElementById('search-input-clear');
   const sidebarEl = document.getElementById('channel-sidebar');
   const sidebarOverlay = document.getElementById('sidebar-overlay');
   const epgGridEl = document.getElementById('epg-grid');
@@ -953,6 +954,7 @@
       currentType = e.target.dataset.type;
       catSelect.value = '';
       searchInput.value = '';
+      updateClearBtnVisibility();
       updateCategories();
       renderView();
     });
@@ -965,7 +967,27 @@
   });
 
   // Search
+  function updateClearBtnVisibility() {
+    if (searchInputClear) {
+      if (searchInput.value) {
+        searchInputClear.classList.remove('d-none');
+      } else {
+        searchInputClear.classList.add('d-none');
+      }
+    }
+  }
+
+  if (searchInputClear) {
+    searchInputClear.addEventListener('click', function() {
+      searchInput.value = '';
+      updateClearBtnVisibility();
+      searchInput.focus();
+      searchInput.dispatchEvent(new Event('input'));
+    });
+  }
+
   searchInput.addEventListener('input', debounce(function() {
+    updateClearBtnVisibility();
     if (currentType === 'live') renderTimeline();
     else renderList();
   }, 400));


### PR DESCRIPTION
💡 **What:** Added a clear button ('✕') to the search input field in the Web Player interface. The button is hidden when the input is empty and appears dynamically as the user types. Clicking it clears the input and refocuses the field.
🎯 **Why:** To improve micro-UX and consistency. Other search inputs across the main app (`index.html`) already use this pattern, but the player search was missing it. This saves users from having to manually backspace or select-all-delete when clearing their search filter.
📸 **Before/After:** (See attached Playwright screenshots in PR or local verification artifacts showing the button appearing and clearing the input).
♿ **Accessibility:** The clear button is implemented using a native `<button>` element with an `aria-label="Clear search"` to ensure screen reader compatibility, and clicking it returns focus to the search input so keyboard users don't lose their place.

---
*PR created automatically by Jules for task [8734532518608632463](https://jules.google.com/task/8734532518608632463) started by @Bladestar2105*