### PR TITLE
🛡️ Sentinel: [HIGH] Fix active stream persistence on account modification

### DIFF
--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -1,5 +1,6 @@
 import { clearChannelsCache } from '../services/cacheService.js';
 import { invalidateUserTokens } from '../services/authService.js';
+import streamManager from '../services/streamManager.js';
 import db from '../database/db.js';
 import { encrypt, decrypt } from '../utils/crypto.js';
 import bcrypt from 'bcrypt';
@@ -395,6 +396,18 @@ export const updateUser = async (req, res) => {
 
     params.push(id);
     db.prepare(`UPDATE users SET ${updates.join(', ')} WHERE id = ?`).run(...params);
+
+    // Security Enhancement: Terminate active streams if security credentials/access changed
+    if (password || expiry_date !== undefined || webui_access !== undefined || hdhr_enabled !== undefined || max_connections !== undefined) {
+        try {
+            const activeStreams = db.prepare('SELECT id FROM current_streams WHERE user_id = ?').all(id);
+            for (const stream of activeStreams) {
+                streamManager.remove(stream.id);
+            }
+        } catch (streamErr) {
+            console.error(`Error terminating streams for user ${id}:`, streamErr);
+        }
+    }
 
     clearChannelsCache(id);
     res.json({success: true});


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** When a user's account access was revoked or modified (e.g., changing their password, disabling their web UI access, or setting an expiration date), their currently active streams were not terminated. This allowed unauthorized users to maintain persistent streaming access using stale sessions even after their underlying permissions had been revoked.
🎯 **Impact:** Ex-users or attackers who had an ongoing stream session could maintain that streaming session indefinitely until the connection was naturally dropped, bypassing administrative control and security restrictions.
🔧 **Fix:** Imported `streamManager` into `src/controllers/userController.js`. Updated the `updateUser` function to detect if security-sensitive properties (`password`, `expiry_date`, `webui_access`, `hdhr_enabled`, or `max_connections`) are modified. If so, it securely queries `current_streams` and instantly calls `streamManager.remove(stream.id)` to forcefully disconnect the affected user's active streaming sessions.
✅ **Verification:** Verify that when updating a user's password or expiry date while they have an active stream running, the stream is immediately terminated. Run `pnpm test` to ensure tests continue to pass.

---
*PR created automatically by Jules for task [2789158725220327348](https://jules.google.com/task/2789158725220327348) started by @Bladestar2105*