### PR TITLE
fix: rebuild MPD upstream URLs after provider pooling

### DIFF
--- a/src/controllers/streamController.js
+++ b/src/controllers/streamController.js
@@ -247,22 +247,6 @@ export const proxyMpd = async (req, res) => {
               return res.sendStatus(400);
             }
         }
-    } else {
-        channel.provider_pass = decrypt(channel.provider_pass);
-        const base = channel.provider_url.replace(/\/+$/, '');
-        upstreamUrl = `${base}/live/${encodeURIComponent(channel.provider_user)}/${encodeURIComponent(channel.provider_pass)}/${channel.remote_stream_id}.mpd`;
-
-        try {
-            if (channel.backup_urls) {
-                const backups = JSON.parse(channel.backup_urls);
-                backupStreamUrls = backups.map(bUrl => {
-                    const bBase = bUrl.replace(/\/+$/, '');
-                    return `${bBase}/live/${encodeURIComponent(channel.provider_user)}/${encodeURIComponent(channel.provider_pass)}/${channel.remote_stream_id}.mpd`;
-                });
-            }
-        } catch (e) {
-            console.warn('Failed to parse backup_urls (MPD):', e.message);
-        }
     }
 
     if (user.is_share_guest) {
@@ -295,6 +279,26 @@ export const proxyMpd = async (req, res) => {
     channel.provider_pass = availableProvider.password; // Encrypted password
     channel.backup_urls = availableProvider.backup_urls;
     channel.user_agent = availableProvider.user_agent;
+
+    if (!meta?.original_url) {
+        channel.provider_pass = decrypt(channel.provider_pass);
+        const base = channel.provider_url.replace(/\/+$/, '');
+        upstreamUrl = `${base}/live/${encodeURIComponent(channel.provider_user)}/${encodeURIComponent(channel.provider_pass)}/${channel.remote_stream_id}.mpd`;
+
+        try {
+            if (channel.backup_urls) {
+                const backups = JSON.parse(channel.backup_urls);
+                backupStreamUrls = backups.map(bUrl => {
+                    const bBase = bUrl.replace(/\/+$/, '');
+                    return `${bBase}/live/${encodeURIComponent(channel.provider_user)}/${encodeURIComponent(channel.provider_pass)}/${channel.remote_stream_id}.mpd`;
+                });
+            }
+        } catch (e) {
+            console.warn('Failed to parse backup_urls (MPD):', e.message);
+        }
+    }
+
+    headers['User-Agent'] = channel.user_agent || DEFAULT_USER_AGENT;
 
     await streamManager.add(connectionId, user, sessionName, req.ip, res, channel.provider_id);
     try {

--- a/src/controllers/streamController.js
+++ b/src/controllers/streamController.js
@@ -232,6 +232,10 @@ export const proxyMpd = async (req, res) => {
         Object.assign(headers, meta.http_headers);
     }
 
+    const hasMetadataUserAgentOverride = Boolean(
+        meta?.http_headers && Object.keys(meta.http_headers).some(key => key.toLowerCase() === 'user-agent')
+    );
+
     let upstreamUrl = '';
     let backupStreamUrls = [];
 
@@ -298,7 +302,9 @@ export const proxyMpd = async (req, res) => {
         }
     }
 
-    headers['User-Agent'] = channel.user_agent || DEFAULT_USER_AGENT;
+    if (!hasMetadataUserAgentOverride) {
+        headers['User-Agent'] = channel.user_agent || DEFAULT_USER_AGENT;
+    }
 
     await streamManager.add(connectionId, user, sessionName, req.ip, res, channel.provider_id);
     try {
@@ -881,6 +887,10 @@ export const proxyMovie = async (req, res) => {
         Object.assign(headers, meta.http_headers);
     }
 
+    const hasMetadataUserAgentOverride = Boolean(
+        meta?.http_headers && Object.keys(meta.http_headers).some(key => key.toLowerCase() === 'user-agent')
+    );
+
     const shouldTranscode = (req.query.transcode === 'true') || (isBrowser(req) && /^(avi|mkv)$/i.test(ext));
 
     if (shouldTranscode) {
@@ -1265,6 +1275,10 @@ export const proxyTimeshift = async (req, res) => {
     if (meta && meta.http_headers) {
         Object.assign(headers, meta.http_headers);
     }
+
+    const hasMetadataUserAgentOverride = Boolean(
+        meta?.http_headers && Object.keys(meta.http_headers).some(key => key.toLowerCase() === 'user-agent')
+    );
 
     let upstream, successfulUrl;
     try {


### PR DESCRIPTION
### Motivation
- Prevent a provider-pooling accounting bypass where MPD/DASH upstream URLs were built before selecting a pooled provider, causing the fetch to use stale credentials while the stream was recorded against a different provider.

### Description
- Rebuild MPD `upstreamUrl` and `backupStreamUrls` after `findAvailableProvider` when `meta.original_url` is not present so the selected provider's credentials are used for the actual fetch.
- Update the outbound `User-Agent` header after overriding `channel.user_agent` so request headers match the chosen pooled provider account.
- Preserve existing behavior for `meta.original_url` paths (those continue to use the original URL resolution logic).
- Modified file: `src/controllers/streamController.js` (adjusted control flow around provider pooling and URL construction).

### Testing
- Ran `node --check src/controllers/streamController.js` with no syntax errors.
- Ran `npm exec vitest run tests/security/provider_limit.test.js tests/security/user_connection_limit.test.js` and both test files passed (2 files, 7 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fac877e270832fafafa3e92ff9a110)