### PR TITLE
Prevent duplicate stream sessions, add inactivity timeout default and local resource checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ Optional tuning via environment variables:
 
 - `STREAM_MAX_AGE_MS` (default: `86400000` = 24h)  
   Hard safety cap for a single session age. Very old orphan sessions are removed before limit checks.
-- `STREAM_INACTIVITY_TIMEOUT_MS` (default: `0` = disabled)  
-  Optional inactivity expiry. Set this only if you explicitly want inactivity-based stream expiration.
+- `STREAM_INACTIVITY_TIMEOUT_MS` (default: `120000` = 2 minutes)  
+  Inactivity expiry for stalled streams to prevent orphan sessions from blocking new playback.
 
 For most deployments, keep the defaults unless you have a specific operational need.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -33,8 +33,8 @@ tests. Keep it in sync when environment variables or startup behavior changes.
   workers or instances. Without Redis, in-memory tracking is used.
 - `STREAM_MAX_AGE_MS`: Hard safety cap for stale stream sessions. Defaults to
   `86400000` (24 hours).
-- `STREAM_INACTIVITY_TIMEOUT_MS`: Optional inactivity timeout for stream
-  sessions. Defaults to `0` (disabled).
+- `STREAM_INACTIVITY_TIMEOUT_MS`: Inactivity timeout for stream sessions.
+  Defaults to `120000` (2 minutes).
 
 ## Scheduled Jobs and GeoIP
 

--- a/src/controllers/streamController.js
+++ b/src/controllers/streamController.js
@@ -745,7 +745,7 @@ export const proxySegment = async (req, res) => {
         // so we use the providerId passed in the payload (which was the one chosen by the playlist generator).
         // For segments, pooling might have already happened when generating the M3U8,
         // or we just track it against the original provider.
-        await streamManager.add(connectionId, user, `${channelName}`, req.ip, res, providerId);
+        await streamManager.add(connectionId, user, `${channelName}`, req.ip, res, providerId, { dedupe: false });
     }
 
     const contentType = upstream.headers.get('content-type');

--- a/src/services/streamManager.js
+++ b/src/services/streamManager.js
@@ -1,7 +1,7 @@
 
 const REDIS_KEY_STREAMS = 'iptv:streams';
 const REDIS_PREFIX_USER = 'iptv:user_idx:';
