### PR TITLE
🎨 Palette: Add call-to-action for empty EPG Sources list

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1966,7 +1966,12 @@ async function loadEpgSources() {
     list.innerHTML = '';
     
     if (sources.length === 0) {
-      list.innerHTML = `<li class="list-group-item text-muted">${t('noEpgSourcesConfigured')}</li>`;
+      list.innerHTML = `<li class="list-group-item text-center py-4 text-muted">
+        <div class="mb-2">${t('noEpgSourcesConfigured')}</div>
+        <button class="btn btn-sm btn-primary mt-2" onclick="showAddEpgSourceModal()">
+          ${t('addEpgSource')}
+        </button>
+      </li>`;
       return;
     }
     


### PR DESCRIPTION
💡 **What**: Added an explicit call-to-action button ("➕ Add EPG Source") to the empty state of the EPG Sources list in the dashboard.

🎯 **Why**: Previously, when the list of EPG sources was empty, the UI only displayed a passive text message ("No EPG sources configured"). This required users to locate the "➕" button at the top right of the card to proceed. By placing the CTA directly within the empty state context, we reduce user friction and provide a clearer onboarding path for new users or fresh installations.

📸 **Visual Changes**:
The empty state now features a centered layout with the existing descriptive text and a newly added primary button that directly opens the "Add EPG Source" modal.

♿ **Accessibility**:
The new button utilizes existing standard Bootstrap classes and inherits the translation/ARIA configuration of the generic EPG addition process, keeping the interface consistent and screen-reader friendly.

---
*PR created automatically by Jules for task [17765764512285220848](https://jules.google.com/task/17765764512285220848) started by @Bladestar2105*