### PR TITLE
🧹 remove unused path import from epgDb.js

### DIFF
--- a/src/database/epgDb.js
+++ b/src/database/epgDb.js
@@ -1,5 +1,4 @@
 import Database from 'better-sqlite3';
-import path from 'path';
 import fs from 'fs';
 import { DATA_DIR, EPG_DB_PATH } from '../config/constants.js';
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `path` import from `src/database/epgDb.js`.
💡 **Why:** Removing unused imports improves code maintainability and readability by reducing noise.
✅ **Verification:** Verified the syntactic correctness of the file using `node -c src/database/epgDb.js`. Confirmed the import was unused via `grep`.
✨ **Result:** Cleaner code in `src/database/epgDb.js`.

---
*PR created automatically by Jules for task [3553779778414277176](https://jules.google.com/task/3553779778414277176) started by @Bladestar2105*