### PR TITLE
fix: Resolve Vitest errors with better-sqlite3 and missing mocks

### DIFF
--- a/tests/auth_otp.test.js
+++ b/tests/auth_otp.test.js
@@ -1,9 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as authController from '../src/controllers/authController.js';
-import db from '../src/database/db.js';
-import bcrypt from 'bcrypt';
-import { authenticator } from 'otplib';
-
 // Mock dependencies
 vi.mock('../src/database/db.js', () => ({
   default: {
@@ -19,6 +15,10 @@ vi.mock('bcrypt', () => ({
     hash: vi.fn()
   }
 }));
+
+import db from '../src/database/db.js';
+import bcrypt from 'bcrypt';
+import { authenticator } from 'otplib';
 
 vi.mock('../src/utils/crypto.js', () => ({
   decrypt: vi.fn((val) => val), // Simple pass-through for test

--- a/tests/auth_token_cache.test.js
+++ b/tests/auth_token_cache.test.js
@@ -1,7 +1,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { getXtreamUser, tokenCache } from '../src/services/authService.js';
 import db from '../src/database/db.js';
+import { getXtreamUser, tokenCache } from '../src/services/authService.js';
 
 describe('Auth Service Token Caching', () => {
     beforeEach(() => {

--- a/tests/controllers/xtream_channels_json.test.js
+++ b/tests/controllers/xtream_channels_json.test.js
@@ -32,6 +32,7 @@ vi.mock('../../src/utils/crypto.js', () => ({
 
 vi.mock('../../src/utils/helpers.js', () => ({
   getBaseUrl: vi.fn().mockReturnValue('http://localhost'),
+  safeLookup: vi.fn((hostname, options, callback) => callback(null, '127.0.0.1', 4)),
 }));
 
 vi.mock('../../src/config/constants.js', () => ({

--- a/tests/controllers/xtream_playlist.test.js
+++ b/tests/controllers/xtream_playlist.test.js
@@ -32,6 +32,7 @@ vi.mock('../../src/utils/crypto.js', () => ({
 
 vi.mock('../../src/utils/helpers.js', () => ({
   getBaseUrl: vi.fn().mockReturnValue('http://localhost'),
+  safeLookup: vi.fn((hostname, options, callback) => callback(null, '127.0.0.1', 4)),
 }));
 
 vi.mock('../../src/config/constants.js', () => ({

--- a/tests/security/m3u_injection.test.js
+++ b/tests/security/m3u_injection.test.js
@@ -33,6 +33,7 @@ vi.mock('../../src/utils/crypto.js', () => ({
 
 vi.mock('../../src/utils/helpers.js', () => ({
   getBaseUrl: vi.fn().mockReturnValue('http://localhost'),
+  safeLookup: vi.fn((hostname, options, callback) => callback(null, '127.0.0.1', 4)),
 }));
 
 vi.mock('../../src/config/constants.js', () => ({

--- a/tests/shares_edit.test.js
+++ b/tests/shares_edit.test.js
@@ -1,20 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockPrepare, mockRun, mockGet, mockAll } = vi.hoisted(() => {
-    const mockRun = vi.fn();
-    const mockGet = vi.fn();
-    const mockAll = vi.fn();
-    const mockPrepare = vi.fn(() => ({
-        run: mockRun,
-        get: mockGet,
-        all: mockAll
-    }));
-    return { mockPrepare, mockRun, mockGet, mockAll };
-});
+const mockRun = vi.fn();
+const mockGet = vi.fn();
+const mockAll = vi.fn();
+const mockPrepare = vi.fn(() => ({
+    run: mockRun,
+    get: mockGet,
+    all: mockAll
+}));
 
 vi.mock('../src/database/db.js', () => ({
     default: {
-        prepare: mockPrepare
+        prepare: (...args) => mockPrepare(...args)
     }
 }));
 


### PR DESCRIPTION
Fixes multiple Vitest failures related to better-sqlite3 native bindings and improper mock initializations.

---
*PR created automatically by Jules for task [817169723070602257](https://jules.google.com/task/817169723070602257) started by @Bladestar2105*