### PR TITLE
fix: resolve SqliteError no such table users during initialization

### DIFF
--- a/src/database/db.js
+++ b/src/database/db.js
@@ -75,14 +75,6 @@ export function initDb(isPrimary) {
       created_at INTEGER DEFAULT (strftime('%s', 'now'))
     );
 
-    CREATE TABLE IF NOT EXISTS temporary_tokens (
-      token TEXT PRIMARY KEY,
-      user_id INTEGER NOT NULL,
-      created_at INTEGER DEFAULT (strftime('%s', 'now')),
-      expires_at INTEGER NOT NULL,
-      FOREIGN KEY (user_id) REFERENCES users(id)
-    );
-
     CREATE TABLE IF NOT EXISTS users (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       username TEXT UNIQUE NOT NULL,
@@ -92,6 +84,14 @@ export function initDb(isPrimary) {
       max_connections INTEGER DEFAULT 0,
       expiry_date INTEGER,
       allowed_countries TEXT
+    );
+
+    CREATE TABLE IF NOT EXISTS temporary_tokens (
+      token TEXT PRIMARY KEY,
+      user_id INTEGER NOT NULL,
+      created_at INTEGER DEFAULT (strftime('%s', 'now')),
+      expires_at INTEGER NOT NULL,
+      FOREIGN KEY (user_id) REFERENCES users(id)
     );
 
     CREATE TABLE IF NOT EXISTS user_categories (


### PR DESCRIPTION
Reordered the table creation sequence in `src/database/db.js` so that `users` is created before `temporary_tokens`. This satisfies the foreign key constraint and prevents `SqliteError: no such table: users` during initialization on a fresh install or new build.

---
*PR created automatically by Jules for task [5115118944950921378](https://jules.google.com/task/5115118944950921378) started by @Bladestar2105*