### PR TITLE
feat: prevent deleted provider channels from being re-added on sync

### DIFF
--- a/src/controllers/channelController.js
+++ b/src/controllers/channelController.js
@@ -190,7 +190,7 @@ export const getCategoryChannels = (req, res) => {
       FROM user_channels uc
       JOIN provider_channels pc ON pc.id = uc.provider_channel_id
       LEFT JOIN epg_channel_mappings map ON map.provider_channel_id = pc.id
-      WHERE uc.user_category_id = ?
+      WHERE uc.user_category_id = ? AND uc.is_hidden = 0
       ORDER BY uc.sort_order
     `).all(catId);
     res.json(rows);
@@ -212,9 +212,19 @@ export const addUserChannel = (req, res) => {
     const maxSort = db.prepare('SELECT COALESCE(MAX(sort_order), -1) as max_sort FROM user_channels WHERE user_category_id = ?').get(catId);
     const newSortOrder = (maxSort?.max_sort || -1) + 1;
 
-    const info = db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, sort_order) VALUES (?, ?, ?)').run(catId, Number(provider_channel_id), newSortOrder);
+    const existingHidden = db.prepare('SELECT id FROM user_channels WHERE user_category_id = ? AND provider_channel_id = ? AND is_hidden = 1').get(catId, Number(provider_channel_id));
+
+    let insertId;
+    if (existingHidden) {
+        db.prepare('UPDATE user_channels SET is_hidden = 0, sort_order = ? WHERE id = ?').run(newSortOrder, existingHidden.id);
+        insertId = existingHidden.id;
+    } else {
+        const info = db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, sort_order) VALUES (?, ?, ?)').run(catId, Number(provider_channel_id), newSortOrder);
+        insertId = info.lastInsertRowid;
+    }
+
     clearChannelsCache(cat.user_id);
-    res.json({id: info.lastInsertRowid});
+    res.json({id: insertId});
   } catch (e) { res.status(500).json({error: e.message}); }
 };
 
@@ -262,7 +272,7 @@ export const deleteUserChannel = (req, res) => {
         return res.status(403).json({error: 'Access denied'});
     }
 
-    db.prepare('DELETE FROM user_channels WHERE id = ?').run(id);
+    db.prepare('UPDATE user_channels SET is_hidden = 1 WHERE id = ?').run(id);
     clearChannelsCache(channel.user_id);
     res.json({success: true});
   } catch (e) {
@@ -298,7 +308,7 @@ export const bulkDeleteUserChannels = (req, res) => {
         }
     }
 
-    db.prepare(`DELETE FROM user_channels WHERE id IN (${placeholders})`).run(...ids);
+    db.prepare(`UPDATE user_channels SET is_hidden = 1 WHERE id IN (${placeholders})`).run(...ids);
 
     userIdsToClear.forEach(uId => clearChannelsCache(uId));
     res.json({success: true, deleted: ids.length});

--- a/src/controllers/hdhrController.js
+++ b/src/controllers/hdhrController.js
@@ -76,7 +76,7 @@ export const lineup = async (req, res) => {
       FROM user_channels uc
       JOIN provider_channels pc ON pc.id = uc.provider_channel_id
       JOIN user_categories cat ON cat.id = uc.user_category_id
-      WHERE cat.user_id = ? AND pc.stream_type = 'live'
+      WHERE cat.user_id = ? AND pc.stream_type = 'live' AND uc.is_hidden = 0
       ORDER BY uc.sort_order
     `).all(user.id);
 
@@ -118,7 +118,7 @@ export const auto = async (req, res) => {
       FROM user_channels uc
       JOIN provider_channels pc ON pc.id = uc.provider_channel_id
       JOIN user_categories cat ON cat.id = uc.user_category_id
-      WHERE uc.id = ? AND cat.user_id = ?
+      WHERE uc.id = ? AND cat.user_id = ? AND uc.is_hidden = 0
     `).get(channelId, user.id);
 
     if (!channel) return res.status(404).send('Channel not found');

--- a/src/controllers/xtreamController.js
+++ b/src/controllers/xtreamController.js
@@ -82,7 +82,7 @@ export const playerApi = async (req, res) => {
         FROM user_categories cat
         JOIN user_channels uc ON uc.user_category_id = cat.id
         JOIN provider_channels pc ON pc.id = uc.provider_channel_id
-        WHERE cat.user_id = ? AND pc.stream_type = ?
+        WHERE cat.user_id = ? AND pc.stream_type = ? AND uc.is_hidden = 0
         ORDER BY cat.sort_order
       `).all(user.id, type);
 
