### PR TITLE
Fix local LAN player authentication (401 Unauthorized)

### DIFF
--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -293,7 +293,7 @@ export const createPlayerToken = (req, res) => {
         sameSite: 'strict',
         path: '/',
         maxAge: 21600000, // 6 hours
-        secure: process.env.NODE_ENV === 'production' || req.secure
+        secure: req.secure
     });
 
     // Cleanup old tokens


### PR DESCRIPTION
Fixes the 401 Unauthorized issue when opening the web player over a local unencrypted LAN HTTP connection. The cookie's `secure` flag now relies dynamically on `req.secure` rather than forcing it based on `NODE_ENV=production`. This maintains HTTPS security for proxy-fronted setups while allowing LAN HTTP to function properly.

---
*PR created automatically by Jules for task [13308399559056846151](https://jules.google.com/task/13308399559056846151) started by @Bladestar2105*