### PR TITLE
🎨 Palette: [UX improvement] Add show/hide password toggles to export and import fields

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -41,3 +41,7 @@
 ## 2026-03-05 - [Localized Screen Reader Labels]
 **Learning:** Hardcoded `aria-label` attributes (e.g., `aria-label="Clear search"`, `aria-label="Close"`) on icon-only buttons remain in English regardless of the user's selected language, reducing accessibility for non-English screen reader users.
 **Action:** Always use the declarative `data-i18n-label="key"` attribute (e.g., `data-i18n-label="clearSearch"`) instead of `aria-label` directly in the HTML. The `translatePage` utility will automatically translate it and set the `aria-label` accordingly.
+
+## 2024-03-08 - Added show/hide password buttons to export/import
+**Learning:** Missed toggles on password inputs like "Encryption Password" / "Decryption Password" degrade the user experience significantly because typos can easily occur, leading to data loss/failure. Centralized Javascript logic handles the toggling for `data-toggle-password` attributes, making it very easy to keep the UX consistent.
+**Action:** When adding new input fields that obscure data, always verify if existing components have toggles, and use the global `data-toggle-password` handler to easily give the users visibility into their inputs.

--- a/public/index.html
+++ b/public/index.html
@@ -531,7 +531,10 @@
 
                 <div class="mb-3">
                   <label class="form-label" data-i18n="encryptionPassword" for="export-password">Encryption Password</label>
-                  <input type="password" class="form-control" name="password" id="export-password" required minlength="8" data-i18n-placeholder="passwordPlaceholder" aria-describedby="export-password-help">
+                  <div class="input-group">
+                    <input type="password" class="form-control" name="password" id="export-password" required minlength="8" data-i18n-placeholder="passwordPlaceholder" aria-describedby="export-password-help">
+                    <button class="btn btn-outline-secondary" type="button" data-toggle-password="export-password" data-i18n-label="show_password" data-i18n-title="show_password">👁️</button>
+                  </div>
                   <div class="form-text" data-i18n="encryptionPasswordHint" id="export-password-help">This password will be required to decrypt and import the data.</div>
                 </div>
 
@@ -556,7 +559,10 @@
 
                 <div class="mb-3">
                   <label class="form-label" data-i18n="decryptionPassword" for="import-password">Decryption Password</label>
-                  <input type="password" class="form-control" name="password" id="import-password" required data-i18n-placeholder="passwordPlaceholder">
+                  <div class="input-group">
+                    <input type="password" class="form-control" name="password" id="import-password" required data-i18n-placeholder="passwordPlaceholder">
+                    <button class="btn btn-outline-secondary" type="button" data-toggle-password="import-password" data-i18n-label="show_password" data-i18n-title="show_password">👁️</button>
+                  </div>
                 </div>
 
                 <button type="submit" class="btn btn-warning w-100" id="import-btn" data-i18n="importBtn">Import Data</button>


### PR DESCRIPTION
### 💡 What
Added "show/hide password" toggle buttons to the "Encryption Password" (Export) and "Decryption Password" (Import) fields in the Settings page.

### 🎯 Why
Making a typo when exporting a backup with a password means the user could permanently lose access to their data, as they won't be able to decrypt it on import. Giving users visibility into these fields drastically reduces the risk of accidental data loss and provides a consistent UX, as all other password fields in the application already feature this toggle.

### ♿ Accessibility
The buttons use the standard `data-toggle-password` component which natively integrates with the existing Javascript logic. When toggled, the application automatically updates the `aria-label` and `title` with localized strings ("Show Password" / "Hide Password") to ensure screen readers stay synced with the visual state.

---
*PR created automatically by Jules for task [5785377137471656582](https://jules.google.com/task/5785377137471656582) started by @Bladestar2105*