### PR TITLE
fix: correct EPG auto-mapping historical bypass

### DIFF
--- a/src/controllers/epgController.js
+++ b/src/controllers/epgController.js
@@ -449,12 +449,6 @@ export const autoMapping = async (req, res) => {
 
     if (channels.length === 0) return res.json({matched: 0, message: 'No unmapped channels found'});
 
-    const globalMappings = db.prepare(`
-      SELECT pc.name, map.epg_channel_id
-      FROM epg_channel_mappings map
-      JOIN provider_channels pc ON pc.id = map.provider_channel_id
-    `).all();
-
     // Load ALL EPG Channels from DB to pass to worker
     const allEpgChannels = await loadAllEpgChannels();
 
@@ -465,8 +459,7 @@ export const autoMapping = async (req, res) => {
     const worker = new Worker(path.join(process.cwd(), 'src', 'workers', 'epgWorker.js'), {
       workerData: {
         channels,
-        allEpgChannels,
-        globalMappings
+        allEpgChannels
       }
     });
 

--- a/src/workers/epgWorker.js
+++ b/src/workers/epgWorker.js
@@ -1,33 +1,14 @@
 import { parentPort, workerData } from 'worker_threads';
 import { ChannelMatcher } from '../services/channelMatcher.js';
 
-export function matchChannels(channels, allEpgChannels, globalMappings) {
+export function matchChannels(channels, allEpgChannels) {
     const updates = [];
     let matched = 0;
-
-    // 1. Build Global Map (History)
-    const globalMap = new Map();
-    if (globalMappings) {
-        for (const m of globalMappings) {
-            // We use a stricter normalization for global mappings to avoid cross-language false positives
-            const clean = m.name ? m.name.toLowerCase().replace(/\s+/g, ' ').trim() : '';
-            if (clean) globalMap.set(clean, m.epg_channel_id);
-        }
-    }
 
     const matcher = new ChannelMatcher(allEpgChannels);
 
     for (const ch of channels) {
-       // A. Prioritize Global Mappings
-       const cleaned = ch.name ? ch.name.toLowerCase().replace(/\s+/g, ' ').trim() : '';
-       if (cleaned && globalMap.has(cleaned)) {
-           const epgId = globalMap.get(cleaned);
-           updates.push({pid: ch.id, eid: epgId});
-           matched++;
-           continue;
-       }
-
-       // B. Automapping
+       // Automapping
        const result = matcher.match(ch.name, ch.epg_id);
 
        if (result.epgChannel) {
@@ -42,10 +23,10 @@ export function matchChannels(channels, allEpgChannels, globalMappings) {
 async function run() {
   if (!workerData) return; // Not running in worker thread
 
-  const { channels, allEpgChannels, globalMappings } = workerData;
+  const { channels, allEpgChannels } = workerData;
 
   try {
-    const { updates, matched } = matchChannels(channels, allEpgChannels || [], globalMappings);
+    const { updates, matched } = matchChannels(channels, allEpgChannels || []);
     parentPort.postMessage({ success: true, updates, matched });
 
   } catch (e) {


### PR DESCRIPTION
Fixes an issue where EPG auto-mapping applied incorrect channel assignments despite manual suggestions providing a 100% correct match. The bug was traced to `epgWorker.js`, which prioritized a history cache of global mappings (`epg_channel_mappings`) over the actual fuzzy matching algorithm (`ChannelMatcher.js`), perpetuating past mistakes. Removed the historical bypass.

---
*PR created automatically by Jules for task [14610681804018387640](https://jules.google.com/task/14610681804018387640) started by @Bladestar2105*