### PR TITLE
Prevent active long-running streams from being untracked by stale cleanup

### DIFF
--- a/src/services/streamManager.js
+++ b/src/services/streamManager.js
@@ -228,11 +228,14 @@ class StreamManager {
     if (stream.worker_pid === this.pid && this.hasActiveLocalResource(stream.id)) return false;
 
     const startTime = Number(stream.start_time || 0);
-    const lastActivity = Number(stream.last_activity || startTime || 0);
-    if (!lastActivity) return false;
+    const lastActivity = Number(stream.last_activity || 0);
 
-    if (STREAM_INACTIVITY_TIMEOUT_MS > 0 && now - lastActivity > STREAM_INACTIVITY_TIMEOUT_MS) return true;
-    if (startTime && now - startTime > STREAM_MAX_AGE_MS) return true;
+    if (lastActivity > 0) {
+      if (STREAM_INACTIVITY_TIMEOUT_MS > 0 && now - lastActivity > STREAM_INACTIVITY_TIMEOUT_MS) return true;
+      return false;
+    }
+
+    if (startTime && STREAM_MAX_AGE_MS > 0 && now - startTime > STREAM_MAX_AGE_MS) return true;
     return false;
   }
 

--- a/tests/stream_manager.test.js
+++ b/tests/stream_manager.test.js
@@ -87,7 +87,7 @@ describe('StreamManager (SQLite)', () => {
         db.prepare(`
           INSERT INTO current_streams (id, user_id, username, channel_name, start_time, last_activity, ip, worker_pid, provider_id)
           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-        `).run('old-but-active', 2, 'activeuser', 'Live C', now - (26 * 60 * 60 * 1000), now - 1000, '127.0.0.8', 999999, 2);
+        `).run('old-but-active', 2, 'activeuser', 'Live C', now - (26 * 60 * 60 * 1000), now - 1000, '127.0.0.8', process.pid, 2);
 
         const count = await streamManager.getUserConnectionCount(2);
         expect(count).toBe(1);

--- a/tests/stream_manager.test.js
+++ b/tests/stream_manager.test.js
@@ -81,6 +81,21 @@ describe('StreamManager (SQLite)', () => {
          expect(streams).toHaveLength(2);
     });
 
+
+    it('should keep active sessions countable even when start_time is old', async () => {
+        const now = Date.now();
+        db.prepare(`
+          INSERT INTO current_streams (id, user_id, username, channel_name, start_time, last_activity, ip, worker_pid, provider_id)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `).run('old-but-active', 2, 'activeuser', 'Live C', now - (26 * 60 * 60 * 1000), now - 1000, '127.0.0.8', 999999, 2);
+
+        const count = await streamManager.getUserConnectionCount(2);
+        expect(count).toBe(1);
+
+        const streams = await streamManager.getAll();
+        expect(streams.map(s => s.id)).toContain('old-but-active');
+    });
+
     it('should cleanup streams from dead workers before counting limits', async () => {
         const user = { id: 1, username: 'testuser' };
         await streamManager.add('active-stream', user, 'C1', '127.0.0.1', null, 1);


### PR DESCRIPTION
### Motivation
- The stale-session cleanup could remove streams purely because `start_time` exceeded `STREAM_MAX_AGE_MS` even when `last_activity` was fresh, allowing active long-running streams to be untracked in clustered deployments and enabling connection-limit bypass.
- The change aims to preserve accounting correctness for active sessions while still allowing genuine stale/inactive records to be removed.

### Description
- Change `isStale()` in `src/services/streamManager.js` to prefer a present `last_activity`: if `last_activity` exists and is recent, the stream is considered active and will not be expired; the hard `STREAM_MAX_AGE_MS` check is now only a fallback for records that lack `last_activity`.
- Keep existing worker-alive and local-resource short-circuit checks so a worker never kills another worker's local resource while still preserving shared tracking semantics.
- Add a regression test in `tests/stream_manager.test.js` that inserts an old `start_time` record with a recent `last_activity` and asserts the stream remains counted and present after limit checks.

### Testing
- Ran `npm run lint`, which completed successfully (repository contains pre-existing lint warnings but no new lint errors from this change).
- Attempted the targeted test run with `npm exec vitest run tests/stream_manager.test.js`, but the suite could not run in this environment due to missing native `better-sqlite3` bindings; the new regression test was added but could not be executed here for that reason.
- No other automated test failures were introduced by the code edits based on available checks in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fac1aa9008832fa2b6dd73dcaf6914)