### PR TITLE
🧪 Add tests for getCookie and improve robustness

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -137,9 +137,13 @@ export function getSetting(db, key, defaultValue) {
 }
 
 export function getCookie(req, name) {
-  const cookieHeader = req.headers.cookie;
-  if (!cookieHeader) return null;
-  const match = cookieHeader.match(new RegExp('(^| )' + name + '=([^;]+)'));
-  if (match) return match[2];
+  if (!req || !req.headers || !req.headers.cookie) return null;
+  const cookies = req.headers.cookie.split(';');
+  for (let i = 0; i < cookies.length; i++) {
+    const cookie = cookies[i].trim();
+    if (cookie.startsWith(name + '=')) {
+      return cookie.substring(name.length + 1);
+    }
+  }
   return null;
 }

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { isAdultCategory, getSetting, clearSettingsCache } from '../src/utils/helpers.js';
+import { isAdultCategory, getSetting, clearSettingsCache, getCookie } from '../src/utils/helpers.js';
 
 describe('isAdultCategory', () => {
   const adultKeywords = [
@@ -137,5 +137,58 @@ describe('getSetting', () => {
     expect(getSetting(mockDb, 'clear_key', 'def')).toBe(value2);
     // Should be called twice in total (once for first call, once for second call)
     expect(mockDb.prepare).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('getCookie', () => {
+  it('should return null if req is null or undefined', () => {
+    expect(getCookie(null, 'test')).toBe(null);
+    expect(getCookie(undefined, 'test')).toBe(null);
+  });
+
+  it('should return null if req.headers is missing', () => {
+    expect(getCookie({}, 'test')).toBe(null);
+  });
+
+  it('should return null if cookie header is missing', () => {
+    const req = { headers: {} };
+    expect(getCookie(req, 'test')).toBe(null);
+  });
+
+  it('should return cookie value when it exists', () => {
+    const req = { headers: { cookie: 'test=value' } };
+    expect(getCookie(req, 'test')).toBe('value');
+  });
+
+  it('should return correct cookie value when multiple cookies exist', () => {
+    const req = { headers: { cookie: 'foo=bar; test=value; baz=qux' } };
+    expect(getCookie(req, 'test')).toBe('value');
+    expect(getCookie(req, 'foo')).toBe('bar');
+    expect(getCookie(req, 'baz')).toBe('qux');
+  });
+
+  it('should handle cookies without spaces after semicolon', () => {
+    const req = { headers: { cookie: 'foo=bar;test=value;baz=qux' } };
+    expect(getCookie(req, 'test')).toBe('value');
+  });
+
+  it('should return null if cookie does not exist', () => {
+    const req = { headers: { cookie: 'foo=bar; baz=qux' } };
+    expect(getCookie(req, 'test')).toBe(null);
+  });
+
+  it('should not match cookie name as substring of another cookie name', () => {
+    const req = { headers: { cookie: 'mytest=value; other=123' } };
+    expect(getCookie(req, 'test')).toBe(null);
+  });
+
+  it('should handle cookie at the end of the string', () => {
+    const req = { headers: { cookie: 'foo=bar; test=value' } };
+    expect(getCookie(req, 'test')).toBe('value');
+  });
+
+  it('should handle cookie at the beginning of the string', () => {
+    const req = { headers: { cookie: 'test=value; foo=bar' } };
+    expect(getCookie(req, 'test')).toBe('value');
   });
 });


### PR DESCRIPTION
This PR addresses the missing test coverage for the `getCookie` utility function in `src/utils/helpers.js`. 

### Changes:
1. **New Tests**: Added a suite of 10 test cases in `tests/helpers.test.js` to verify `getCookie` against various scenarios, including:
   - Valid cookie extraction (happy path).
   - Multiple cookies in different positions.
   - Handling of missing `req`, `req.headers`, or `cookie` header.
   - Handling of varying whitespace in the cookie header (e.g., no space after semicolon).
   - Ensuring no partial name matches (e.g., 'test' vs 'mytest').
2. **Improved Implementation**: Updated `getCookie` in `src/utils/helpers.js` to be more robust by:
   - Adding defensive checks for `req` and `req.headers`.
   - Switching from a Regex-based match to a split/trim loop for more reliable parsing of standard cookie headers.

All tests in `tests/helpers.test.js` pass with the new implementation.

---
*PR created automatically by Jules for task [4568730073571173325](https://jules.google.com/task/4568730073571173325) started by @Bladestar2105*