### PR TITLE
Fix GeoIP blocks from proxy/IPv6 IPs and display country codes in Security Logs

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -3042,7 +3042,7 @@ async function loadSecurity() {
             tdDate.textContent = new Date(log.timestamp * 1000).toLocaleString();
 
             const tdIp = document.createElement('td');
-            tdIp.textContent = log.ip;
+            tdIp.textContent = log.ip + (log.country ? ` [${log.country}]` : '');
 
             const tdAction = document.createElement('td');
             tdAction.textContent = log.action;

--- a/src/controllers/systemController.js
+++ b/src/controllers/systemController.js
@@ -7,7 +7,7 @@ import { encryptWithPassword, decryptWithPassword, decrypt, encrypt } from '../u
 import { calculateNextSync } from '../services/syncService.js';
 import { clearSettingsCache } from '../utils/helpers.js';
 import { isIP } from 'net';
-import { isSafeUrl } from '../utils/helpers.js';
+import { isSafeUrl, cleanIp } from '../utils/helpers.js';
 import si from 'systeminformation';
 import { spawn } from 'child_process';
 import path from 'path';
@@ -94,7 +94,14 @@ export const getSecurityLogs = (req, res) => {
     if (!req.user.is_admin) return res.status(403).json({error: 'Access denied'});
     const limit = req.query.limit ? Number(req.query.limit) : 100;
     const logs = db.prepare('SELECT * FROM security_logs ORDER BY timestamp DESC LIMIT ?').all(limit);
-    res.json(logs);
+
+    // Augment with country code
+    const logsWithGeo = logs.map(log => {
+      const geo = geoip.lookup(cleanIp(log.ip));
+      return { ...log, country: geo && geo.country ? geo.country : null };
+    });
+
+    res.json(logsWithGeo);
   } catch (e) { res.status(500).json({error: e.message}); }
 };
 
@@ -113,8 +120,7 @@ export const getBlockedIps = (req, res) => {
 
     // Augment with country code for better admin check
     const ipsWithGeo = ips.map(b => {
-      const cleanIp = b.ip.startsWith('::ffff:') ? b.ip.replace(/^::ffff:/, '') : b.ip;
-      const geo = geoip.lookup(cleanIp);
+      const geo = geoip.lookup(cleanIp(b.ip));
       return { ...b, country: geo && geo.country ? geo.country : null };
     });
 

--- a/src/services/geoIpService.js
+++ b/src/services/geoIpService.js
@@ -1,5 +1,6 @@
 import geoip from 'geoip-lite';
 import db from '../database/db.js';
+import { cleanIp } from '../utils/helpers.js';
 
 /**
  * Checks if the given IP is allowed for the given user based on region locks.
@@ -24,8 +25,8 @@ export function isIpAllowedForUser(ip, user) {
   if (isWhitelisted) return true;
 
   // Resolve IP to country
-  const cleanIp = ip.startsWith('::ffff:') ? ip.replace(/^::ffff:/, '') : ip;
-  const geo = geoip.lookup(cleanIp);
+  const sanitizedIp = cleanIp(ip);
+  const geo = geoip.lookup(sanitizedIp);
 
   // If IP cannot be resolved, we have to block it because they enabled region lock
   if (!geo || !geo.country) return false;

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -16,6 +16,17 @@ export function getBaseUrl(req) {
   return `${protocol}://${host}`;
 }
 
+export function cleanIp(ip) {
+  if (!ip || typeof ip !== 'string') return '';
+  // Handle comma-separated IPs (like X-Forwarded-For)
+  let cleaned = ip.split(',')[0].trim();
+  // Remove IPv6 mapped IPv4 prefix
+  if (cleaned.startsWith('::ffff:')) {
+    cleaned = cleaned.replace(/^::ffff:/, '');
+  }
+  return cleaned;
+}
+
 export function isUnsafeIP(ip) {
     const ipVer = isIP(ip);
     if (ipVer === 0) return false;


### PR DESCRIPTION
Resolves an issue where connections originating from whitelisted countries were being blocked because their IP contained proxy chains or IPv6 prefixes (`::ffff:`). `geoip-lite` failed to resolve these, returning `null` and defaulting to a strict block.

Additionally, this adds the country code directly to the Security Logs and Blocked IPs views in the frontend (e.g., `149.102.246.7 [US]`), allowing administrators to quickly identify the resolved region that caused a block.

---
*PR created automatically by Jules for task [11652362352600322738](https://jules.google.com/task/11652362352600322738) started by @Bladestar2105*