### PR TITLE
Expose share validity window in Xtream metadata responses

### DIFF
--- a/docs/SHARE_COMPANION_INTEGRATION.md
+++ b/docs/SHARE_COMPANION_INTEGRATION.md
@@ -38,6 +38,14 @@ A share should work without regular user credentials while still providing:
   - `...&action=get_series_info&series_id=<id>`
   - `...&action=get_short_epg&stream_id=<id>&limit=<n>`
 
+When calling `GET /player_api.php?token=<share_token>` the `user_info` object includes share validity metadata for share guests:
+
+- `valid_from`: UNIX timestamp (seconds) from when the share becomes valid, or `null`.
+- `valid_until`: UNIX timestamp (seconds) when the share expires, or `null`.
+- `is_valid_now`: `1` if currently valid, otherwise `0`.
+
+Companion clients should poll this endpoint every 5 minutes to detect window updates (e.g. changed start/end times) and react without a full re-import.
+
 ### M3U + EPG
 
 - Playlist: `GET /get.php?token=<share_token>&type=m3u_plus`
@@ -57,3 +65,4 @@ A share should work without regular user credentials while still providing:
 - Store tokens securely (never log raw tokens; avoid unencrypted persistence).
 - On HTTP 401/403, discard the token and prompt the user to re-open or re-import the share URL.
 - Cache EPG/metadata with a short TTL (e.g. 5–15 minutes), because shares can be revoked or expire.
+- For validity state, prefer a 5-minute `player_api.php` check and compare `valid_from`/`valid_until` to previously cached values.

--- a/src/controllers/xtreamController.js
+++ b/src/controllers/xtreamController.js
@@ -84,6 +84,22 @@ const appendAllowedChannelFilter = (query, params, allowedChannelIds, column = '
   };
 };
 
+const getShareValidityInfo = (user, nowSec) => {
+  if (!user?.is_share_guest) return {};
+
+  const validFrom = user.share_start ? Math.floor(user.share_start) : null;
+  const validUntil = user.share_end ? Math.floor(user.share_end) : null;
+  const isNotYetValid = validFrom !== null && nowSec < validFrom;
+  const isExpired = validUntil !== null && nowSec > validUntil;
+  const isCurrentlyValid = !isNotYetValid && !isExpired;
+
+  return {
+    valid_from: validFrom !== null ? String(validFrom) : null,
+    valid_until: validUntil !== null ? String(validUntil) : null,
+    is_valid_now: isCurrentlyValid ? 1 : 0
+  };
+};
+
 export const playerApi = async (req, res) => {
   try {
     const username = (req.query.username || '').trim();
@@ -102,12 +118,19 @@ export const playerApi = async (req, res) => {
     const now = Math.floor(Date.now() / 1000);
     const shareScope = getShareScope(user);
     if (shareScope.isExpired) {
-      return res.json({user_info: {auth: 0, message: 'Share expired'}});
+      return res.json({
+        user_info: {
+          auth: 0,
+          message: 'Share expired',
+          ...getShareValidityInfo(user, now)
+        }
+      });
     }
 
     if (!action || action === '') {
       const { default: streamManager } = await import('../services/streamManager.js');
       const activeCons = await streamManager.getUserConnectionCount(user.id);
+      const shareValidity = getShareValidityInfo(user, now);
 
       return res.json({
         user_info: {
@@ -121,7 +144,8 @@ export const playerApi = async (req, res) => {
           active_cons: activeCons,
           created_at: now.toString(),
           max_connections: user.max_connections === 0 ? 999999 : (user.max_connections || 1),
-          allowed_output_formats: ['m3u8', 'ts']
+          allowed_output_formats: ['m3u8', 'ts'],
+          ...shareValidity
         },
         server_info: {
           url: req.hostname,

--- a/tests/controllers/xtream_share_compat.test.js
+++ b/tests/controllers/xtream_share_compat.test.js
@@ -108,13 +108,14 @@ describe('xtreamController share compatibility', () => {
   });
 
   it('serves Xtream metadata for active share tokens', async () => {
+    const nowSec = Math.floor(Date.now() / 1000);
     req.query = { token: 'share-token' };
     getXtreamUser.mockResolvedValue({
       id: 1,
       is_share_guest: true,
       allowed_channels: [100],
-      share_start: null,
-      share_end: null,
+      share_start: nowSec - 300,
+      share_end: nowSec + 600,
       max_connections: 1
     });
 
@@ -122,7 +123,53 @@ describe('xtreamController share compatibility', () => {
 
     expect(res.sendStatus).not.toHaveBeenCalledWith(403);
     expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
-      user_info: expect.objectContaining({ auth: 1 })
+      user_info: expect.objectContaining({
+        auth: 1,
+        valid_from: String(nowSec - 300),
+        valid_until: String(nowSec + 600),
+        is_valid_now: 1
+      })
+    }));
+  });
+
+  it('returns updated validity window on subsequent metadata checks', async () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    req.query = { token: 'share-token' };
+
+    getXtreamUser.mockResolvedValueOnce({
+      id: 1,
+      is_share_guest: true,
+      allowed_channels: [100],
+      share_start: nowSec - 120,
+      share_end: nowSec + 120,
+      max_connections: 1
+    });
+
+    await playerApi(req, res);
+    expect(res.json).toHaveBeenLastCalledWith(expect.objectContaining({
+      user_info: expect.objectContaining({
+        valid_from: String(nowSec - 120),
+        valid_until: String(nowSec + 120),
+        is_valid_now: 1
+      })
+    }));
+
+    getXtreamUser.mockResolvedValueOnce({
+      id: 1,
+      is_share_guest: true,
+      allowed_channels: [100],
+      share_start: nowSec + 240,
+      share_end: nowSec + 900,
+      max_connections: 1
+    });
+
+    await playerApi(req, res);
+    expect(res.json).toHaveBeenLastCalledWith(expect.objectContaining({
+      user_info: expect.objectContaining({
+        valid_from: String(nowSec + 240),
+        valid_until: String(nowSec + 900),
+        is_valid_now: 0
+      })
     }));
   });
 


### PR DESCRIPTION
### Motivation

- Companion clients need to know when a share becomes valid and when it expires so they can react without a full re-import. 

### Description

- Add `getShareValidityInfo(user, nowSec)` and expose `valid_from`, `valid_until` and `is_valid_now` in the Xtream metadata `user_info` for share-token clients. 
- Include the same validity fields when a share is outside its validity window and the response returns `auth: 0`, so clients can still observe timing boundaries. 
- Wire the validity info into the `playerApi` flow so both active (`auth: 1`) and expired/not-yet-valid shares include the new fields. 
- Update companion integration docs (`docs/SHARE_COMPANION_INTEGRATION.md`) and extend tests (`tests/controllers/xtream_share_compat.test.js`) to validate the new fields and that changed start/end windows are reflected on subsequent checks. 

### Testing

- Ran `npm test -- tests/controllers/xtream_share_compat.test.js` and the test suite for that file passed (4 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e497669c90832f9bfbd9d5700549bb)