@@ -115,7 +115,7 @@ export const playerApi = async (req, res) => {
         JOIN provider_channels pc ON pc.id = uc.provider_channel_id
         JOIN user_categories cat ON cat.id = uc.user_category_id
         LEFT JOIN epg_channel_mappings map ON map.provider_channel_id = pc.id
-        WHERE cat.user_id = ? AND pc.stream_type = 'live'`;
+        WHERE cat.user_id = ? AND pc.stream_type = 'live' AND uc.is_hidden = 0`;
       const params = [user.id];
 
       if (categoryId && categoryId !== '*' && categoryId !== '0') {
@@ -157,7 +157,7 @@ export const playerApi = async (req, res) => {
         FROM user_channels uc
         JOIN provider_channels pc ON pc.id = uc.provider_channel_id
         JOIN user_categories cat ON cat.id = uc.user_category_id
-        WHERE cat.user_id = ? AND pc.stream_type = 'movie'`;
+        WHERE cat.user_id = ? AND pc.stream_type = 'movie' AND uc.is_hidden = 0`;
       const params = [user.id];
 
       if (categoryId && categoryId !== '*' && categoryId !== '0') {
@@ -198,7 +198,7 @@ export const playerApi = async (req, res) => {
         FROM user_channels uc
         JOIN provider_channels pc ON pc.id = uc.provider_channel_id
         JOIN user_categories cat ON cat.id = uc.user_category_id
-        WHERE cat.user_id = ? AND pc.stream_type = 'series'`;
+        WHERE cat.user_id = ? AND pc.stream_type = 'series' AND uc.is_hidden = 0`;
       const params = [user.id];
 
       if (categoryId && categoryId !== '*' && categoryId !== '0') {
@@ -253,7 +253,7 @@ export const playerApi = async (req, res) => {
         JOIN provider_channels pc ON pc.id = uc.provider_channel_id
         JOIN providers p ON p.id = pc.provider_id
         JOIN user_categories cat ON cat.id = uc.user_category_id
-        WHERE uc.id = ? AND cat.user_id = ?
+        WHERE uc.id = ? AND cat.user_id = ? AND uc.is_hidden = 0
       `).get(seriesId, user.id);
 
       if (!channel) return res.json({});
@@ -305,7 +305,7 @@ export const playerApi = async (req, res) => {
         JOIN provider_channels pc ON pc.id = uc.provider_channel_id
         JOIN providers p ON p.id = pc.provider_id
         JOIN user_categories cat ON cat.id = uc.user_category_id
-        WHERE uc.id = ? AND cat.user_id = ?
+        WHERE uc.id = ? AND cat.user_id = ? AND uc.is_hidden = 0
       `).get(vodId, user.id);
 
       if (!channel) return res.json({});
@@ -352,7 +352,7 @@ export const playerApi = async (req, res) => {
         JOIN provider_channels pc ON pc.id = uc.provider_channel_id
         JOIN user_categories cat ON cat.id = uc.user_category_id
         LEFT JOIN epg_channel_mappings map ON map.provider_channel_id = pc.id
-        WHERE uc.id = ? AND cat.user_id = ?
+        WHERE uc.id = ? AND cat.user_id = ? AND uc.is_hidden = 0
       `).get(streamId, user.id);
 
       if (!channel) return res.json({epg_listings: []});
@@ -410,7 +410,7 @@ export const getPlaylist = async (req, res) => {
       JOIN provider_channels pc ON pc.id = uc.provider_channel_id
       JOIN user_categories cat ON cat.id = uc.user_category_id
       LEFT JOIN epg_channel_mappings map ON map.provider_channel_id = pc.id
-      WHERE cat.user_id = ?
+      WHERE cat.user_id = ? AND uc.is_hidden = 0
       ORDER BY uc.sort_order
     `).all(user.id);
 
@@ -494,7 +494,7 @@ export const xmltv = async (req, res) => {
         JOIN provider_channels pc ON pc.id = uc.provider_channel_id
         JOIN user_categories cat ON cat.id = uc.user_category_id
         LEFT JOIN epg_channel_mappings map ON map.provider_channel_id = pc.id
-        WHERE cat.user_id = ?
+        WHERE cat.user_id = ? AND uc.is_hidden = 0
         AND (map.epg_channel_id IS NOT NULL OR pc.epg_channel_id IS NOT NULL)
     `).all(user.id);
 
@@ -553,7 +553,7 @@ export const playerChannelsJson = async (req, res) => {
       JOIN provider_channels pc ON pc.id = uc.provider_channel_id
       JOIN user_categories cat ON cat.id = uc.user_category_id
       LEFT JOIN epg_channel_mappings map ON map.provider_channel_id = pc.id
-      WHERE cat.user_id = ? AND pc.stream_type != 'series'
+      WHERE cat.user_id = ? AND pc.stream_type != 'series' AND uc.is_hidden = 0
       ORDER BY uc.sort_order
     `).all(user.id);
 
@@ -672,7 +672,7 @@ export const playerPlaylist = async (req, res) => {
       JOIN provider_channels pc ON pc.id = uc.provider_channel_id
       JOIN user_categories cat ON cat.id = uc.user_category_id
       LEFT JOIN epg_channel_mappings map ON map.provider_channel_id = pc.id
-      WHERE cat.user_id = ? AND pc.stream_type != 'series'
+      WHERE cat.user_id = ? AND pc.stream_type != 'series' AND uc.is_hidden = 0
       ORDER BY uc.sort_order
     `).all(user.id);
 

--- a/src/database/db.js
+++ b/src/database/db.js
@@ -108,7 +108,8 @@ export function initDb(isPrimary) {
       user_category_id INTEGER NOT NULL,
       provider_channel_id INTEGER NOT NULL,
       sort_order INTEGER DEFAULT 0,
-      custom_name TEXT DEFAULT ''
+      custom_name TEXT DEFAULT '',
+      is_hidden INTEGER DEFAULT 0
     );
 
     CREATE TABLE IF NOT EXISTS user_backups (
@@ -268,6 +269,7 @@ export function initDb(isPrimary) {
             migrations.migrateUserTokenVersion(db);
             migrations.migrateUserAllowedCountries(db);
             migrations.migrateUserChannelsCustomName(db);
+            migrations.migrateUserChannelsIsHidden(db);
 
             // Clear ephemeral streams
             db.exec('DELETE FROM current_streams');

--- a/src/database/migrations.js
+++ b/src/database/migrations.js
@@ -722,3 +722,17 @@ export function migrateUserChannelsCustomName(db) {
     console.error('User Channels Custom Name migration error:', e);
   }
 }
+
+export function migrateUserChannelsIsHidden(db) {
+  try {
+    const tableInfo = db.prepare("PRAGMA table_info(user_channels)").all();
+    const columns = tableInfo.map(c => c.name);
+
+    if (!columns.includes('is_hidden')) {
+      db.exec('ALTER TABLE user_channels ADD COLUMN is_hidden INTEGER DEFAULT 0');
+      console.log('✅ DB Migration: is_hidden column added to user_channels');
+    }
+  } catch (e) {
+    console.error('User Channels is_hidden migration error:', e);
+  }
+}


### PR DESCRIPTION
Added an `is_hidden` column to the `user_channels` table to facilitate soft-deletion of channels. When a user deletes a channel or bulk deletes channels via the UI, the `is_hidden` flag is now set to 1 instead of executing a hard DELETE.

This allows the provider synchronization process (`syncService`) to recognize that the channel assignment already exists, preventing it from being incorrectly re-added to the user's category during the next sync interval. If the provider moves the channel to a new category, the sync service will correctly remove the hidden assignment and re-add it as visible in the new category.

Additionally:
- Updated `xtreamController`, `hdhrController`, and `channelController` endpoints to filter out `is_hidden = 1` channels from all playlists and APIs.
- Updated `addUserChannel` logic to recycle a hidden row (resetting `is_hidden` to 0) if the user manually attempts to re-add a channel they previously hid, avoiding database UNIQUE constraint collisions or requiring frontend refactoring.
- Created `migrateUserChannelsIsHidden` migration to seamlessly apply schema updates.

---
*PR created automatically by Jules for task [12050739211874525949](https://jules.google.com/task/12050739211874525949) started by @Bladestar2105*