### PR TITLE
Make user cloning resilient to unique-constraint conflicts and copy channel hidden flag

### DIFF
--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -183,7 +183,7 @@ export const createUser = async (req, res) => {
                     const placeholders = Array(oldProviderIdsForSync.length).fill('?').join(',');
                     const sourceSyncs = db.prepare(`SELECT * FROM sync_configs WHERE provider_id IN (${placeholders})`).all(...oldProviderIdsForSync);
                     const insertSync = db.prepare(`
-                        INSERT INTO sync_configs (provider_id, user_id, enabled, sync_interval, auto_add_categories, auto_add_channels)
+                        INSERT OR IGNORE INTO sync_configs (provider_id, user_id, enabled, sync_interval, auto_add_categories, auto_add_channels)
                         VALUES (?, ?, ?, ?, ?, ?)
                     `);
                     for (const sync of sourceSyncs) {
@@ -245,7 +245,7 @@ export const createUser = async (req, res) => {
                 }
 
                 // 3b. Copy EPG Channel Mappings
-                const insertEpgMap = db.prepare('INSERT INTO epg_channel_mappings (provider_channel_id, epg_channel_id) VALUES (?, ?)');
+                const insertEpgMap = db.prepare('INSERT OR IGNORE INTO epg_channel_mappings (provider_channel_id, epg_channel_id) VALUES (?, ?)');
                 // Optimization: Replace O(N) database queries with a single set-based lookup to avoid N+1 bottleneck
                 const oldChannelIds = Object.keys(channelMap);
                 if (oldChannelIds.length > 0) {
@@ -291,7 +291,7 @@ export const createUser = async (req, res) => {
                 // 5. Copy Category Mappings
                 const sourceMappings = db.prepare('SELECT * FROM category_mappings WHERE user_id = ?').all(sourceUserId);
                 const insertMapping = db.prepare(`
-                    INSERT INTO category_mappings (provider_id, user_id, provider_category_id, provider_category_name, user_category_id, auto_created, category_type)
+                    INSERT OR IGNORE INTO category_mappings (provider_id, user_id, provider_category_id, provider_category_name, user_category_id, auto_created, category_type)
                     VALUES (?, ?, ?, ?, ?, ?, ?)
                 `);
 
@@ -313,13 +313,13 @@ export const createUser = async (req, res) => {
                 // We need to iterate over source user's categories to find channels
                 // Or simply select all user_channels linked to source user's categories
                 const insertUserChan = db.prepare(`
-                    INSERT INTO user_channels (user_category_id, provider_channel_id, sort_order, custom_name)
-                    VALUES (?, ?, ?, ?)
+                    INSERT INTO user_channels (user_category_id, provider_channel_id, sort_order, custom_name, is_hidden)
+                    VALUES (?, ?, ?, ?, ?)
                 `);
 
                 // Fetch all user channels for source user categories
                 const sourceUserChans = db.prepare(`
-                    SELECT uc.user_category_id, uc.provider_channel_id, uc.sort_order, uc.custom_name
+                    SELECT uc.user_category_id, uc.provider_channel_id, uc.sort_order, uc.custom_name, uc.is_hidden
                     FROM user_channels uc
                     JOIN user_categories cat ON uc.user_category_id = cat.id
                     WHERE cat.user_id = ?
@@ -330,7 +330,7 @@ export const createUser = async (req, res) => {
                     const newProvChanId = channelMap[uc.provider_channel_id];
 
                     if (newCatId && newProvChanId) {
-                        insertUserChan.run(newCatId, newProvChanId, uc.sort_order, uc.custom_name || '');
+                        insertUserChan.run(newCatId, newProvChanId, uc.sort_order, uc.custom_name || '', uc.is_hidden || 0);
                     }
                 }
             }


### PR DESCRIPTION
### Motivation
- Prevent new user creation from failing with HTTP 400 when copying settings from another user due to unique-constraint collisions in legacy or duplicate data.
- Ensure cloned user channels preserve the original `is_hidden` state so visibility is consistent after cloning.

### Description
- Switched copy inserts to `INSERT OR IGNORE` for `sync_configs`, `epg_channel_mappings`, and `category_mappings` to avoid aborting on unique-constraint violations during cloning in `createUser` (`src/controllers/userController.js`).
- Expanded the `user_channels` copy to include the `is_hidden` column by updating the `SELECT` to fetch `uc.is_hidden` and the `INSERT` to store `is_hidden` so channel visibility is preserved for the new user.
- Kept the provider/channel/category mapping logic and batch-query optimizations intact while making the copy operations idempotent to handle overlapping data.

### Testing
- Ran `npm test -- tests/export_regression.test.js`, which could not complete in this environment because the `better-sqlite3` native bindings are missing, causing the test run to fail with a bindings error.
- No other automated test failures were observed in the code changes themselves during static review; full test-suite verification requires a runtime with `better-sqlite3` native bindings available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f50b40be64832fbcd8ac9c36684fcd)