### PR TITLE
Fix unhandled gunzip errors in EPG import stream

### DIFF
--- a/src/services/epgService.js
+++ b/src/services/epgService.js
@@ -63,6 +63,9 @@ export async function importEpgFromUrl(url, sourceType, sourceId) {
                 });
 
                 originalStream.pipe(gunzip).pipe(sizeChecker);
+                gunzip.on('error', (err) => {
+                    sizeChecker.destroy(err);
+                });
                 stream = sizeChecker;
             } else {
                 stream = originalStream;


### PR DESCRIPTION
### Motivation
- Prevent a process crash when malformed or truncated gzip EPG responses emit zlib errors on the upstream `gunzip` stream that were previously unhandled because `stream` was reassigned to the downstream `sizeChecker` transform.

### Description
- In `src/services/epgService.js` forward `gunzip` errors into the downstream transform by adding `gunzip.on('error', (err) => { sizeChecker.destroy(err); })`, so existing `stream.on('error')` handling will run for gzip parse failures while keeping the zip-bomb `sizeChecker` guard unchanged.

### Testing
- Ran `npm run lint` which completed successfully (repository has pre-existing warnings but no new errors) and no automated tests were modified or added for this small runtime fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fac48540ec832f9f4ea5a524be3338)