### PR TITLE
fix: prevent region lock on local users when allowed_countries is not set

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -748,7 +748,7 @@ function showEditUserModal(user) {
 
   // Set selected countries
   const allowedCountriesSelect = document.getElementById('edit-user-allowed-countries');
-  const userCountries = user.allowed_countries ? user.allowed_countries.split(',').map(c => c.trim().toUpperCase()) : [];
+  const userCountries = (user.allowed_countries && user.allowed_countries !== 'null' && user.allowed_countries !== 'undefined') ? user.allowed_countries.split(',').map(c => c.trim().toUpperCase()) : [];
   Array.from(allowedCountriesSelect.options).forEach(opt => {
       opt.selected = userCountries.includes(opt.value);
   });

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -124,7 +124,7 @@ export const createUser = async (req, res) => {
             hdhrToken,
             (max_connections !== undefined && max_connections !== '') ? Number(max_connections) : 0,
             expiry_date || null,
-            allowed_countries || null
+            (allowed_countries && allowed_countries !== 'null' && allowed_countries !== 'undefined') ? allowed_countries : null
         );
         const newUserId = info.lastInsertRowid;
 
@@ -398,7 +398,7 @@ export const updateUser = async (req, res) => {
 
     if (allowed_countries !== undefined) {
         updates.push('allowed_countries = ?');
-        params.push(allowed_countries || null);
+        params.push((allowed_countries && allowed_countries !== 'null' && allowed_countries !== 'undefined') ? allowed_countries : null);
     }
 
     if (updates.length === 0) return res.json({success: true}); // Nothing to update

--- a/src/services/geoIpService.js
+++ b/src/services/geoIpService.js
@@ -12,9 +12,9 @@ export function isIpAllowedForUser(ip, user) {
   if (!user || user.is_admin) return true;
 
   // If no countries are allowed (null or empty string), then no restrictions apply
-  if (!user.allowed_countries) return true;
+  if (!user.allowed_countries || user.allowed_countries === 'null' || user.allowed_countries === 'undefined') return true;
 
-  const allowedList = user.allowed_countries.split(',').map(c => c.trim().toUpperCase()).filter(Boolean);
+  const allowedList = String(user.allowed_countries).split(',').map(c => c.trim().toUpperCase()).filter(Boolean);
 
   // Empty array after splitting means no restriction
   if (allowedList.length === 0) return true;


### PR DESCRIPTION
- Investigated the "Blocked Xtream/Stream Access (Region Lock)" error occurring on fresh installs for local users.
- Found that `isIpAllowedForUser` in `src/services/geoIpService.js` was improperly handling stringified versions of null/undefined or empty values for `user.allowed_countries`.
- Because the user is testing locally (`127.0.0.1` or `::1`), `geoip.lookup()` returns `null`, causing the region check to fail when the array contains `['NULL']`.
- Updated `src/services/geoIpService.js` to explicitly treat literal `"null"` and `"undefined"` strings as empty/allow-all.
- Updated `src/controllers/userController.js` and `public/app.js` to rigidly enforce saving and reading true JavaScript `null` when no countries are selected.
- Cleaned up exploratory scripts and temporary testing dependencies (jsdom) from the workspace.

---
*PR created automatically by Jules for task [6739948157281199855](https://jules.google.com/task/6739948157281199855) started by @Bladestar2105*