### PR TITLE
Enhance EPG mapper for Magenta Sport and Myteam Sport

### DIFF
--- a/src/services/channelMatcher.js
+++ b/src/services/channelMatcher.js
@@ -223,7 +223,7 @@ export class ChannelMatcher {
     return name
       .toLowerCase()
       .replace(/\s+hd|uhd|4k|fhd|hevc|h\.?264|h\.?265/gi, '') // Qualität
-      .replace(/\bmagenta\s*sport\b/gi, 'myteamtv') // Magenta Sport -> MyTeamTV mapping
+      .replace(/\b(?:magenta|myteam|myteamtv)\s*sport\b/gi, 'myteamtv') // Magenta Sport / MyTeam Sport -> MyTeamTV mapping
       .replace(/\s+plus|\s*\+/gi, ' plus') // "+" normalisieren
       .replace(/[^\w\s]/g, '') // Sonderzeichen (keeps numbers)
       .replace(/\s+/g, ' ') // Multiple Spaces


### PR DESCRIPTION
Enhance the EPG Mapper to correctly map "Myteam Sport (number)" and "Magenta Sport (number)" to EPG entries that use "myteamtv" with a number before or after.
This replaces the old rule mapping `magenta sport` -> `myteamtv` with a generalized regex that covers `magenta`, `myteam`, and `myteamtv`.

---
*PR created automatically by Jules for task [1998471567738585340](https://jules.google.com/task/1998471567738585340) started by @Bladestar2105*