### PR TITLE
🎨 Palette: Improve User Management list selection UX

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2026-03-01 - [Non-Blocking Notifications]
 **Learning:** Standard browser `alert()` dialogs block the entire UI thread, disrupting user flow for routine success confirmations (e.g., "Settings saved").
 **Action:** Replaced `alert()` calls with `showToast(msg, 'success/danger')` for administrative actions like Sync and EPG updates. This provides visible feedback without interrupting the workflow.
+
+## 2026-03-02 - [Contextual List Selection State]
+**Learning:** Master-detail views (like a user list updating a details panel) can leave users disoriented if the currently selected item in the master list isn't visually highlighted, especially when returning to the tab after interacting with the details. In addition, only making the text clickable reduces the target area.
+**Action:** Always apply an `.active` state to the selected `list-group-item` in the master list, and ensure the clickable area (using `flex-grow-1` and padding like `py-1`) covers the entire row for better Fitts's Law compliance.

--- a/public/app.js
+++ b/public/app.js
@@ -569,10 +569,17 @@ async function loadUsers() {
     const li = document.createElement('li');
     li.className = 'list-group-item d-flex justify-content-between align-items-center';
     
+    if (selectedUserId === u.id) {
+        li.classList.add('active');
+    }
+
     const span = document.createElement('span');
     span.textContent = `${u.username} (id=${u.id})`;
+    span.className = 'flex-grow-1 py-1 text-break';
     span.style.cursor = 'pointer';
     makeAccessible(span, () => {
+      document.querySelectorAll('#user-list .list-group-item').forEach(el => el.classList.remove('active'));
+      li.classList.add('active');
       renderUserDetails(u);
     });
     


### PR DESCRIPTION
💡 What: Added visual indication (active state) to the currently selected user in the User Management list, and expanded the clickable area of the user's name to span the entire available row width.
🎯 Why: In master-detail views, users can easily lose context of which item they are currently editing on the right side if the left-side list doesn't explicitly highlight the selection. Furthermore, restricting the click area to just the text content makes interaction harder (violating Fitts's Law).
📸 Before/After: The active user now receives Bootstrap's `.active` highlight, and clicking anywhere in the blank space of the row selects the user.
♿ Accessibility: The larger click target benefits users with motor impairments. Keyboard navigation remains unaffected.

---
*PR created automatically by Jules for task [13311682402793766734](https://jules.google.com/task/13311682402793766734) started by @Bladestar2105*