### PR TITLE
Fix "Clear EPG" button by replacing undefined getAuthHeaders with fetchJSON

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2451,17 +2451,10 @@ document.addEventListener('DOMContentLoaded', () => {
       clearEpgBtn.textContent = '...';
       clearEpgBtn.disabled = true;
       try {
-        const res = await fetch('/api/epg-sources/clear', {
-          method: 'POST',
-          headers: getAuthHeaders()
-        });
-        if (res.ok) {
-          showToast(i18n[currentLang].success || 'EPG cleared', 'success');
-        } else {
-          showToast('Clear failed', 'danger');
-        }
+        await fetchJSON('/api/epg-sources/clear', { method: 'POST' });
+        showToast(i18n[currentLang].success || 'EPG cleared', 'success');
       } catch (e) {
-        showToast('Error', 'danger');
+        showToast(e.message || 'Error', 'danger');
       } finally {
         clearEpgBtn.textContent = originalText;
         clearEpgBtn.disabled = false;


### PR DESCRIPTION
The "Clear EPG" button in the WebUI was broken because its click handler attempted to use a function `getAuthHeaders` that was not defined in `public/app.js` (or anywhere else in the file). This caused a `ReferenceError`.

The fix was to swap out the native `fetch` call with the existing `fetchJSON` utility function available globally in `public/app.js`, which automatically handles the `Authorization` headers correctly using `getToken()` and `isTokenExpired()`.

This aligns the `clearEpgBtn` click handler with the rest of the application's API interactions.

---
*PR created automatically by Jules for task [15871133490958152976](https://jules.google.com/task/15871133490958152976) started by @Bladestar2105*