-const STREAM_INACTIVITY_TIMEOUT_MS = Number(process.env.STREAM_INACTIVITY_TIMEOUT_MS || 0);
+const STREAM_INACTIVITY_TIMEOUT_MS = Number(process.env.STREAM_INACTIVITY_TIMEOUT_MS || 2 * 60 * 1000);
 const STREAM_MAX_AGE_MS = Number(process.env.STREAM_MAX_AGE_MS || 24 * 60 * 60 * 1000);
 
 class StreamManager {
@@ -27,6 +27,7 @@ class StreamManager {
           `);
           this.stmtRemove = this.db.prepare('DELETE FROM current_streams WHERE id = ?');
           this.stmtCleanup = this.db.prepare('SELECT id FROM current_streams WHERE user_id = ? AND ip = ?');
+          this.stmtFindSameSession = this.db.prepare('SELECT id FROM current_streams WHERE user_id = ? AND ip = ? AND channel_name = ? AND provider_id = ? AND id != ?');
           this.stmtGetAll = this.db.prepare('SELECT * FROM current_streams');
           this.stmtCountUser = this.db.prepare('SELECT COUNT(*) as count FROM (SELECT DISTINCT channel_name, ip, provider_id FROM current_streams WHERE user_id = ?)');
           this.stmtCountProvider = this.db.prepare('SELECT COUNT(*) as count FROM (SELECT DISTINCT channel_name, ip, user_id FROM current_streams WHERE provider_id = ?)');
@@ -54,6 +55,8 @@ class StreamManager {
       provider_id: providerId
     };
 
+    await this.cleanupSession(user.id, ip, channelName, providerId, id);
+
     if (this.redis) {
       try {
         const json = JSON.stringify(data);
@@ -75,6 +78,43 @@ class StreamManager {
 
     if (resource) {
       this.localStreams.set(id, resource);
+    }
+  }
+
+  async cleanupSession(userId, ip, channelName, providerId = 0, excludeId = null) {
+    if (!userId || !ip || !channelName) return;
+
+    if (this.redis) {
+      try {
+        const all = await this.getAll();
+        const sameSessionIds = all
+          .filter(stream =>
+            stream.user_id === userId &&
+            stream.ip === ip &&
+            stream.channel_name === channelName &&
+            stream.provider_id === providerId &&
+            stream.id !== excludeId
+          )
+          .map(stream => stream.id);
+
+        for (const sessionId of sameSessionIds) {
+          await this.remove(sessionId);
+        }
+      } catch (e) {
+        console.error('Redis Session Cleanup Error:', e);
+      }
+      return;
+    }
+
+    if (this.db) {
+      try {
+        const rows = this.stmtFindSameSession.all(userId, ip, channelName, providerId, excludeId || '');
+        for (const row of rows) {
+          await this.remove(row.id);
+        }
+      } catch (e) {
+        console.error('DB Session Cleanup Error:', e.message);
+      }
     }
   }
 
@@ -168,9 +208,21 @@ class StreamManager {
     }
   }
 
+  hasActiveLocalResource(streamId) {
+    if (!streamId) return false;
+    const resource = this.localStreams.get(streamId);
+    if (!resource) return false;
+
+    if (typeof resource.destroyed === 'boolean') return !resource.destroyed;
+    if (typeof resource.writableEnded === 'boolean') return !resource.writableEnded;
+    if (typeof resource.readableEnded === 'boolean') return !resource.readableEnded;
+    return true;
+  }
+
   isStale(stream, now = Date.now()) {
     if (!stream) return false;
     if (!this.isWorkerAlive(stream.worker_pid)) return true;
+    if (stream.worker_pid === this.pid && this.hasActiveLocalResource(stream.id)) return false;
 
     const startTime = Number(stream.start_time || 0);
     const lastActivity = Number(stream.last_activity || startTime || 0);

--- a/src/services/streamManager.js
+++ b/src/services/streamManager.js
@@ -42,7 +42,8 @@ class StreamManager {
     }
   }
 
-  async add(id, user, channelName, ip, resource = null, providerId = 0) {
+  async add(id, user, channelName, ip, resource = null, providerId = 0, options = {}) {
+    const { dedupe = true } = options;
     const data = {
       id,
       user_id: user.id,
@@ -55,7 +56,9 @@ class StreamManager {
       provider_id: providerId
     };
 
-    await this.cleanupSession(user.id, ip, channelName, providerId, id);
+    if (dedupe) {
+      await this.cleanupSession(user.id, ip, channelName, providerId, id);
+    }
 
     if (this.redis) {
       try {


### PR DESCRIPTION
### Motivation
- Prevent duplicate/overlapping stream sessions for the same user/ip/channel/provider that could block new playback.
- Provide a sensible default inactivity timeout to automatically expire stalled sessions instead of leaving `0` (disabled).
- Ensure streams with an active local resource on the current worker are not erroneously classified as stale.

### Description
- Updated the default `STREAM_INACTIVITY_TIMEOUT_MS` from `0` to `120000` (2 minutes) in `src/services/streamManager.js`, `README.md`, and `docs/CONFIGURATION.md` to document and apply the new default behavior.
- Added a new prepared statement `stmtFindSameSession` and implemented `cleanupSession(userId, ip, channelName, providerId, excludeId)` to remove existing identical sessions before creating a new one; this handles both Redis and SQLite backends.
- Invoked `cleanupSession` from `add` so duplicate sessions are cleaned up automatically when a new stream is added, and ensured Redis/SQLite removal paths are used appropriately.
- Introduced `hasActiveLocalResource(streamId)` and updated `isStale` to consider active local resources on the same worker PID so locally served streams are not marked stale.

### Testing
- Ran `npm run lint` to validate formatting and static checks and it completed successfully.
- Ran the existing test suite with `npm test` and the tests passed against the changed code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8fd4377f4832fac7c84370f21226a)