### PR TITLE
⚡ Bolt: [performance improvement] Hoist `db.prepare` in userController

### DIFF
--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -222,10 +222,12 @@ export const createUser = async (req, res) => {
 
                 // 3b. Copy EPG Channel Mappings
                 const insertEpgMap = db.prepare('INSERT INTO epg_channel_mappings (provider_channel_id, epg_channel_id) VALUES (?, ?)');
+                // Optimization: Hoist db.prepare outside the loop to prevent O(N) database query compilations
+                const selectEpgMap = db.prepare('SELECT epg_channel_id FROM epg_channel_mappings WHERE provider_channel_id = ?');
                 // Get all mappings where provider_channel_id is in our key set
                 // Efficient way: loop channelMap keys
                 for (const oldChId of Object.keys(channelMap)) {
-                    const mapping = db.prepare('SELECT epg_channel_id FROM epg_channel_mappings WHERE provider_channel_id = ?').get(oldChId);
+                    const mapping = selectEpgMap.get(oldChId);
                     if (mapping) {
                         insertEpgMap.run(channelMap[oldChId], mapping.epg_channel_id);
                     }


### PR DESCRIPTION
💡 **What:** Hoisted the `db.prepare('SELECT epg_channel_id FROM epg_channel_mappings WHERE provider_channel_id = ?')` statement out of the `for (const oldChId of Object.keys(channelMap))` loop in `src/controllers/userController.js`. It is now precompiled once as `selectEpgMap` and called via `.get()` inside the loop.

🎯 **Why:** Preparing an SQLite query is computationally expensive. Compiling it inside a loop creates an $O(N)$ performance bottleneck, where $N$ is the number of channels being mapped. By hoisting it out, we conform to the codebase's performance anti-pattern and compile it only once $O(1)$.

📊 **Impact:** Significantly reduces CPU overhead and database interaction time during the cloning of users with large channel datasets.

🔬 **Measurement:** Cloning a user with thousands of channels should execute noticeably faster due to the elimination of thousands of redundant query compilations. No unit test regressions observed.

---
*PR created automatically by Jules for task [11011829178579635459](https://jules.google.com/task/11011829178579635459) started by @Bladestar2105*