### PR TITLE
fix: fix hardcoded translations in ui

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       dotenv:
         specifier: ^17.3.1
         version: 17.3.1
+      esbuild:
+        specifier: ^0.27.3
+        version: 0.27.3
       express:
         specifier: ^4.21.2
         version: 4.22.1

--- a/public/i18n.js
+++ b/public/i18n.js
@@ -159,6 +159,8 @@ const translations = {
     typeLive: 'Live',
     typeMovie: 'Movies',
     typeSeries: 'Series',
+    toggleSidebar: 'Toggle sidebar',
+    hdhomerun: 'HDHomeRun',
 
     // Authentication
     login: 'Login',
@@ -621,6 +623,8 @@ const translations = {
     typeLive: 'Live',
     typeMovie: 'Filme',
     typeSeries: 'Serien',
+    toggleSidebar: 'Seitenleiste umschalten',
+    hdhomerun: 'HDHomeRun',
 
     // Authentication
     login: 'Anmelden',
@@ -1075,6 +1079,8 @@ const translations = {
     typeLive: 'Live',
     typeMovie: 'Films',
     typeSeries: 'Séries',
+    toggleSidebar: 'Basculer la barre latérale',
+    hdhomerun: 'HDHomeRun',
 
     // Authentication
     login: 'Connexion',
@@ -1529,6 +1535,8 @@ const translations = {
     typeLive: 'Live',
     typeMovie: 'Ταινίες',
     typeSeries: 'Σειρές',
+    toggleSidebar: 'Εναλλαγή πλευρικής μπάρας',
+    hdhomerun: 'HDHomeRun',
 
     // Authentication
     login: 'Σύνδεση',

--- a/public/index.html
+++ b/public/index.html
@@ -190,7 +190,7 @@
                        <button class="nav-link" id="tab-xtream-btn" data-bs-toggle="tab" data-bs-target="#tab-xtream" type="button" data-i18n="xtreamCodes">Xtream Codes</button>
                     </li>
                     <li class="nav-item">
-                       <button class="nav-link" id="tab-hdhr-btn" data-bs-toggle="tab" data-bs-target="#tab-hdhr" type="button" aria-label="HDHomeRun">HDHomeRun</button>
+                       <button class="nav-link" id="tab-hdhr-btn" data-bs-toggle="tab" data-bs-target="#tab-hdhr" type="button" data-i18n-label="hdhomerun" data-i18n="hdhomerun">HDHomeRun</button>
                     </li>
                  </ul>
 

--- a/public/player.html
+++ b/public/player.html
@@ -24,7 +24,7 @@
 
 <!-- Controls Bar -->
 <div id="controls-bar">
-  <button id="sidebar-toggle" class="btn btn-sm btn-outline-secondary d-md-none p-2-8" aria-label="Toggle sidebar">&#9776;</button>
+  <button id="sidebar-toggle" class="btn btn-sm btn-outline-secondary d-md-none p-2-8" data-i18n-label="toggleSidebar">&#9776;</button>
 
   <div class="form-check form-switch min-w-fit">
     <input class="form-check-input" type="checkbox" id="transcode-switch">

--- a/public/player.js
+++ b/public/player.js
@@ -70,6 +70,12 @@
     document.querySelectorAll('[data-i18n-placeholder]').forEach(function(el) {
       el.placeholder = t(el.getAttribute('data-i18n-placeholder'));
     });
+    document.querySelectorAll('[data-i18n-label]').forEach(function(el) {
+      el.setAttribute('aria-label', t(el.getAttribute('data-i18n-label')));
+    });
+    document.querySelectorAll('[data-i18n-title]').forEach(function(el) {
+      el.title = t(el.getAttribute('data-i18n-title'));
+    });
     document.title = t('playerTitle');
   }
   translatePage();


### PR DESCRIPTION
This PR replaces hardcoded strings with proper i18n tags for two specific buttons that were found.

Changes:
- Added `toggleSidebar` and `hdhomerun` entries to `public/i18n.js` for all languages.
- Modified `public/player.html` to use `data-i18n-label` instead of `aria-label="Toggle sidebar"`.
- Modified `public/index.html` to use `data-i18n-label` and `data-i18n` instead of `aria-label="HDHomeRun"` and hardcoded text content.
- Updated `public/player.js`'s `translatePage` function to correctly parse and apply `data-i18n-label` and `data-i18n-title`.

---
*PR created automatically by Jules for task [17096332671525733875](https://jules.google.com/task/17096332671525733875) started by @Bladestar2105*