### PR TITLE
fix: copy over edited channel custom names to new users

### DIFF
--- a/src/controllers/systemController.js
+++ b/src/controllers/systemController.js
@@ -588,14 +588,14 @@ export const importData = async (req, res) => {
       }
 
       const userAssignments = importData.channels.filter(c => c.type === 'user_assignment');
-      const insertUserChannel = db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, sort_order) VALUES (?, ?, ?)');
+      const insertUserChannel = db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, sort_order, custom_name) VALUES (?, ?, ?, ?)');
 
       for (const ua of userAssignments) {
         const newUserCatId = categoryIdMap.get(ua.user_category_id);
         const newProvChannelId = providerChannelIdMap.get(ua.provider_channel_id);
 
         if (newUserCatId && newProvChannelId) {
-          insertUserChannel.run(newUserCatId, newProvChannelId, ua.sort_order);
+          insertUserChannel.run(newUserCatId, newProvChannelId, ua.sort_order, ua.custom_name || '');
           stats.channels++;
         }
       }

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -277,13 +277,13 @@ export const createUser = async (req, res) => {
                 // We need to iterate over source user's categories to find channels
                 // Or simply select all user_channels linked to source user's categories
                 const insertUserChan = db.prepare(`
-                    INSERT INTO user_channels (user_category_id, provider_channel_id, sort_order)
-                    VALUES (?, ?, ?)
+                    INSERT INTO user_channels (user_category_id, provider_channel_id, sort_order, custom_name)
+                    VALUES (?, ?, ?, ?)
                 `);
 
                 // Fetch all user channels for source user categories
                 const sourceUserChans = db.prepare(`
-                    SELECT uc.user_category_id, uc.provider_channel_id, uc.sort_order
+                    SELECT uc.user_category_id, uc.provider_channel_id, uc.sort_order, uc.custom_name
                     FROM user_channels uc
                     JOIN user_categories cat ON uc.user_category_id = cat.id
                     WHERE cat.user_id = ?
@@ -294,7 +294,7 @@ export const createUser = async (req, res) => {
                     const newProvChanId = channelMap[uc.provider_channel_id];
 
                     if (newCatId && newProvChanId) {
-                        insertUserChan.run(newCatId, newProvChanId, uc.sort_order);
+                        insertUserChan.run(newCatId, newProvChanId, uc.sort_order, uc.custom_name || '');
                     }
                 }
             }


### PR DESCRIPTION
This commit addresses the issue where `custom_name` configurations inside `user_channels` (which map directly to "edited channels") were lost when copying settings over to a new user. It ensures that the `custom_name` field is carried over properly in the database query. I also made sure that `custom_name` works properly with imports.

---
*PR created automatically by Jules for task [6546136743648572791](https://jules.google.com/task/6546136743648572791) started by @Bladestar2105*