### PR TITLE
🎨 Palette: [UX improvement] Add missing aria-labels to buttons

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -180,7 +180,7 @@
                        <button class="nav-link" id="tab-xtream-btn" data-bs-toggle="tab" data-bs-target="#tab-xtream" type="button" data-i18n="xtreamCodes">Xtream Codes</button>
                     </li>
                     <li class="nav-item">
-                       <button class="nav-link" id="tab-hdhr-btn" data-bs-toggle="tab" data-bs-target="#tab-hdhr" type="button">HDHomeRun</button>
+                       <button class="nav-link" id="tab-hdhr-btn" data-bs-toggle="tab" data-bs-target="#tab-hdhr" type="button" aria-label="HDHomeRun">HDHomeRun</button>
                     </li>
                  </ul>
 
@@ -698,7 +698,7 @@
       <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title" data-i18n="importCategoriesTitle">Import Provider Categories</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
           <div class="mb-3 d-flex gap-2 justify-content-center">
@@ -749,7 +749,7 @@
       <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title" data-i18n="syncConfig">Sync Configuration</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <form id="sync-config-form">
           <div class="modal-body">
@@ -809,7 +809,7 @@
       <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title" data-i18n="syncLogs">Sync Logs</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
           <div class="table-responsive">
@@ -843,7 +843,7 @@
       <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title" data-i18n="addEpgSourceTitle">Add EPG Source</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <form id="add-epg-source-form">
           <div class="modal-body">
@@ -889,7 +889,7 @@
       <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title" data-i18n="editEpgSourceTitle">Edit EPG Source</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <form id="edit-epg-source-form">
           <div class="modal-body">
@@ -936,7 +936,7 @@
       <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title" data-i18n="browseEpgSourcesTitle">Browse Available EPG Sources</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
           <div class="input-group input-group-sm mb-3">
@@ -995,7 +995,7 @@
       <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title" data-i18n="setup_2fa">Two-Factor Authentication</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
           <div id="otp-setup-step-1">
@@ -1025,7 +1025,7 @@
       <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title" data-i18n="editUser">Edit User</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <form id="edit-user-form">
           <div class="modal-body">
@@ -1070,7 +1070,7 @@
       <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title" data-i18n="change_password">Change Password</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
           <form id="change-password-form" >
@@ -1111,7 +1111,7 @@
       <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title" data-i18n="addProvider">Add Provider</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <form id="provider-form">
           <div class="modal-body">
@@ -1197,7 +1197,7 @@
       <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title" data-i18n="createShareLink">Create Share Link</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
           <form id="share-form">
@@ -1252,7 +1252,7 @@
       <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title" data-i18n="activeShares">Active Shares</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
            <div class="table-responsive">
@@ -1285,7 +1285,7 @@
       <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title" data-i18n="selectEpgChannel">Select EPG Channel</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
           <div class="input-group input-group-sm mb-3">


### PR DESCRIPTION
💡 What: Added missing `aria-label` attributes to the modal close buttons and the HDHomeRun tab button.
🎯 Why: To improve screen reader accessibility by providing context to icon-only buttons (`.btn-close`) and clarifying the purpose of the tab button for assistive technologies.
📸 Before/After: Visual appearance remains unchanged.
♿ Accessibility: Significantly improves keyboard navigation and screen reader experience for users interacting with modals and tabs.

---
*PR created automatically by Jules for task [4249289533731526940](https://jules.google.com/task/4249289533731526940) started by @Bladestar2105*