### PR TITLE
🎨 Palette: Add tooltip to Toast close button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,9 @@
+## 2026-03-12 - Consistent Password Toggle Accessibility
+**Learning:** The password visibility toggle pattern in this app is generally good, using `data-toggle-password` and automatically updating the aria-label in JS (e.g. `public/app.js` line 416). However, some inputs (like the GeoIP License Key) use a different/inconsistent i18n label key (`togglePasswordVisibility` instead of `show_password`), and also have hardcoded `aria-label` attributes that bypass the dynamic translation, and use a different icon (`<i class="bi bi-eye"></i>` instead of `👁️`). This causes inconsistency for screen readers and visual users.
+**Action:** Standardized all password toggle buttons to use `data-i18n-label="show_password"`, `data-i18n-title="show_password"`, and the `👁️` icon, ensuring the global toggle script in `app.js` correctly manages their state and translations.
+## 2026-03-12 - Toast Close Button Missing Tooltip
+**Learning:** The toast notification close buttons only had a `data-i18n-label`, but were missing a `data-i18n-title` like all other `.btn-close` buttons in the UI. Sighted mouse users didn't get a tooltip on hover for the toast close button.
+**Action:** Add `data-i18n-title="close"` to the toast close button HTML template to ensure parity with modal close buttons.
+## 2026-03-12 - Emojis vs Icon Fonts in Form Fields
+**Learning:** When standardizing form inputs, do not blindly replace existing icon font classes (like `.bi-eye`) with emojis (like `👁️`) just to match other hardcoded parts of the app. Emojis break visual consistency, don't inherit text colors (crucial for dark mode), and removing hardcoded `aria-label`s before JS hydration is an accessibility regression.
+**Action:** Avoid replacing proper icon fonts with emojis. Ensure icon-only buttons always have a fallback `aria-label` attribute in HTML.

--- a/public/app.js
+++ b/public/app.js
@@ -4314,7 +4314,7 @@ function showToast(message, type = 'primary') {
                 ${icon ? `<span class="fs-5">${icon}</span>` : ''}
                 <div>${message}</div>
             </div>
-            <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" data-i18n-label="close"></button>
+            <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" data-i18n-label="close" data-i18n-title="close"></button>
         </div>
     `;
 


### PR DESCRIPTION
💡 **What:** Added `data-i18n-title="close"` to the close button in Toast notifications.
🎯 **Why:** Previously, only a `data-i18n-label` was present. Adding the title provides a native browser tooltip for sighted mouse users hovering over the "X", ensuring parity with all other modal `.btn-close` buttons in the application.
♿ **Accessibility:** Enhances usability for sighted mouse users while maintaining existing screen reader accessibility.

---
*PR created automatically by Jules for task [7331318377891259997](https://jules.google.com/task/7331318377891259997) started by @Bladestar2105*