### PR TITLE
fix(epg): correctly parse language from channel names with leading separators

### DIFF
--- a/src/services/channelMatcher.js
+++ b/src/services/channelMatcher.js
@@ -2,6 +2,9 @@ import ISO6391 from 'iso-639-1';
 
 // Optimization: Pre-compile regex patterns to avoid re-compilation on every match
 const CHANNEL_NAME_PATTERNS = [
+  // "| DE | Arte", "[EN] CNN", "|FR| TF1", "(DE) RTL"
+  /^[\|\-_\.\[\]\(\)]+\s*([A-Z]{2,3})\s*[\-_\.\|:\]\)]+\s*(.+)$/i,
+
   // "DE: Arte", "EN: CNN", "DE| RTL", "DE - RTL"
   /^([A-Z]{2,3})\s*[\-_\.\|:]\s*(.+)$/i,
 

--- a/tests/channel_matcher.test.js
+++ b/tests/channel_matcher.test.js
@@ -56,6 +56,20 @@ describe('ChannelMatcher', () => {
         expect(result.epgChannel.id).toBe('03');
     });
 
+    it('handles leading separators correctly (e.g. | DE | CHANNEL)', () => {
+        const result1 = matcher.parseChannelName('| DE | NICK TOONS HD');
+        expect(result1.language).toBe('de');
+        expect(result1.baseName).toContain('nick toons');
+
+        const result2 = matcher.parseChannelName('[EN] CNN');
+        expect(result2.language).toBe('en');
+        expect(result2.baseName).toBe('cnn');
+
+        const result3 = matcher.match('| DE | RTL TELEVISION');
+        expect(result3.epgChannel).not.toBeNull();
+        expect(result3.epgChannel.id).toBe('3'); // Maps to RTL Television
+    });
+
     it('matches fuzzy names', () => {
         const result = matcher.match('Sky Cin. Action');
         expect(result.epgChannel.id).toBe('10');


### PR DESCRIPTION
Fixes an issue where EPG auto-mapping chooses incorrect languages (like `nl` or `fr` instead of `de`) for channels with names formatted with leading separators, such as `| DE | NICK TOONS HD`. 

The core issue was that the regex patterns in `channelMatcher.js` required the language code to be at the exact beginning of the string (e.g., `DE | `). Any preceding pipe, bracket, or hyphen caused parsing to fail, falling back to a fuzzy match across all languages instead of prioritizing the extracted language.

- Added regex pattern `/^[\|\-_\.\[\]\(\)]+\s*([A-Z]{2,3})\s*[\-_\.\|:\]\)]+\s*(.+)$/i` to `CHANNEL_NAME_PATTERNS`.
- Added a corresponding unit test to `channel_matcher.test.js` covering `| DE | NICK TOONS HD` and `| DE | RTL TELEVISION` inputs.

---
*PR created automatically by Jules for task [12420161407017162597](https://jules.google.com/task/12420161407017162597) started by @Bladestar2105*