### PR TITLE
fix: correct HDHomeRun emulator URL for Plex compatibility

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -521,7 +521,7 @@ function renderUserDetails(u) {
             const protocol = window.location.protocol;
             const host = window.location.host;
             // u.hdhr_token is returned by GET /api/users
-            if (hdhrUrlInput) hdhrUrlInput.value = `${protocol}//${host}/hdhr/${u.hdhr_token}/discover.json`;
+            if (hdhrUrlInput) hdhrUrlInput.value = `${protocol}//${host}/hdhr/${u.hdhr_token}`;
         } else {
             hdhrEnabledSection.classList.add('d-none');
             hdhrDisabledSection.classList.remove('d-none');


### PR DESCRIPTION
Fixes an issue where the HDHomeRun emulation URL presented in the UI included `/discover.json`, which caused configuration issues when users pasted it into Plex, as Plex expects the base URL to probe.

---
*PR created automatically by Jules for task [16250849119285201179](https://jules.google.com/task/16250849119285201179) started by @Bladestar2105*