### PR TITLE
feat: Add is_adult property to Xtream API category endpoints

### DIFF
--- a/src/controllers/xtreamController.js
+++ b/src/controllers/xtreamController.js
@@ -89,7 +89,8 @@ export const playerApi = async (req, res) => {
       return cats.map(c => ({
         category_id: String(c.id),
         category_name: c.name,
-        parent_id: 0
+        parent_id: 0,
+        is_adult: c.is_adult || 0
       }));
     };
 


### PR DESCRIPTION
Adds the `is_adult` property (`0` or `1`) to the objects returned by `get_live_categories`, `get_vod_categories`, and `get_series_categories` in the Xtream Codes API. This allows custom IPTV players to identify and apply parental controls or PIN locks to entire FSK18 categories, improving client-side filtering capabilities.

---
*PR created automatically by Jules for task [18123481881522486680](https://jules.google.com/task/18123481881522486680) started by @Bladestar2105*