### PR TITLE
feat: add epg mapping for magenta sport to myteamtv

### DIFF
--- a/src/services/channelMatcher.js
+++ b/src/services/channelMatcher.js
@@ -223,6 +223,7 @@ export class ChannelMatcher {
     return name
       .toLowerCase()
       .replace(/\s+hd|uhd|4k|fhd|hevc|h\.?264|h\.?265/gi, '') // Qualität
+      .replace(/\bmagenta\s*sport\b/gi, 'myteamtv') // Magenta Sport -> MyTeamTV mapping
       .replace(/\s+plus|\s*\+/gi, ' plus') // "+" normalisieren
       .replace(/[^\w\s]/g, '') // Sonderzeichen (keeps numbers)
       .replace(/\s+/g, ' ') // Multiple Spaces

--- a/tests/channel_matcher.test.js
+++ b/tests/channel_matcher.test.js
@@ -58,6 +58,14 @@ describe('ChannelMatcher', () => {
         }
     });
 
+    it('maps magenta sport to myteamtv', () => {
+        const parsed1 = matcher.parseChannelName('Magenta Sport 1');
+        expect(parsed1.baseName).toContain('myteamtv');
+
+        const parsed2 = matcher.parseChannelName('Magentasport 2 HD');
+        expect(parsed2.baseName).toContain('myteamtv');
+    });
+
     it('prioritizes language match', () => {
         const parsed = matcher.parseChannelName('US: CNN');
         expect(parsed.language).toBe('en');


### PR DESCRIPTION
This change updates the `ChannelMatcher`'s `normalizeBaseName` function in `src/services/channelMatcher.js` to map occurrences of "magenta sport" or "magentasport" to "myteamtv". This improves the fuzzy matcher's ability to map these channels to their correct "myteam" EPG counterparts. Tests have been added in `tests/channel_matcher.test.js` to verify the mapping works correctly.

---
*PR created automatically by Jules for task [760138095962337115](https://jules.google.com/task/760138095962337115) started by @Bladestar2105*