### PR TITLE
Fix orphaned active stream connections for HLS playlists

### DIFF
--- a/src/controllers/streamController.js
+++ b/src/controllers/streamController.js
@@ -485,9 +485,7 @@ export const proxyLive = async (req, res) => {
       res.setHeader('Expires', '0');
       res.send(newText);
 
-      if (reqExt !== 'm3u8') {
-          streamManager.remove(connectionId);
-      }
+      streamManager.remove(connectionId);
       return;
     }
 


### PR DESCRIPTION
Fixes a bug where HLS master playlist requests were leaking active stream connections due to an unreachable cleanup conditional, causing the dashboard to display incorrect (infinitely incrementing) active durations for disconnected clients.

---
*PR created automatically by Jules for task [17229608120964043614](https://jules.google.com/task/17229608120964043614) started by @Bladestar2105*