### PR TITLE
Fix stream termination across cluster workers

### DIFF
--- a/src/controllers/systemController.js
+++ b/src/controllers/systemController.js
@@ -888,9 +888,27 @@ export const terminateActiveStream = async (req, res) => {
     if (!streamId) return res.status(400).json({ error: 'Stream ID required' });
 
     const allStreams = await streamManager.getAll();
-    const exists = allStreams.some(s => s.id === streamId);
-    if (!exists) return res.status(404).json({ error: 'Stream not found' });
+    const stream = allStreams.find(s => s.id === streamId);
+    if (!stream) return res.status(404).json({ error: 'Stream not found' });
 
+    // If the stream belongs to this worker, terminate directly.
+    if (!stream.worker_pid || stream.worker_pid === process.pid) {
+      await streamManager.remove(streamId);
+      return res.json({ success: true });
+    }
+
+    // In cluster mode, ask primary process to forward the terminate command
+    // to the worker that owns this stream resource.
+    if (typeof process.send === 'function') {
+      process.send({
+        type: 'terminate_stream',
+        streamId,
+        targetPid: stream.worker_pid
+      });
+      return res.json({ success: true, forwarded: true });
+    }
+
+    // Single-process fallback.
     await streamManager.remove(streamId);
     res.json({ success: true });
   } catch (e) {

--- a/src/server.js
+++ b/src/server.js
@@ -72,8 +72,28 @@ let redisClient = null;
       const newWorker = cluster.fork(env);
       if (isScheduler) schedulerPid = newWorker.process.pid;
     });
+
+    // Forward stream termination requests to the worker that owns the stream.
+    cluster.on('message', (worker, message) => {
+      if (!message || message.type !== 'terminate_stream' || !message.targetPid || !message.streamId) return;
+      const targetWorker = Object.values(cluster.workers).find(w => w && w.process && w.process.pid === message.targetPid);
+      if (!targetWorker) return;
+      targetWorker.send({
+        type: 'terminate_stream',
+        streamId: message.streamId
+      });
+    });
   } else {
     // Worker Process
+
+    process.on('message', async (message) => {
+      if (!message || message.type !== 'terminate_stream' || !message.streamId) return;
+      try {
+        await streamManager.remove(message.streamId);
+      } catch (e) {
+        console.error('Failed to terminate forwarded stream:', e.message);
+      }
+    });
 
     // Start Schedulers if flagged
     if (process.env.IS_SCHEDULER === 'true') {


### PR DESCRIPTION
### Motivation
- Active streams were only removed from the tracking store when terminated from a different worker, which hid the stream in the UI but did not stop the actual worker-local resource.
- The change ensures the owning worker performs the actual teardown so playback is truly stopped instead of merely being hidden.

### Description
- `terminateActiveStream` in `src/controllers/systemController.js` now looks up the owning stream and, if the stream belongs to the current process, calls `streamManager.remove(streamId)` directly.
- If the stream is owned by another worker, the endpoint sends an IPC message (`process.send`) with `type: 'terminate_stream'` and the target worker PID so the primary can forward it to the correct worker.  
- `src/server.js` was updated so the primary process routes `terminate_stream` messages to the worker with the matching `targetPid`, and workers listen for forwarded `terminate_stream` messages and call `streamManager.remove(streamId)` locally.  
- A single-process fallback still removes the stream if IPC is not available.

### Testing
- Ran `npm run lint`, which completed successfully (project has existing warnings but no new errors introduced by this change). 
- Ran `npx vitest run tests/system/terminate_stream.test.js`, which passed (3/3 tests). 
- Ran full test suite with `npm test`; many suites failed in this environment due to missing native `better-sqlite3` bindings unrelated to these changes (test failures are environmental, not introduced by this PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da4bdd2614832fad8bd0d2cc54a24b)