### PR TITLE
fix: Correct `<URLBase>` placement in HDHomeRun device.xml for Plex compatibility

### DIFF
--- a/src/controllers/hdhrController.js
+++ b/src/controllers/hdhrController.js
@@ -176,6 +176,7 @@ export const deviceXml = async (req, res) => {
     <major>1</major>
     <minor>0</minor>
   </specVersion>
+  <URLBase>${baseURL}</URLBase>
   <device>
     <deviceType>urn:schemas-upnp-org:device:MediaServer:1</deviceType>
     <friendlyName>${escapeXml(friendlyName)}</friendlyName>
@@ -185,7 +186,6 @@ export const deviceXml = async (req, res) => {
     <serialNumber>${deviceID}</serialNumber>
     <UDN>uuid:${deviceID}</UDN>
     <presentationURL>${baseURL}</presentationURL>
-    <URLBase>${baseURL}/</URLBase>
   </device>
 </root>`;
 


### PR DESCRIPTION
### What
Moved the `<URLBase>` tag in the HDHomeRun `deviceXml` response from being a child of `<device>` to being a child of `<root>`.

### Why
Users reported that Plex servers were unable to recognize the HomeRun emulator device URL. Plex uses a strict UPnP parser that rejects the `device.xml` payload if `<URLBase>` is improperly nested. According to the UPnP Device Architecture (UDA) 1.0 specification, `<URLBase>` must be a direct child of `<root>`. 

### Impact
Plex and other strict UPnP clients will now correctly parse the `device.xml` payload and map the base URL, allowing the IPTV Manager HDHomeRun emulator to be successfully added as a Live TV & DVR device.

### Measurement
Run `pnpm test tests/hdhr_routes.test.js` to verify routing still works and that no syntax errors were introduced. Checked via Github Issues for similar projects (`xTeVe`, `tvhProxy`) and verified their working implementations structure `<URLBase>` as a child of `<root>`.

---
*PR created automatically by Jules for task [13170838935326249863](https://jules.google.com/task/13170838935326249863) started by @Bladestar2105*