### PR TITLE
Add Playwright smoke test; move EPG loading into worker; improve EPG import batching and XML decoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "type": "module",
   "scripts": {
     "start": "node src/server.js",
+    "build": "node -e \"console.log('No build step required for IPTV-Manager')\"",
     "lint": "eslint src/",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:playwright:smoke": "node scripts/playwright_smoke.mjs"
   },
   "dependencies": {
     "@iptv/xtream-api": "^1.2.1",

--- a/scripts/playwright_smoke.mjs
+++ b/scripts/playwright_smoke.mjs
@@ -1,0 +1,48 @@
+import { chromium } from 'playwright';
+import app from '../src/app.js';
+import { initDb } from '../src/database/db.js';
+import { initEpgDb } from '../src/database/epgDb.js';
+
+async function run() {
+  initDb(true);
+  initEpgDb();
+
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once('listening', resolve);
+    server.once('error', reject);
+  });
+
+  const address = server.address();
+  const port = typeof address === 'object' && address ? address.port : 3000;
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+
+  try {
+    const response = await page.goto(baseUrl, { waitUntil: 'networkidle', timeout: 15000 });
+    if (!response || response.status() >= 400) {
+      throw new Error(`Unexpected response status: ${response ? response.status() : 'no response'}`);
+    }
+
+    const title = await page.title();
+    if (!title || !title.toLowerCase().includes('iptv-manager')) {
+      throw new Error(`Unexpected page title: "${title}"`);
+    }
+
+    // Smoke-check static container that is required by the web app.
+    const toastContainer = await page.$('#toast-container');
+    if (!toastContainer) {
+      throw new Error('Missing #toast-container in UI');
+    }
+  } finally {
+    await browser.close();
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/controllers/epgController.js
+++ b/src/controllers/epgController.js
@@ -449,17 +449,9 @@ export const autoMapping = async (req, res) => {
 
     if (channels.length === 0) return res.json({matched: 0, message: 'No unmapped channels found'});
 
-    // Load ALL EPG Channels from DB to pass to worker
-    const allEpgChannels = await loadAllEpgChannels();
-
-    if (allEpgChannels.length === 0) {
-        return res.status(503).json({error: 'EPG data empty. Please update EPG sources.'});
-    }
-
     const worker = new Worker(path.join(process.cwd(), 'src', 'workers', 'epgWorker.js'), {
       workerData: {
-        channels,
-        allEpgChannels
+        channels
       }
     });
 
@@ -473,6 +465,9 @@ export const autoMapping = async (req, res) => {
 
     if (!result.success) {
       throw new Error(result.error || 'Worker failed');
+    }
+    if (result.epgEmpty) {
+      return res.status(503).json({error: 'EPG data empty. Please update EPG sources.'});
     }
 
     const { updates, matched } = result;

--- a/src/services/epgService.js
+++ b/src/services/epgService.js
@@ -9,6 +9,11 @@ import { decodeXml } from '../utils/epgUtils.js';
 import { EPG_DB_PATH } from '../config/constants.js';
 import { invalidateEpgLogosCache } from './logoResolver.js';
 
+function decodeXmlIfNeeded(value) {
+    if (!value) return '';
+    return value.includes('&') ? decodeXml(value) : value;
+}
+
 export async function importEpgFromUrl(url, sourceType, sourceId) {
     console.debug(`📡 Fetching EPG for ${sourceType} ${sourceId} from: ${url}`);
     // fetchSafe performs isSafeUrl check
@@ -78,15 +83,16 @@ export async function importEpgFromUrl(url, sourceType, sourceId) {
 
         let channelBatch = [];
         let programBatch = [];
-        const BATCH_SIZE = 500;
+        const BATCH_SIZE = 2000;
+
+        const processBatchTx = importDb.transaction((channelsToInsert, programsToInsert) => {
+            for (const ch of channelsToInsert) insertChannel.run(ch);
+            for (const prog of programsToInsert) insertProgram.run(prog);
+        });
 
         const processBatches = () => {
             if (channelBatch.length > 0 || programBatch.length > 0) {
-                const updateTx = importDb.transaction(() => {
-                    for (const ch of channelBatch) insertChannel.run(ch);
-                    for (const prog of programBatch) insertProgram.run(prog);
-                });
-                updateTx();
+                processBatchTx(channelBatch, programBatch);
                 channelBatch = [];
                 programBatch = [];
             }
@@ -167,13 +173,13 @@ export async function importEpgFromUrl(url, sourceType, sourceId) {
             parser.on('closetag', function (name) {
                 if (currentChannel && name === 'display-name') {
                     if (!currentChannel.hasName) {
-                        currentChannel.name = decodeXml(currentText);
+                        currentChannel.name = decodeXmlIfNeeded(currentText);
                         currentChannel.hasName = true;
                     }
                 } else if (currentProgram && name === 'title') {
-                    currentProgram.title = decodeXml(currentText);
+                    currentProgram.title = decodeXmlIfNeeded(currentText);
                 } else if (currentProgram && name === 'desc') {
-                    currentProgram.desc = decodeXml(currentText);
+                    currentProgram.desc = decodeXmlIfNeeded(currentText);
                 }
 
                 if (name === 'channel' && currentChannel) {

--- a/src/workers/epgWorker.js
+++ b/src/workers/epgWorker.js
@@ -1,11 +1,12 @@
 import { parentPort, workerData } from 'worker_threads';
 import { ChannelMatcher } from '../services/channelMatcher.js';
+import { loadAllEpgChannels } from '../services/epgService.js';
 
-export function matchChannels(channels, allEpgChannels) {
+export function matchChannels(channels, allEpgChannels = null) {
     const updates = [];
     let matched = 0;
 
-    const matcher = new ChannelMatcher(allEpgChannels);
+    const matcher = new ChannelMatcher(allEpgChannels || []);
 
     for (const ch of channels) {
        // Automapping
@@ -23,9 +24,15 @@ export function matchChannels(channels, allEpgChannels) {
 async function run() {
   if (!workerData) return; // Not running in worker thread
 
-  const { channels, allEpgChannels } = workerData;
+  const { channels } = workerData;
 
   try {
+    const allEpgChannels = await loadAllEpgChannels();
+    if (!allEpgChannels || allEpgChannels.length === 0) {
+      parentPort.postMessage({ success: true, updates: [], matched: 0, epgEmpty: true });
+      return;
+    }
+
     const { updates, matched } = matchChannels(channels, allEpgChannels || []);
     parentPort.postMessage({ success: true, updates, matched });
 

--- a/tests/controllers/epgController.test.js
+++ b/tests/controllers/epgController.test.js
@@ -55,7 +55,7 @@ describe('EPG Controller', () => {
         });
 
         it('should block unsafe URLs', async () => {
-            helpers.isSafeUrl.mockResolvedValue(false);
+            helpers.isSafeUrl.mockReturnValue(false);
             const req = { user: { is_admin: true }, body: { name: 'Test', url: 'http://unsafe.local' } };
             const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
 
@@ -66,7 +66,7 @@ describe('EPG Controller', () => {
         });
 
         it('should create a valid EPG source', async () => {
-            helpers.isSafeUrl.mockResolvedValue(true);
+            helpers.isSafeUrl.mockReturnValue(true);
             const req = {
                 user: { is_admin: true },
                 body: { name: 'Test EPG', url: 'http://example.com/epg.xml', enabled: true, update_interval: 3600 }
@@ -85,7 +85,7 @@ describe('EPG Controller', () => {
 
     describe('updateEpgSourceEndpoint', () => {
         it('should update existing source fields', async () => {
-            helpers.isSafeUrl.mockResolvedValue(true);
+            helpers.isSafeUrl.mockReturnValue(true);
             const info = db.prepare('INSERT INTO epg_sources (name, url, enabled) VALUES (?, ?, ?)').run('Old Name', 'http://old.com', 1);
             const id = info.lastInsertRowid;
 
@@ -105,7 +105,7 @@ describe('EPG Controller', () => {
         });
 
         it('should block unsafe URLs during update', async () => {
-            helpers.isSafeUrl.mockResolvedValue(false);
+            helpers.isSafeUrl.mockReturnValue(false);
             const info = db.prepare('INSERT INTO epg_sources (name, url, enabled) VALUES (?, ?, ?)').run('Valid', 'http://valid.com', 1);
             const id = info.lastInsertRowid;
 


### PR DESCRIPTION
### Motivation

- Add a lightweight end-to-end smoke test to verify the web UI can start and serve the main page. 
- Avoid loading the entire EPG dataset on the main thread during auto-mapping to reduce memory/CPU pressure and improve responsiveness. 
- Make EPG import more robust and faster by increasing batch sizes, using transactions for batch inserts, and handling XML entity decoding more safely. 

### Description

- Added a new npm script `build` that prints a no-op message and a `test:playwright:smoke` script to run the Playwright smoke test. 
- Introduced `scripts/playwright_smoke.mjs`, which starts the app, initializes DBs, launches a headless Chromium, verifies the root page returns OK, checks the page title contains `IPTV-Manager`, and asserts `#toast-container` exists. 
- Changed `autoMapping` in `src/controllers/epgController.js` to stop preloading all EPG channels; the worker now loads EPG data and the controller handles the new `epgEmpty` result by returning `503` if no EPG data exists. 
- Updated `src/workers/epgWorker.js` so the worker calls `loadAllEpgChannels()` itself, returns an `epgEmpty` flag when no channels are present, and made `matchChannels` accept an optional `allEpgChannels` parameter. 
- Enhanced `src/services/epgService.js` by adding `decodeXmlIfNeeded` to avoid unnecessary decoding, increasing `BATCH_SIZE` from `500` to `2000`, and batching inserts inside a single transaction via `processBatchTx` to improve import performance and reliability. 
- Adjusted tests in `tests/controllers/epgController.test.js` to use `helpers.isSafeUrl.mockReturnValue(...)` instead of `mockResolvedValue`, matching the current `isSafeUrl` usage. 

### Testing

- Ran unit tests with `npm test` (Vitest) and all modified controller unit tests passed. 
- Executed the new smoke test with `npm run test:playwright:smoke` against a local server and it completed successfully. 
- Linting with `npm run lint` was checked and reported no new issues related to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef780bfd04832f865a1b3f703492fc)