### PR TITLE
🛡️ Sentinel: [HIGH] Fix IDOR in Provider endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -13,3 +13,7 @@
 **Vulnerability:** User inputs (`search`) and error responses (`e.message`) were directly passed into DOM template literals without encoding and rendered via `innerHTML`.
 **Learning:** `innerHTML` allows XSS evaluation of unsanitized HTML tags (like `<img src=x onerror=...>`) when injecting text from potentially untrusted origins.
 **Prevention:** Always wrap variables that could include untrusted strings with `escapeHtml` (or standard framework escaping) when doing raw `innerHTML` string interpolation.
+## 2025-03-09 - [Missing Provider Authorization]
+**Vulnerability:** IDOR in Provider Categories and Channels retrieval endpoints.
+**Learning:** `getProviderChannels` and `getProviderCategories` lacked ownership checks, allowing any user to query details of any provider by ID.
+**Prevention:** Always verify `!req.user.is_admin && provider.user_id !== req.user.id` when returning provider-specific data.

--- a/src/controllers/providerController.js
+++ b/src/controllers/providerController.js
@@ -391,6 +391,11 @@ export const getProviderChannels = (req, res) => {
     const { type, page, limit, search } = req.query;
     const providerId = Number(req.params.id);
 
+    if (!req.user.is_admin) {
+        const provider = db.prepare('SELECT user_id FROM providers WHERE id = ?').get(providerId);
+        if (!provider || provider.user_id !== req.user.id) return res.status(403).json({error: 'Access denied'});
+    }
+
     if (page || limit || search) {
       const pageNum = parseInt(page) || 1;
       const limitNum = parseInt(limit) || 50;
@@ -446,6 +451,10 @@ export const getProviderCategories = async (req, res) => {
 
     const provider = db.prepare('SELECT * FROM providers WHERE id = ?').get(id);
     if (!provider) return res.status(404).json({error: 'Provider not found'});
+
+    if (!req.user.is_admin && provider.user_id !== req.user.id) {
+        return res.status(403).json({error: 'Access denied'});
+    }
 
     const decryptedPassword = decrypt(provider.password);
 


### PR DESCRIPTION
### 🛡️ Sentinel: [HIGH] Fix IDOR in Provider endpoints

🚨 **Severity:** HIGH
💡 **Vulnerability:** Insecure Direct Object Reference (IDOR) existed in the endpoints fetching a provider's channels and categories (`/api/providers/:id/channels` and `/api/providers/:id/categories`). These endpoints failed to verify if the requesting user was the owner of the provider.
🎯 **Impact:** Any authenticated user could enumerate provider IDs and access channels and categories belonging to other users or administrators, exposing sensitive configuration data and potentially bypassing service access restrictions.
🔧 **Fix:** Added an explicit authorization check that queries the provider's `user_id` and blocks access (`403 Forbidden`) if the current user is not an administrator and does not match the provider's `user_id`.
✅ **Verification:** Verified by passing the test suite (`pnpm test`) and verifying `src/controllers/providerController.js` logic.

---
*PR created automatically by Jules for task [12658473565071765264](https://jules.google.com/task/12658473565071765264) started by @Bladestar2105*