### PR TITLE
Fix GeoIP Lite Update Script Memory Limits and Arg Handling

### DIFF
--- a/src/controllers/systemController.js
+++ b/src/controllers/systemController.js
@@ -319,10 +319,11 @@ export const updateGeoIpDatabase = (req, res) => {
        return res.status(400).json({error: 'A MaxMind License Key is required to update the GeoIP database. Please add it in Settings.'});
     }
 
-    const child = spawn(process.execPath, ['scripts/updatedb.js'], {
+    const scriptPath = path.resolve('node_modules/geoip-lite/scripts/updatedb.js');
+    const child = spawn(process.execPath, ['--max-old-space-size=4096', scriptPath, `license_key=${licenseKey}`], {
         cwd: path.resolve('node_modules/geoip-lite'),
         env: { ...process.env, LICENSE_KEY: licenseKey },
-        stdio: 'ignore'
+        stdio: 'inherit'
     });
 
     child.on('error', (err) => {

--- a/src/services/schedulerService.js
+++ b/src/services/schedulerService.js
@@ -128,10 +128,11 @@ export function startGeoIpUpdater() {
 
       console.info('🌍 GeoIP Auto-Update: Starting...');
 
-      const child = spawn(process.execPath, ['scripts/updatedb.js'], {
+      const scriptPath = path.resolve('node_modules/geoip-lite/scripts/updatedb.js');
+      const child = spawn(process.execPath, ['--max-old-space-size=4096', scriptPath, `license_key=${licenseKey}`], {
           cwd: path.resolve('node_modules/geoip-lite'),
           env: { ...process.env, LICENSE_KEY: licenseKey },
-          stdio: 'ignore'
+          stdio: 'inherit'
       });
 
       child.on('error', (err) => {


### PR DESCRIPTION
Fixed a bug where the `geoip-lite` auto-updater would fail silently or crash out of memory when processing large `.csv` databases.

**Root cause:**
- `geoip-lite`'s `updatedb.js` converts large MaxMind CSVs to dat files, which can require more memory than Node's default limits.
- Standard I/O streams were completely ignored (`stdio: 'ignore'`), silencing errors and rendering crashes invisible to the user.

**Fix:**
- Spawned `updatedb.js` using `--max-old-space-size=4096`.
- Set `stdio: 'inherit'` to allow monitoring of the output and errors.
- Construct the script path directly via `path.resolve` and correctly map the `license_key` param to the args.

---
*PR created automatically by Jules for task [12341737842584959017](https://jules.google.com/task/12341737842584959017) started by @Bladestar2105*