### PR TITLE
fix: Return integer connection counts in XTream API

### DIFF
--- a/src/controllers/xtreamController.js
+++ b/src/controllers/xtreamController.js
@@ -60,9 +60,9 @@ export const playerApi = async (req, res) => {
           status: 'Active',
           exp_date: user.expiry_date ? Math.floor(new Date(user.expiry_date).getTime() / 1000).toString() : '1773864593',
           is_trial: '0',
-          active_cons: activeCons.toString(),
+          active_cons: activeCons,
           created_at: now.toString(),
-          max_connections: user.max_connections === 0 ? '999999' : (user.max_connections || '1').toString(),
+          max_connections: user.max_connections === 0 ? 999999 : (user.max_connections || 1),
           allowed_output_formats: ['m3u8', 'ts']
         },
         server_info: {


### PR DESCRIPTION
This PR fixes a payload typing issue in the XTream API login endpoint (`player_api.php`). Previously, the `active_cons` and `max_connections` fields were being serialized as strings, causing strict-parsing IPTV clients (like IPTV Smarters) to throw an "Active connection is not recognised" error when attempting to log in. This patch converts them back to native integers in the JSON payload.

---
*PR created automatically by Jules for task [17000921698661662156](https://jules.google.com/task/17000921698661662156) started by @Bladestar2105*