### PR TITLE
⚡ Bolt: Optimize XMLTV generation with stream chunking

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -11,3 +11,7 @@
 ## 2026-03-10 - Expensive Substring Checks in Hot Loops
 **Learning:** Using `String.prototype.includes()` checks (e.g., `streamUrl.includes('/movie/')`) repeatedly inside hot loops containing tens of thousands of items causes a measurable performance bottleneck.
 **Action:** Replace URL/string-based inference with direct property equality checks (`ch.stream_type === 'movie'`) mapped directly from the database schema to ensure O(1) performance.
+
+## 2026-03-10 - Generator Stream Buffering for XMLTV
+**Learning:** Returning thousands of small string fragments (like individual XML elements) from an `async function*` generator and passing them directly to `res.write()` introduces massive network stack overhead and event loop blocking, drastically reducing throughput.
+**Action:** Implement string buffering directly inside the generator function, accumulating smaller yields into larger chunks (e.g., 64KB) before calling `yield`. This minimizes I/O operations and context switching overhead.

--- a/src/services/epgService.js
+++ b/src/services/epgService.js
@@ -376,6 +376,12 @@ export async function* getEpgXmlForChannels(channelIds) {
     const ids = Array.from(channelIds);
     const BATCH_SIZE = 900; // SQLite limit
 
+    // ⚡ Bolt: Buffer XML strings to avoid massive overhead of individual res.write calls per program
+    // 🎯 Why: Tens of thousands of small `yield` strings severely block the Node event loop and network stack
+    // 📊 Impact: Drastically increases XMLTV generation throughput and lowers CPU usage
+    let buffer = '';
+    const FLUSH_LIMIT = 65536; // 64KB
+
     // 1. Fetch Channels
     for (let i = 0; i < ids.length; i += BATCH_SIZE) {
         const batch = ids.slice(i, i + BATCH_SIZE);
@@ -388,10 +394,11 @@ export async function* getEpgXmlForChannels(channelIds) {
         `).all(batch);
 
         for (const ch of channels) {
-            yield `<channel id="${escapeXml(ch.id)}">
-    <display-name>${escapeXml(ch.name)}</display-name>
-    <icon src="${escapeXml(ch.logo || '')}" />
-  </channel>\n`;
+            buffer += `<channel id="${escapeXml(ch.id)}">\n    <display-name>${escapeXml(ch.name)}</display-name>\n    <icon src="${escapeXml(ch.logo || '')}" />\n  </channel>\n`;
+            if (buffer.length >= FLUSH_LIMIT) {
+                yield buffer;
+                buffer = '';
+            }
         }
     }
 
@@ -423,11 +430,16 @@ export async function* getEpgXmlForChannels(channelIds) {
         `);
 
         for (const prog of stmt.iterate(batch)) {
-            yield `<programme start="${prog.xmltv_start}" stop="${prog.xmltv_stop}" channel="${escapeXml(prog.channel_id)}">
-    <title>${escapeXml(prog.title)}</title>
-    <desc>${escapeXml(prog.desc || '')}</desc>
-  </programme>\n`;
+            buffer += `<programme start="${prog.xmltv_start}" stop="${prog.xmltv_stop}" channel="${escapeXml(prog.channel_id)}">\n    <title>${escapeXml(prog.title)}</title>\n    <desc>${escapeXml(prog.desc || '')}</desc>\n  </programme>\n`;
+            if (buffer.length >= FLUSH_LIMIT) {
+                yield buffer;
+                buffer = '';
+            }
         }
+    }
+
+    if (buffer.length > 0) {
+        yield buffer;
     }
 }
 


### PR DESCRIPTION
💡 What: Implemented a 64KB string buffer in the `getEpgXmlForChannels` generator inside `src/services/epgService.js`.
🎯 Why: Previously, the generator yielded a separate string for every single XML `<channel>` and `<programme>` element. For large EPG databases with tens or hundreds of thousands of programs, this resulted in an equivalent number of asynchronous `yield` operations and blocking `res.write()` calls in the controller, causing massive overhead on the Node.js event loop and network stack.
📊 Impact: Drastically reduces the number of context switches and I/O write operations. A query returning 50,000 programs now executes ~150 network writes instead of 50,000, severely reducing CPU usage and improving XMLTV API throughput.
🔬 Measurement: Verified by running the full test suite and generating a test XML payload to ensure character-for-character correctness of the batched chunks.

---
*PR created automatically by Jules for task [4941597363415328028](https://jules.google.com/task/4941597363415328028) started by @Bladestar2105*