### PR TITLE
🎨 Palette: Add focus-visible rings and required field indicators

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -612,3 +612,24 @@ span {
 .th-w-25 { width: 25%; }
 .th-w-30 { width: 30%; }
 .qr-code-img { max-width: 200px; }
+
+/* Focus visible styles for accessibility */
+[role="button"]:focus-visible,
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+.btn:focus-visible {
+  outline: 2px solid var(--tv-cyan);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* Add visual indicator for required form fields */
+.form-label:has(+ input[required])::after,
+.form-label:has(+ select[required])::after,
+.form-label:has(+ .input-group > input[required])::after,
+.form-label:has(+ .input-group > select[required])::after {
+  content: " *";
+  color: var(--tv-red);
+}


### PR DESCRIPTION
💡 What: Added consistent keyboard focus rings (`:focus-visible`) to all interactive elements, and added a visual "required" indicator (red asterisk) to form labels next to required inputs.
🎯 Why: 
1) Sighted keyboard users could not easily see which element was currently focused, particularly on custom elements like list items that received `role="button"` via `makeAccessible`. 
2) Many forms had `required` inputs (like Username and Password) but gave no visual indication of this requirement to the user, leading to a confusing UX when attempting to submit incomplete forms.
📸 Before/After: See the attached screenshot showing the red asterisk gracefully added to the login form labels.
♿ Accessibility: Huge improvement for keyboard navigators, who now have a visible `outline: 2px solid var(--tv-cyan);` around focused elements. Sighted users are now also alerted to required fields before attempting to submit forms.

---
*PR created automatically by Jules for task [18179720630625076317](https://jules.google.com/task/18179720630625076317) started by @Bladestar2105*