### PR TITLE
fix(matcher): improve channel matching for myTeamTV and RAW channels

### DIFF
--- a/src/services/channelMatcher.js
+++ b/src/services/channelMatcher.js
@@ -224,6 +224,8 @@ export class ChannelMatcher {
       .toLowerCase()
       .replace(/\s+hd|uhd|4k|fhd|hevc|h\.?264|h\.?265/gi, '') // Qualität
       .replace(/\b(?:magenta|myteam|myteamtv)\s*sport\b/gi, 'myteamtv') // Magenta Sport / MyTeam Sport -> MyTeamTV mapping
+      .replace(/\bsport\s*(\d*)\s*(?:-|\|)?\s*myteamtv\b/gi, 'myteamtv $1') // "Sport 1 - myTeamTV" -> "myteamtv 1"
+      .replace(/\braw\b/gi, '') // "RAW" entfernen
       .replace(/\s+plus|\s*\+/gi, ' plus') // "+" normalisieren
       .replace(/[^\w\s]/g, '') // Sonderzeichen (keeps numbers)
       .replace(/\s+/g, ' ') // Multiple Spaces

--- a/tests/channel_matcher.test.js
+++ b/tests/channel_matcher.test.js
@@ -127,3 +127,28 @@ describe('ChannelMatcher', () => {
         expect(best.score).toBeGreaterThan(0);
     });
 });
+
+describe('myteamtv raw sports channels mapping', () => {
+  it('correctly maps "MAGENTA SPORT 1 FHD" to "Sport 1 - myTeamTV" ignoring "RAW"', () => {
+    const epgChannels = [
+      { id: '1', name: 'DE - Sport 1 - myTeamTV' },
+      { id: '2', name: 'MG | SPORT 1 - MYTEAMTV RAW' },
+      { id: '3', name: 'DE - Sport 10 - myTeamTV' },
+      { id: '4', name: 'MG | SPORT 10 - MYTEAMTV RAW' }
+    ];
+
+    const matcher = new ChannelMatcher(epgChannels);
+
+    const match1 = matcher.match('DE | MAGENTA SPORT 1 FHD');
+    expect(match1.epgChannel).not.toBeNull();
+    expect(match1.epgChannel.id).toBe('1');
+
+    const match2 = matcher.match('MG | MAGENTA SPORT 1 FHD');
+    expect(match2.epgChannel).not.toBeNull();
+    expect(match2.epgChannel.id).toBe('2');
+
+    const match3 = matcher.match('DE | MAGENTA SPORT 10 FHD');
+    expect(match3.epgChannel).not.toBeNull();
+    expect(match3.epgChannel.id).toBe('3');
+  });
+});


### PR DESCRIPTION
This fixes an issue where channels labeled as "MG | SPORT X - MYTEAMTV RAW" and similar external EPG strings ("MAGENTA SPORT X FHD") were not properly aligning with the internal EPG channel IDs, leading to unmatched IDs in the UI.

The `ChannelMatcher` was updated to properly strip out the "RAW" tag and to normalize "Sport X - myTeamTV" structure consistently with the rest of the matching logic, so that it reduces to "myteamtv X" instead of leaving formatting artifacts.

---
*PR created automatically by Jules for task [833606892402722654](https://jules.google.com/task/833606892402722654) started by @Bladestar2105*