### PR TITLE
fix: Increase proxy image fetch timeout and handle AbortError

### DIFF
--- a/src/routes/proxy.js
+++ b/src/routes/proxy.js
@@ -94,7 +94,7 @@ router.get('/image', authenticateAnyToken, async (req, res) => {
           'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
         Accept: 'image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8',
       },
-      // timeout: 5000 // Add timeout? default is usually fine but maybe too long.
+      timeout: 30000
     });
 
     if (!response.ok) {
@@ -234,7 +234,7 @@ router.get('/image', authenticateAnyToken, async (req, res) => {
       return res.status(502).send('Bad Gateway (Upstream Unreachable)');
     }
 
-    if (error.code === 'ETIMEDOUT') {
+    if (error.code === 'ETIMEDOUT' || error.name === 'AbortError' || error.type === 'aborted') {
       return res.status(504).send('Gateway Timeout');
     }
 


### PR DESCRIPTION
Addresses an issue where fetching images from slow external servers triggers a timeout (via `AbortError` from `fetchSafe`), resulting in a `500 Internal Server Error`. This PR increases the allowed fetch duration to 30 seconds and properly catches the timeout abort to return a `504 Gateway Timeout`.

---
*PR created automatically by Jules for task [5274023765505104600](https://jules.google.com/task/5274023765505104600) started by @Bladestar2105*