### PR TITLE
🎨 Palette: Improve navbar toggler accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2026-03-12 - Emojis vs Icon Fonts in Form Fields
 **Learning:** When standardizing form inputs, do not blindly replace existing icon font classes (like `.bi-eye`) with emojis (like `👁️`) just to match other hardcoded parts of the app. Emojis break visual consistency, don't inherit text colors (crucial for dark mode), and removing hardcoded `aria-label`s before JS hydration is an accessibility regression.
 **Action:** Avoid replacing proper icon fonts with emojis. Ensure icon-only buttons always have a fallback `aria-label` attribute in HTML.
+## 2026-03-18 - Add ARIA attributes to mobile navbar toggler
+**Learning:** The Bootstrap mobile navbar toggle button (`.navbar-toggler`) was missing standard ARIA attributes (`aria-controls` and `aria-expanded`), causing screen readers to not properly announce its state or purpose.
+**Action:** When implementing or modifying Bootstrap collapse components, always explicitly initialize `aria-controls="<target_id>"` and `aria-expanded="false"` in the HTML markup. Bootstrap's JS will handle toggling the state, but the initial markup must be compliant.

--- a/public/index.html
+++ b/public/index.html
@@ -23,7 +23,7 @@
         <img src="logo.png" alt="IPTV-Manager Logo" width="30" height="30" class="d-inline-block align-text-top">
         IPTV-Manager
       </a>
-      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" data-i18n-label="toggleNavigation">
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" data-i18n-label="toggleNavigation">
         <span class="navbar-toggler-icon"></span>
       </button>
       <div class="collapse navbar-collapse" id="navbarNav">


### PR DESCRIPTION
**What:**
Added `aria-controls="navbarNav"` and `aria-expanded="false"` to the `.navbar-toggler` button.

**Why:**
This improves accessibility for screen reader users by properly describing the button's action and state when accessing the site via a mobile device or a narrow viewport. 

**Accessibility:**
The missing ARIA attributes were added to the `navbar-toggler` button making the initial HTML compliant.

---
*PR created automatically by Jules for task [13623482567501243150](https://jules.google.com/task/13623482567501243150) started by @Bladestar2105*