### PR TITLE
⚡ Optimize Provider Categories and Adult Check Performance

### DIFF
--- a/src/controllers/providerController.js
+++ b/src/controllers/providerController.js
@@ -475,22 +475,32 @@ export const getProviderCategories = async (req, res) => {
       console.error('Failed to fetch categories:', e);
     }
 
+    if (!categories || categories.length === 0) {
+      return res.json([]);
+    }
+
     let streamType = 'live';
     if(type === 'movie') streamType = 'movie';
     if(type === 'series') streamType = 'series';
 
-    const localCats = db.prepare(`
-      SELECT DISTINCT original_category_id,
-             COUNT(*) as channel_count
-      FROM provider_channels
-      WHERE provider_id = ? AND stream_type = ? AND original_category_id > 0
-      GROUP BY original_category_id
-      ORDER BY channel_count DESC
-    `).all(id, streamType);
-
+    // ⚡ Bolt: Extract category IDs and use an IN clause to fetch channel counts only for relevant categories.
+    // Also remove redundant DISTINCT and ORDER BY to reduce SQLite overhead.
+    const categoryIds = categories.map(cat => Number(cat.category_id)).filter(id => id > 0);
     const localCatsMap = new Map();
-    for (const l of localCats) {
-      localCatsMap.set(Number(l.original_category_id), l);
+
+    if (categoryIds.length > 0) {
+      const placeholders = Array(categoryIds.length).fill('?').join(',');
+      const localCats = db.prepare(`
+        SELECT original_category_id,
+               COUNT(*) as channel_count
+        FROM provider_channels
+        WHERE provider_id = ? AND stream_type = ? AND original_category_id IN (${placeholders})
+        GROUP BY original_category_id
+      `).all(id, streamType, ...categoryIds);
+
+      for (const l of localCats) {
+        localCatsMap.set(Number(l.original_category_id), l);
+      }
     }
 
     const merged = categories.map(cat => {

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -116,29 +116,22 @@ export function safeLookup(hostname, options, callback) {
   });
 }
 
+// ⚡ Bolt: Hoist regex patterns to module level to avoid redundant compilation in every call.
+const wordKeywords = [
+  'adult', 'adults', 'adulting', 'xxx', 'porn', 'porno', 'pornography',
+  'erotic', 'erotica', 'sex', 'sexual', 'nsfw', 'for adults',
+  'erwachsene', 'mature', 'sexy', 'hot'
+];
+
+const specialKeywords = ['18\\+', '\\+18', '18 plus'];
+
+// Exact word boundary matching for all words
+const wordPattern = new RegExp(`(?:\\b|_|\\W|^)(${wordKeywords.join('|')})(?:\\b|_|\\W|$)`, 'i');
+// Match special keywords as exact matches with boundary
+const specialPattern = new RegExp(`(?:^|\\s|\\W)(${specialKeywords.join('|')})(?:\\s|$|\\W)`, 'i');
+
 export function isAdultCategory(name) {
   const nameLower = name.toLowerCase();
-
-  // We want to match exact words or specific prefixes.
-  // But wait, \bhot matches "hotel" because 'hot' is at a word boundary.
-  // Instead of prefix matching, we should just match exact words, but allow known variations.
-  // A safer approach is to split the category name into words and check if any word matches the exact keyword
-  // or specific allowed variations (like 'adults', 'adulting', 'porno', 'pornography', 'sexual').
-  // Given the complexity of regex word stems, let's just use exact word matching + explicit variations.
-
-  const wordKeywords = [
-    'adult', 'adults', 'adulting', 'xxx', 'porn', 'porno', 'pornography',
-    'erotic', 'erotica', 'sex', 'sexual', 'nsfw', 'for adults',
-    'erwachsene', 'mature', 'sexy', 'hot'
-  ];
-
-  const specialKeywords = ['18\\+', '\\+18', '18 plus'];
-
-  // Exact word boundary matching for all words
-  const wordPattern = new RegExp(`(?:\\b|_|\\W|^)(${wordKeywords.join('|')})(?:\\b|_|\\W|$)`, 'i');
-  // Match special keywords as exact matches with boundary
-  const specialPattern = new RegExp(`(?:^|\\s|\\W)(${specialKeywords.join('|')})(?:\\s|$|\\W)`, 'i');
-
   return wordPattern.test(nameLower) || specialPattern.test(nameLower);
 }
 


### PR DESCRIPTION
### 💡 What:
Optimized the `getProviderCategories` endpoint and the `isAdultCategory` utility function.
- `getProviderCategories`: Replaced a full-table scan/fetch-all approach with a targeted `IN` clause query that only fetches channel counts for categories returned by the provider API.
- `isAdultCategory`: Hoisted regex pattern compilation to the module scope to avoid redundant compilation on every call, which was previously happening inside a loop for each category.

### 🎯 Why:
- **Database Efficiency:** For providers with thousands of categories, fetching counts for all of them when only a subset is needed was wasteful and slow. The query was also using `DISTINCT` and `ORDER BY` unnecessarily.
- **CPU Efficiency:** `isAdultCategory` is called for every category in the list. Compiling regex patterns repeatedly inside this loop wasted significant CPU cycles.

### 📊 Measured Improvement:
- **Database:** Reduced SQL overhead by targeting specific IDs and removing unnecessary aggregate/sort operations.
- **CPU:** Eliminated O(N) regex compilations per request, where N is the number of categories.
- **Correctness:** Verified identical logic behavior with a standalone test suite covering edge cases and merging logic.

---
*PR created automatically by Jules for task [16161558795013877528](https://jules.google.com/task/16161558795013877528) started by @Bladestar2105*