### PR TITLE
⚡ Bolt: Fix N+1 query compilation overhead in getStatistics

### DIFF
--- a/src/controllers/systemController.js
+++ b/src/controllers/systemController.js
@@ -679,11 +679,16 @@ export const getStatistics = async (req, res) => {
     `).all();
 
     const allStreams = await streamManager.getAll();
+
+    // ⚡ Bolt: Hoist the prepared statement outside the loop to prevent parsing/compiling the SQL on every iteration.
+    // This provides a massive speedup without the memory overhead of fetching tens of thousands of channels.
+    const getLogoStmt = db.prepare('SELECT logo FROM provider_channels WHERE name = ? AND provider_id = ? LIMIT 1');
+
     const streams = allStreams.map(s => {
       // Find logo if possible (for Active Streams)
       let logo = null;
       if (s.channel_name && s.provider_id) {
-          const ch = db.prepare('SELECT logo FROM provider_channels WHERE name = ? AND provider_id = ? LIMIT 1').get(s.channel_name, s.provider_id);
+          const ch = getLogoStmt.get(s.channel_name, s.provider_id);
           if (ch) logo = ch.logo;
       }
       return {


### PR DESCRIPTION
💡 What: Hoisted the `db.prepare('SELECT logo FROM provider_channels WHERE name = ? AND provider_id = ? LIMIT 1')` statement outside of the `allStreams.map()` loop in `src/controllers/systemController.js`.
🎯 Why: Inside the `getStatistics` endpoint, `db.prepare()` was being invoked on every single active stream iteration. This forced `better-sqlite3` to repeatedly parse, compile, and allocate memory for the same SQL statement, causing an N+1 compilation overhead that degraded performance during high stream concurrency.
📊 Impact: Considerably faster execution of the `getStatistics` endpoint and reduced CPU/memory overhead by compiling the SQL statement exactly once, regardless of the number of active streams.
🔬 Measurement: Verify by executing `pnpm test` and observing performance under high load; the logic is perfectly preserved while removing redundant parser execution.

---
*PR created automatically by Jules for task [4259156759685638245](https://jules.google.com/task/4259156759685638245) started by @Bladestar2105*