### PR TITLE
docs: clarify default password generation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ chmod +x proxmox.sh
 
 ### First Time Setup
 - **Default Username**: `admin`
-- **Default Password**: Random 16-char hex string (check console output).
+- **Default Password**: Automatically generated (check your console output).
 - **Important**: Change password immediately after login.
 
 ### CORS Configuration


### PR DESCRIPTION
Fixes a confusing instruction in the `README.md` file regarding the default admin password.

**Problem:**
The previous instruction for the default password was "Random 16-char hex string (check console output)". Users misinterpreted this as an instruction to *create* and enter their own 16-character hex string rather than simply copying the one that the application automatically generated and printed to the terminal console. This misunderstanding caused users to fail login multiple times and get their IPs automatically banned by the system.

**Solution:**
Changed the wording in the `README.md` to:
`Automatically generated (check your console output).`

This directly tells the user where to look without suggesting they need to generate the string themselves.

---
*PR created automatically by Jules for task [13247330818977847229](https://jules.google.com/task/13247330818977847229) started by @Bladestar2105*