### PR TITLE
⚡ Bolt: Optimize provider channel sorting with composite index

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -23,3 +23,7 @@
 ## 2026-03-17 - SQLite Rate Limiting Query Optimization
 **Learning:** Querying log tables (like `security_logs`) without proper indices for rate-limiting operations (e.g., checking failed logins) can result in continuous full table scans. During brute-force attacks or frequent automated scans, this degrades performance exponentially, consuming vast amounts of CPU and blocking the event loop since SQLite operates synchronously in the Node thread.
 **Action:** Always ensure that time-series log tables queried for rate-limiting or aggregate analysis have composite indices matching the primary access patterns, typically `(identifier, timestamp)` or `(timestamp)` depending on whether queries filter by specific entities.
+
+## 2026-03-19 - SQLite Temp B-Trees on Ordered Filtering
+**Learning:** Filtering and then ordering a large dataset in SQLite (e.g., `WHERE provider_id = ? ORDER BY original_sort_order ASC, name ASC`) will force the engine to allocate a temporary B-tree for the sort pass if the used index does not cover the sorting columns sequentially after the filtered ones. For datasets with millions of rows, this results in O(N log N) overhead per query instead of O(N) linear read.
+**Action:** When filtering by `A` and `B` and ordering by `C` and `D`, create a strict composite index `(A, B, C, D)` to allow SQLite to walk the B-tree sequentially without additional memory allocation or sorting passes.

--- a/src/database/db.js
+++ b/src/database/db.js
@@ -232,6 +232,10 @@ export function initDb(isPrimary) {
     CREATE INDEX IF NOT EXISTS idx_user_channels_cat_sort ON user_channels(user_category_id, sort_order);
     CREATE INDEX IF NOT EXISTS idx_user_channels_prov ON user_channels(provider_channel_id);
 
+    -- ⚡ Bolt: Add composite indexes for rapid filtering and sorting in provider endpoints without creating Temp B-trees
+    CREATE INDEX IF NOT EXISTS idx_pc_prov_type_sort_name ON provider_channels(provider_id, stream_type, original_sort_order, name);
+    CREATE INDEX IF NOT EXISTS idx_pc_prov_type_cat_sort_name ON provider_channels(provider_id, stream_type, original_category_id, original_sort_order, name);
+
     -- ⚡ Bolt: Add composite index for rapid rate-limiting queries to prevent full table scans during brute-force DoS attacks
     CREATE INDEX IF NOT EXISTS idx_security_logs_ip_time ON security_logs(ip, timestamp);
   `);

--- a/src/database/migrations.js
+++ b/src/database/migrations.js
@@ -370,6 +370,10 @@ export function migrateIndexes(db) {
     db.exec('CREATE INDEX IF NOT EXISTS idx_sync_logs_prov ON sync_logs(provider_id)');
     db.exec('CREATE INDEX IF NOT EXISTS idx_current_streams_prov ON current_streams(provider_id)');
 
+    // ⚡ Bolt: Add composite indexes for rapid filtering and sorting in provider endpoints without creating Temp B-trees
+    db.exec('CREATE INDEX IF NOT EXISTS idx_pc_prov_type_sort_name ON provider_channels(provider_id, stream_type, original_sort_order, name)');
+    db.exec('CREATE INDEX IF NOT EXISTS idx_pc_prov_type_cat_sort_name ON provider_channels(provider_id, stream_type, original_category_id, original_sort_order, name)');
+
     // ⚡ Bolt: Add composite index for rapid rate-limiting queries to prevent full table scans during brute-force DoS attacks
     db.exec('CREATE INDEX IF NOT EXISTS idx_security_logs_ip_time ON security_logs(ip, timestamp)');
 


### PR DESCRIPTION
💡 **What:** Added composite indexes `idx_pc_prov_type_sort_name` and `idx_pc_prov_type_cat_sort_name` to the `provider_channels` table in `src/database/db.js` and `src/database/migrations.js` that sequentially cover the sorted properties after filtering (`original_sort_order`, `name`).
🎯 **Why:** To prevent SQLite from allocating and building expensive temporary B-trees in memory to fulfill `ORDER BY original_sort_order ASC, name ASC` operations when querying large providers, while rigorously preserving the provider's original sort order.
📊 **Impact:** Reduces O(N log N) overhead down to O(1) index access + linear walk, eliminating a significant CPU and memory bottleneck when retrieving or syncing huge IPTV datasets containing tens or hundreds of thousands of channels.
🔬 **Measurement:** `EXPLAIN QUERY PLAN` on endpoints hitting `provider_channels` filtering by provider now shows `USING COVERING INDEX` without any `USE TEMP B-TREE FOR ORDER BY` overhead.

---
*PR created automatically by Jules for task [11414858496795512444](https://jules.google.com/task/11414858496795512444) started by @Bladestar2105*