### PR TITLE
fix: correct geoip update api endpoint in frontend

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2462,7 +2462,7 @@ document.addEventListener('DOMContentLoaded', () => {
       btnUpdateGeoip.addEventListener('click', async () => {
           setLoadingState(btnUpdateGeoip, true, 'updating');
           try {
-              const res = await fetchJSON('/api/system/geoip/update', { method: 'POST' });
+              const res = await fetchJSON('/api/geoip/update', { method: 'POST' });
               showToast(res.message || t('success'), 'success');
           } catch (e) {
               showToast(t('errorPrefix') + ' ' + e.message, 'danger');


### PR DESCRIPTION
Fixes a 404 error when attempting to update the GeoIP database from the settings page. The frontend fetch call was pointing to `/api/system/geoip/update` instead of the correct `/api/geoip/update` route.

---
*PR created automatically by Jules for task [5034328999649081795](https://jules.google.com/task/5034328999649081795) started by @Bladestar2105*