### PR TITLE
feat: Add /cpp and player_api.php?action=cpp pre-check endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "bootstrap": "^5.3.0",
         "cors": "^2.8.5",
         "dotenv": "^17.3.1",
+        "esbuild": "^0.27.3",
         "express": "^4.21.2",
         "express-rate-limit": "^8.2.1",
         "ffmpeg-static": "^5.3.0",
@@ -64,7 +65,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -81,7 +81,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -98,7 +97,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -115,7 +113,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -132,7 +129,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -149,7 +145,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -166,7 +161,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -183,7 +177,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -200,7 +193,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -217,7 +209,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -234,7 +225,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -251,7 +241,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -268,7 +257,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -285,7 +273,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -302,7 +289,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -319,7 +305,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -336,7 +321,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -353,7 +337,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -370,7 +353,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -387,7 +369,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -404,7 +385,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -421,7 +401,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -438,7 +417,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -455,7 +433,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -472,7 +449,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -489,7 +465,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2225,7 +2200,6 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "bootstrap": "^5.3.0",
     "cors": "^2.8.5",
     "dotenv": "^17.3.1",
+    "esbuild": "^0.27.3",
     "express": "^4.21.2",
     "express-rate-limit": "^8.2.1",
     "ffmpeg-static": "^5.3.0",

--- a/src/controllers/xtreamController.js
+++ b/src/controllers/xtreamController.js
@@ -22,11 +22,19 @@ const sanitizeMetadata = (val) => {
   return String(val).replace(/[\r\n]+/g, ' ').replace(/"/g, "'").trim();
 };
 
+export const cppEndpoint = (req, res) => {
+  res.json(true);
+};
+
 export const playerApi = async (req, res) => {
   try {
     const username = (req.query.username || '').trim();
     const password = (req.query.password || '').trim();
     const action = (req.query.action || '').trim();
+
+    if (action === 'cpp') {
+      return res.json(true);
+    }
 
     const user = await getXtreamUser(req);
     if (!user) {

--- a/src/routes/xtream.js
+++ b/src/routes/xtream.js
@@ -3,6 +3,7 @@ import * as xtreamController from '../controllers/xtreamController.js';
 
 const router = express.Router();
 
+router.get('/cpp', xtreamController.cppEndpoint);
 router.get('/player_api.php', xtreamController.playerApi);
 router.get('/get.php', xtreamController.getPlaylist);
 router.get('/xmltv.php', xtreamController.xmltv);

--- a/tests/controllers/xtream_cpp.test.js
+++ b/tests/controllers/xtream_cpp.test.js
@@ -1,0 +1,32 @@
+import express from 'express';
+import request from 'supertest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as xtreamController from '../../src/controllers/xtreamController.js';
+import { getXtreamUser } from '../../src/services/authService.js';
+
+vi.mock('../../src/services/authService.js', () => ({
+  getXtreamUser: vi.fn(),
+}));
+
+const app = express();
+app.get('/cpp', xtreamController.cppEndpoint);
+app.get('/player_api.php', xtreamController.playerApi);
+
+describe('Xtream Controller CPP pre-check', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return true for /cpp endpoint', async () => {
+    const res = await request(app).get('/cpp');
+    expect(res.status).toBe(200);
+    expect(res.text).toBe('true');
+  });
+
+  it('should return true for player_api.php with action=cpp without checking auth', async () => {
+    const res = await request(app).get('/player_api.php?action=cpp');
+    expect(res.status).toBe(200);
+    expect(res.text).toBe('true');
+    expect(getXtreamUser).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Added a new `/cpp` endpoint and an early return for `action=cpp` in `player_api.php` that both return `true` as JSON. This enables custom IPTV player applications to verify if the server is an IPTV-Manager instance prior to authenticating, bypassing `getXtreamUser`. Includes unit tests for both endpoints.

---
*PR created automatically by Jules for task [1778067207332394968](https://jules.google.com/task/1778067207332394968) started by @Bladestar2105*