### PR TITLE
fix: duplicate epg suggestions id in modal

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -941,13 +941,7 @@
         </div>
 
         <div class="modal-body">
-          <div id="epg-suggest-container" class="mb-4 d-none">
-             <h6 class="border-bottom pb-2 mb-3" data-i18n="suggestions">Suggestions</h6>
-             <ul id="epg-suggest-list" class="list-group mb-3"></ul>
-          </div>
-          <h6 class="border-bottom pb-2 mb-3" data-i18n="allChannels">All Channels</h6>
           <div class="input-group input-group-sm mb-3">
-
              <input type="text" id="epg-browse-search" class="form-control" data-i18n-placeholder="searchEpgSources" placeholder="🔍 Search sources...">
              <button class="btn btn-outline-secondary d-none" type="button" id="epg-browse-search-clear" aria-label="Clear search">✕</button>
           </div>


### PR DESCRIPTION
Fixes an issue where EPG mapping suggestions failed to render because the container and list IDs (`epg-suggest-container` and `epg-suggest-list`) were unintentionally duplicated in `public/index.html`. They were present in both the `browse-epg-sources-modal` and the `epg-select-modal`. 

Because `document.getElementById` returns the first matching element it finds in the DOM, the application was injecting the suggestions into the hidden `browse-epg-sources-modal` instead of the visible one. Removing the duplicate IDs from the browse modal resolves this issue.

---
*PR created automatically by Jules for task [11255656535143944230](https://jules.google.com/task/11255656535143944230) started by @Bladestar2105*