### PR TITLE
Enable VOD transcoding for MKV/AVI to fix web player playback

### DIFF
--- a/public/player.js
+++ b/public/player.js
@@ -902,7 +902,7 @@ function escapeHtml(unsafe) {
         initNativePlayer(url, streamType);
       }
     } else if (url.match(/\.(mkv|avi|mp4|mov|wmv)($|\?)/i)) {
-      if (wantTranscode && !url.match(/\.(mkv|avi)($|\?)/i)) {
+      if (wantTranscode) {
         var vodTranscodeUrl = url + (url.includes('?') ? '&' : '?') + 'transcode=true';
         initNativePlayer(vodTranscodeUrl, streamType);
       } else {

--- a/src/controllers/streamController.js
+++ b/src/controllers/streamController.js
@@ -839,7 +839,7 @@ export const proxyMovie = async (req, res) => {
         Object.assign(headers, meta.http_headers);
     }
 
-    const shouldTranscode = (req.query.transcode === 'true') || (isBrowser(req) && ext === 'avi');
+    const shouldTranscode = (req.query.transcode === 'true') || (isBrowser(req) && /^(avi|mkv)$/i.test(ext));
 
     if (shouldTranscode) {
         const transcodeHeaders = { ...headers };
@@ -1020,7 +1020,7 @@ export const proxySeries = async (req, res) => {
       'Connection': 'keep-alive'
     };
 
-    const shouldTranscode = (req.query.transcode === 'true') || (isBrowser(req) && ext === 'avi');
+    const shouldTranscode = (req.query.transcode === 'true') || (isBrowser(req) && /^(avi|mkv)$/i.test(ext));
 
     if (shouldTranscode) {
         const transcodeHeaders = { ...headers };


### PR DESCRIPTION
### Motivation
- Browser playback for VOD `.mkv` streams sometimes failed to start because server-side auto-transcoding only covered `avi` and the frontend transcode toggle logic was excluding MKV/AVI when building the transcode URL.

### Description
- Treat `mkv` the same as `avi` for automatic browser-triggered transcoding in `proxyMovie` and `proxySeries` by matching `/^(avi|mkv)$/i` on the request extension in `src/controllers/streamController.js`.
- Ensure the web player appends `transcode=true` when the Transcode toggle is enabled for VOD files (including `.mkv` and `.avi`) by removing the exclusion in `public/player.js`.
- Changes touch `src/controllers/streamController.js` and `public/player.js` and adjust the VOD/transcode decision paths only.

### Testing
- Ran `npm test -- tests/public/player.test.js tests/security/provider_limit.test.js` and both test files passed (all tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e37608efa4832fb214ae43fbd9aad0)