### PR TITLE
Fix 400 when creating user by copying another user's settings

### DIFF
--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -258,7 +258,7 @@ export const createUser = async (req, res) => {
                             SELECT provider_channel_id, epg_channel_id
                             FROM epg_channel_mappings
                             WHERE provider_channel_id IN (${placeholders})
-                        `).all(batch);
+                        `).all(...batch);
 
                         for (const m of mappings) {
                             const newChId = channelMap[m.provider_channel_id];


### PR DESCRIPTION
### Motivation
- Creating a new user with `copy_from_user_id` could fail with HTTP 400 due to a SQLite binding error when copying EPG channel mappings in batched `IN (...)` queries. 

### Description
- Fix parameter binding in `src/controllers/userController.js` by changing `.all(batch)` to `.all(...batch)` so the number of `?` placeholders matches the provided arguments. 

### Testing
- Ran `npm test -- tests/security/admin_isolation.test.js` and the test suite passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4de43f2d8832fb17eb4855ce6d52a)