### PR TITLE
Add MaxMind License Key support for GeoIP updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
 - **Node.js**: 20.x+
 - **npm**: 9.x+
 - **SQLite**: 3.x (included)
+- **MaxMind GeoLite2 License Key**: While basic region locking functions work out of the box with the included database, updating the internal GeoIP database requires a free MaxMind License Key. You can get one at [maxmind.com](https://support.maxmind.com/hc/en-us/articles/4407111582235-Generate-a-License-Key) and enter it in the WebUI Security Settings.
 
 ### Production Deployment
 For production environments, it is strongly recommended to set `NODE_ENV=production` and run the application behind a reverse proxy (like Nginx or Traefik) that handles HTTPS. The application will enforce secure cookies when in production mode.

--- a/public/app.js
+++ b/public/app.js
@@ -2718,7 +2718,8 @@ document.addEventListener('DOMContentLoaded', () => {
                   admin_block_threshold: document.getElementById('setting-admin-threshold').value,
                   iptv_block_threshold: document.getElementById('setting-iptv-threshold').value,
                   admin_block_duration: document.getElementById('setting-admin-duration').value,
-                  iptv_block_duration: document.getElementById('setting-iptv-duration').value
+                  iptv_block_duration: document.getElementById('setting-iptv-duration').value,
+                  geoip_license_key: document.getElementById('setting-geoip-license-key').value
               };
 
               await fetchJSON('/api/settings', {
@@ -3005,6 +3006,9 @@ async function loadSecurity() {
     }
     if (document.getElementById('setting-iptv-duration')) {
         document.getElementById('setting-iptv-duration').value = settings.iptv_block_duration || '3600';
+    }
+    if (document.getElementById('setting-geoip-license-key')) {
+        document.getElementById('setting-geoip-license-key').value = settings.geoip_license_key || '';
     }
 
     // Render Logs

--- a/public/i18n.js
+++ b/public/i18n.js
@@ -313,6 +313,8 @@ const translations = {
     iptvBlockDuration: 'IPTV Block Duration (seconds)',
     geoIpSettings: 'GeoIP Database',
     geoIpSettingsHelp: 'Update the local GeoIP database used for Region Locking. This downloads the latest MaxMind GeoLite2 data.',
+    getFreeKeyHelp: 'Get a free License Key.',
+    maxmindLicenseKey: 'MaxMind License Key',
     updateGeoIp: 'Update GeoIP',
     confirmUpdateGeoIp: 'Start GeoIP database update? This will run in the background and may take a few minutes.',
     updating: 'Updating...',

--- a/public/index.html
+++ b/public/index.html
@@ -415,17 +415,30 @@
                      <input type="number" class="form-control" name="iptv_block_duration" id="setting-iptv-duration" placeholder="3600">
                   </div>
                </div>
+
+               <hr>
+               <div class="row mb-3 mt-3">
+                  <div class="col-12">
+                     <h6 data-i18n="geoIpSettings">GeoIP Database</h6>
+                     <p class="small text-muted mb-2"><span data-i18n="geoIpSettingsHelp">Update the local GeoIP database used for Region Locking. This downloads the latest MaxMind GeoLite2 data.</span> <a href="https://support.maxmind.com/hc/en-us/articles/4407111582235-Generate-a-License-Key" target="_blank" data-i18n="getFreeKeyHelp">Get a free License Key.</a></p>
+                  </div>
+                  <div class="col-md-8 mb-2">
+                     <label class="form-label" data-i18n="maxmindLicenseKey" for="setting-geoip-license-key">MaxMind License Key</label>
+                     <div class="input-group">
+                        <input type="password" class="form-control" name="geoip_license_key" id="setting-geoip-license-key" placeholder="Enter License Key for Updates">
+                        <button class="btn btn-outline-secondary" type="button" data-toggle-password="setting-geoip-license-key" data-i18n-label="togglePasswordVisibility" aria-label="Toggle password visibility"><i class="bi bi-eye"></i></button>
+                     </div>
+                  </div>
+                  <div class="col-md-4 d-flex align-items-end mb-2">
+                     <button class="btn btn-secondary w-100" type="button" id="btn-update-geoip" data-i18n="updateGeoIp">Update Database</button>
+                  </div>
+               </div>
+
                <!-- Hidden field to maintain backward compatibility if needed, or we can just ignore it -->
                <!-- <input type="hidden" name="ip_block_duration" id="setting-block-duration"> -->
 
-               <button class="btn btn-primary" type="submit" data-i18n="save">Save</button>
+               <button class="btn btn-primary" type="submit" data-i18n="save">Save Settings</button>
             </form>
-            <hr>
-            <div class="mt-3">
-               <h6 data-i18n="geoIpSettings">GeoIP Database</h6>
-               <p class="small text-muted mb-2" data-i18n="geoIpSettingsHelp">Update the local GeoIP database used for Region Locking. This downloads the latest MaxMind GeoLite2 data.</p>
-               <button class="btn btn-secondary" type="button" id="btn-update-geoip" data-i18n="updateGeoIp">Update GeoIP Database</button>
-            </div>
          </div>
       </div>
 

--- a/src/controllers/systemController.js
+++ b/src/controllers/systemController.js
@@ -290,9 +290,17 @@ export const updateGeoIpDatabase = (req, res) => {
   try {
     if (!req.user?.is_admin) return res.status(403).json({error: 'Access denied'});
 
+    const licenseKeyRow = db.prepare('SELECT value FROM settings WHERE key = ?').get('geoip_license_key');
+    const licenseKey = licenseKeyRow ? licenseKeyRow.value : '';
+
+    if (!licenseKey) {
+       return res.status(400).json({error: 'A MaxMind License Key is required to update the GeoIP database. Please add it in Settings.'});
+    }
+
     const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
     const child = spawn(npmCmd, ['run', 'updatedb'], {
         cwd: path.resolve('node_modules/geoip-lite'),
+        env: { ...process.env, LICENSE_KEY: licenseKey },
         stdio: 'ignore'
     });
 


### PR DESCRIPTION
Fixes the issue where updating the local GeoIP database failed due to MaxMind now requiring a free license key.

This PR adds a new setting to the Security tab where users can enter their MaxMind GeoLite2 License Key. The key is securely passed to the `updatedb` script. It also updates the documentation to reflect this change.

---
*PR created automatically by Jules for task [16501700989624590485](https://jules.google.com/task/16501700989624590485) started by @Bladestar2105*