### PR TITLE
Fix 500 error when importing a single category

### DIFF
--- a/src/controllers/providerController.js
+++ b/src/controllers/providerController.js
@@ -558,8 +558,6 @@ export const importCategory = async (req, res) => {
       if(catType === 'movie') streamType = 'movie';
       if(catType === 'series') streamType = 'series';
 
-      // ⚡ Bolt: Replace .all() with .iterate() to eliminate intermediate V8 array allocation overhead
-      // 🎯 Why: Streaming channels via .iterate() handles massive imports gracefully without intermediate memory bloat.
       const stmt = db.prepare(`
         SELECT id FROM provider_channels
         WHERE provider_id = ? AND original_category_id = ? AND stream_type = ?
@@ -567,12 +565,12 @@ export const importCategory = async (req, res) => {
       `);
 
       const insertChannel = db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, sort_order) VALUES (?, ?, ?)');
-
-      let importedCount = 0;
+      const channels = stmt.all(providerId, Number(category_id), streamType);
+      const importedCount = channels.length;
       db.transaction(() => {
-        for (const ch of stmt.iterate(providerId, Number(category_id), streamType)) {
-          insertChannel.run(newCategoryId, ch.id, importedCount++);
-        }
+        channels.forEach((ch, idx) => {
+          insertChannel.run(newCategoryId, ch.id, idx);
+        });
       })();
 
       res.json({


### PR DESCRIPTION
### Motivation
- Importing a single category could throw `TypeError: This database connection is busy executing a query` when inserting rows while iterating a `better-sqlite3` cursor. 
- The change avoids executing another query on the same connection while an `.iterate()` cursor is active.

### Description
- Replace the streaming iteration with a prefetch: load matching channels using `stmt.all(...)` before the transaction. 
- Compute `channels_imported` from `channels.length` and perform `INSERT` operations inside a single `db.transaction()` using `channels.forEach(...)`. 
- Preserve existing `sort_order` behavior by using the iteration index (`idx`) for inserted `user_channels` entries.

### Testing
- No automated test suite was executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f503f1c070832f8c41eed21b5ada8b)