### PR TITLE
fix: increase fetch timeout to prevent AbortError during large syncs

### DIFF
--- a/src/services/syncService.js
+++ b/src/services/syncService.js
@@ -23,7 +23,7 @@ export async function checkProviderExpiry(providerId) {
     const authParams = `username=${encodeURIComponent(provider.username)}&password=${encodeURIComponent(password)}`;
 
     // Use fetch directly to get user_info
-    const resp = await fetchSafe(`${baseUrl}/player_api.php?${authParams}`);
+    const resp = await fetchSafe(`${baseUrl}/player_api.php?${authParams}`, { timeout: 30000 });
     if (!resp.ok) return null;
 
     const data = await resp.json();
@@ -99,7 +99,7 @@ export async function performSync(providerId, userId, isManual = false) {
          liveChans = await xtream.getChannels();
        } catch {
           try {
-             const resp = await fetchSafe(`${baseUrl}/player_api.php?${authParams}&action=get_live_streams`);
+             const resp = await fetchSafe(`${baseUrl}/player_api.php?${authParams}&action=get_live_streams`, { timeout: 60000 });
              if (resp.ok) {
                  const contentType = resp.headers.get('content-type');
                  if (contentType && contentType.includes('application/json')) {
@@ -113,7 +113,7 @@ export async function performSync(providerId, userId, isManual = false) {
        if (!Array.isArray(liveChans) || liveChans.length === 0) {
            try {
              // Try fetching as M3U
-             const m3uResp = await fetchSafe(provider.url); // Use original URL
+             const m3uResp = await fetchSafe(provider.url, { timeout: 60000 }); // Use original URL
              if (m3uResp.ok) {
                  const parsed = await parseM3uStream(m3uResp.body);
                  if (parsed.isM3u) {
@@ -169,7 +169,7 @@ export async function performSync(providerId, userId, isManual = false) {
        }
 
        if (!m3uMode) {
-           const respCat = await fetchSafe(`${baseUrl}/player_api.php?${authParams}&action=get_live_categories`);
+           const respCat = await fetchSafe(`${baseUrl}/player_api.php?${authParams}&action=get_live_categories`, { timeout: 60000 });
            if(respCat.ok) {
               const cats = await respCat.json();
               if (Array.isArray(cats)) {
@@ -182,7 +182,7 @@ export async function performSync(providerId, userId, isManual = false) {
     // 2. Movies (VOD)
     try {
        console.log('Fetching VOD streams...');
-       const resp = await fetchSafe(`${baseUrl}/player_api.php?${authParams}&action=get_vod_streams`);
+       const resp = await fetchSafe(`${baseUrl}/player_api.php?${authParams}&action=get_vod_streams`, { timeout: 60000 });
        if(resp.ok) {
          const vods = await resp.json();
          console.log(`Fetched ${Array.isArray(vods) ? vods.length : 'invalid'} VODs`);
@@ -197,7 +197,7 @@ export async function performSync(providerId, userId, isManual = false) {
          console.error(`VOD fetch failed: ${resp.status}`);
        }
 
-       const respCat = await fetchSafe(`${baseUrl}/player_api.php?${authParams}&action=get_vod_categories`);
+       const respCat = await fetchSafe(`${baseUrl}/player_api.php?${authParams}&action=get_vod_categories`, { timeout: 60000 });
        if(respCat.ok) {
           const cats = await respCat.json();
           if (Array.isArray(cats)) {
@@ -208,7 +208,7 @@ export async function performSync(providerId, userId, isManual = false) {
 
     // 3. Series
     try {
-       const resp = await fetchSafe(`${baseUrl}/player_api.php?${authParams}&action=get_series`);
+       const resp = await fetchSafe(`${baseUrl}/player_api.php?${authParams}&action=get_series`, { timeout: 60000 });
        if(resp.ok) {
          const series = await resp.json();
          if (Array.isArray(series)) {
@@ -223,7 +223,7 @@ export async function performSync(providerId, userId, isManual = false) {
          }
        }
 
-       const respCat = await fetchSafe(`${baseUrl}/player_api.php?${authParams}&action=get_series_categories`);
+       const respCat = await fetchSafe(`${baseUrl}/player_api.php?${authParams}&action=get_series_categories`, { timeout: 60000 });
        if(respCat.ok) {
           const cats = await respCat.json();
           if (Array.isArray(cats)) {


### PR DESCRIPTION
Increases `fetchSafe` timeouts in `src/services/syncService.js` to mitigate `AbortError`s with slow IPTV providers. Large fetches like `get_vod_streams` and `get_series` now have a 60-second timeout, up from the 15-second default.

---
*PR created automatically by Jules for task [2669549225999583374](https://jules.google.com/task/2669549225999583374) started by @Bladestar2105*