### PR TITLE
⚡ Bolt: Replace Promise.all with sequential file deletion

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,7 @@
 ## 2024-05-18 - [SQLite Performance: Replace .all().map() with .iterate()]
 **Learning:** When rendering huge payloads in SQLite endpoints (like xtreamController.js generating tens of thousands of channel entries), chaining .all() to fetch all rows into a massive array followed by .map() duplicates memory allocations and causes V8 GC pressure.
 **Action:** Always use stmt.iterate() in a for...of loop to stream rows natively from better-sqlite3 when handling massive datasets, pushing directly to the final payload array.
+
+## 2024-04-07 - [Promise.all with Mass File I/O]
+**Learning:** Using `Promise.all` with `fs.promises.unlink` for massive file I/O operations (like pruning a large picon cache) can rapidly exhaust the system's file descriptors (`EMFILE`) and block the Node.js event loop due to spawning thousands of concurrent promises.
+**Action:** Always use sequential `for...of` loops or batched processing chunks when performing file system operations on unbound, potentially massive arrays of files.

--- a/src/routes/proxy.js
+++ b/src/routes/proxy.js
@@ -298,7 +298,11 @@ router.delete('/picons', authenticateToken, async (req, res) => {
             throw err;
         }
 
-        await Promise.all(files.map(file => fs.promises.unlink(path.join(PICON_CACHE_DIR, file))));
+        // ⚡ Bolt: Replace Promise.all with sequential file deletion
+        // 🎯 Why: Promise.all with thousands of files can exhaust file descriptors and block the event loop
+        for (const file of files) {
+            await fs.promises.unlink(path.join(PICON_CACHE_DIR, file));
+        }
 
         // Also clear the provider_icon_cache table
         try {


### PR DESCRIPTION
💡 **What:** Replaced `Promise.all` with a sequential `for...of` loop in `src/routes/proxy.js` for massive file deletions.
🎯 **Why:** Using `Promise.all` with thousands of files can exhaust system file descriptors (`EMFILE`) and block the Node.js event loop due to spawning thousands of concurrent promises.
📊 **Impact:** Prevents server crashes and event loop blocking during cache pruning, greatly improving system stability.
🔬 **Measurement:** Verify the application handles cache pruning gracefully when dealing with a massive amount of cached picons without exhausting file descriptors.

---
*PR created automatically by Jules for task [14995227534382634474](https://jules.google.com/task/14995227534382634474) started by @Bladestar2105*