### PR TITLE
Fix EPG Sources Box scrolling

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -536,8 +536,9 @@ span {
 
 /* Fix EPG Sources Box scrolling */
 #epg-sources-list {
-  max-height: 300px;
+  max-height: 400px;
   overflow-y: auto;
+  overflow-x: auto;
 }
 
 /* Fix table-danger visibility in dark mode (used in Client Logs) */


### PR DESCRIPTION
This PR fixes the scrolling behavior of the EPG Sources box in the dashboard.
- Increased `max-height` from 300px to 400px to match the `available-epg-sources-list` and provide more visibility.
- Added `overflow-x: auto` to ensure that long source URLs do not cause layout issues and remain accessible via horizontal scrolling.

---
*PR created automatically by Jules for task [9431460096953039329](https://jules.google.com/task/9431460096953039329) started by @Bladestar2105*