### PR TITLE
Fix EPG Icon activation setting not being saved

### DIFF
--- a/src/controllers/providerController.js
+++ b/src/controllers/providerController.js
@@ -85,7 +85,7 @@ export const getProviders = (req, res) => {
 export const createProvider = async (req, res) => {
   try {
     if (!req.user.is_admin) return res.status(403).json({error: 'Access denied'});
-    const { name, url, username, password, epg_url, user_id, epg_update_interval, epg_enabled, backup_urls, user_agent, max_connections } = req.body;
+    const { name, url, username, password, epg_url, user_id, epg_update_interval, epg_enabled, backup_urls, user_agent, max_connections, use_mapped_epg_icon } = req.body;
     if (!name || !url || !username || !password) return res.status(400).json({error: 'missing'});
 
     if (!/^https?:\/\//i.test(url.trim())) {
@@ -171,8 +171,8 @@ export const createProvider = async (req, res) => {
     const encryptedPassword = encrypt(password.trim());
 
     const info = db.prepare(`
-      INSERT INTO providers (name, url, username, password, epg_url, user_id, epg_update_interval, epg_enabled, backup_urls, user_agent, max_connections)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO providers (name, url, username, password, epg_url, user_id, epg_update_interval, epg_enabled, backup_urls, user_agent, max_connections, use_mapped_epg_icon)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       name.trim(),
       url.trim(),
@@ -184,7 +184,8 @@ export const createProvider = async (req, res) => {
       epg_enabled !== undefined ? (epg_enabled ? 1 : 0) : 1,
       processedBackupUrls,
       user_agent ? user_agent.trim() : null,
-      finalMaxConnections
+      finalMaxConnections,
+      use_mapped_epg_icon ? 1 : 0
     );
 
     // Check expiry
@@ -203,7 +204,7 @@ export const updateProvider = async (req, res) => {
   try {
     if (!req.user.is_admin) return res.status(403).json({error: 'Access denied'});
     const id = Number(req.params.id);
-    const { name, url, username, password, epg_url, user_id, epg_update_interval, epg_enabled, backup_urls, user_agent, max_connections } = req.body;
+    const { name, url, username, password, epg_url, user_id, epg_update_interval, epg_enabled, backup_urls, user_agent, max_connections, use_mapped_epg_icon } = req.body;
     if (!name || !url || !username || !password) {
       return res.status(400).json({error: 'missing fields'});
     }
@@ -293,7 +294,7 @@ export const updateProvider = async (req, res) => {
 
     db.prepare(`
       UPDATE providers
-      SET name = ?, url = ?, username = ?, password = ?, epg_url = ?, user_id = ?, epg_update_interval = ?, epg_enabled = ?, backup_urls = ?, user_agent = ?, max_connections = ?
+      SET name = ?, url = ?, username = ?, password = ?, epg_url = ?, user_id = ?, epg_update_interval = ?, epg_enabled = ?, backup_urls = ?, user_agent = ?, max_connections = ?, use_mapped_epg_icon = ?
       WHERE id = ?
     `).run(
       name.trim(),
@@ -307,6 +308,7 @@ export const updateProvider = async (req, res) => {
       processedBackupUrls,
       user_agent ? user_agent.trim() : null,
       finalMaxConnections,
+      use_mapped_epg_icon !== undefined ? (use_mapped_epg_icon ? 1 : 0) : existing.use_mapped_epg_icon,
       id
     );
 

--- a/tests/provider_backup.test.js
+++ b/tests/provider_backup.test.js
@@ -7,7 +7,8 @@ const { mockDb, mockFetch } = vi.hoisted(() => {
     return {
         mockDb: {
             prepare: vi.fn(),
-            exec: vi.fn()
+            exec: vi.fn(),
+            pragma: vi.fn(),
         },
         mockFetch: vi.fn()
     };


### PR DESCRIPTION
The issue "EPG Icon activation is not saved, the checkbox keeps unchecking" was caused by the `use_mapped_epg_icon` property not being properly extracted and saved in `providerController.js` when processing the HTTP request to update or create a provider.

This commit updates `createProvider` and `updateProvider` in `src/controllers/providerController.js` to extract `use_mapped_epg_icon` from the request body and include it in the `INSERT INTO` and `UPDATE` SQL queries, ensuring the configuration persists in the `providers` table correctly.

---
*PR created automatically by Jules for task [7677219191243071147](https://jules.google.com/task/7677219191243071147) started by @Bladestar2105*