### PR TITLE
fix: map HDHomeRun presentation URL properly

### DIFF
--- a/src/controllers/hdhrController.js
+++ b/src/controllers/hdhrController.js
@@ -185,7 +185,6 @@ export const deviceXml = async (req, res) => {
     <modelNumber>HDHR4-2US</modelNumber>
     <serialNumber>${deviceID}</serialNumber>
     <UDN>uuid:${deviceID}</UDN>
-    <presentationURL>${baseURL}</presentationURL>
   </device>
 </root>`;
 

--- a/src/routes/hdhr.js
+++ b/src/routes/hdhr.js
@@ -5,7 +5,7 @@ import * as streamController from '../controllers/streamController.js';
 const router = express.Router();
 
 router.get(['/:token/discover.json', '/:token//discover.json'], hdhrController.discover);
-router.get(['/:token/device.xml', '/:token//device.xml'], hdhrController.deviceXml);
+router.get(['/:token', '/:token/', '/:token/device.xml', '/:token//device.xml'], hdhrController.deviceXml);
 router.get(['/:token/lineup_status.json', '/:token//lineup_status.json'], hdhrController.lineupStatus);
 router.get(['/:token/lineup.json', '/:token//lineup.json'], hdhrController.lineup);
 router.get('/:token/auto/v:channelId', hdhrController.auto);

--- a/tests/hdhr_routes.test.js
+++ b/tests/hdhr_routes.test.js
@@ -52,6 +52,18 @@ describe('HDHR Routing', () => {
         expect(res.status).toBe(200);
     });
 
+    it('should handle presentationURL root request', async () => {
+        const res = await request(app).get('/hdhr/TOKEN');
+        expect(res.status).toBe(200);
+        expect(res.headers['content-type']).toContain('application/xml');
+    });
+
+    it('should handle presentationURL root request with trailing slash', async () => {
+        const res = await request(app).get('/hdhr/TOKEN/');
+        expect(res.status).toBe(200);
+        expect(res.headers['content-type']).toContain('application/xml');
+    });
+
     it('should handle double slash in lineup.json request', async () => {
         const res = await request(app).get('/hdhr/TOKEN//lineup.json');
         expect(res.status).toBe(200);


### PR DESCRIPTION
- Maps the root `/hdhr/:token` and `/hdhr/:token/` routes to the `deviceXml` controller to handle UPnP presentation URL requests.
- Removes the `<presentationURL>` tag from the `device.xml` output. This matches behavior of established projects like HRTunerProxy and Dispatcharr, which also omit the tag or map the root URL directly to `device.xml` to prevent strict clients from failing when no actual HTML UI exists.