### PR TITLE
fix: rebuild MPD upstream request after provider pooling

### DIFF
--- a/src/controllers/streamController.js
+++ b/src/controllers/streamController.js
@@ -223,6 +223,37 @@ export const proxyMpd = async (req, res) => {
         console.warn('Failed to parse metadata (MPD):', e.message);
     }
 
+    if (user.is_share_guest) {
+        if (!user.allowed_channels.includes(channel.user_channel_id)) return res.sendStatus(403);
+        const nowSec = Date.now() / 1000;
+        if ((user.share_start && nowSec < user.share_start) || (user.share_end && nowSec > user.share_end)) return res.sendStatus(403);
+    }
+
+    const sessionName = `${channel.name} (DASH)`;
+
+    // Check User connection limit first
+    if (user.max_connections > 0) {
+        const isSessionActiveForUser = await streamManager.isSessionActive(user.id, req.ip, sessionName, channel.provider_id);
+        if (!isSessionActiveForUser) {
+            const active = await streamManager.getUserConnectionCount(user.id);
+            if (active >= user.max_connections) return res.status(403).send('Max connections reached');
+        }
+    }
+
+    // Provider Pooling: Find an available provider account with the same URL
+    const availableProvider = await findAvailableProvider(user.id, channel, req.ip, sessionName);
+    if (!availableProvider) {
+        return res.status(403).send('Provider max connections reached across all accounts');
+    }
+
+    // Override channel provider credentials with the available pool account
+    channel.provider_id = availableProvider.id;
+    channel.provider_url = availableProvider.url;
+    channel.provider_user = availableProvider.username;
+    channel.provider_pass = availableProvider.password; // Encrypted password
+    channel.backup_urls = availableProvider.backup_urls;
+    channel.user_agent = availableProvider.user_agent;
+
     const headers = {
       'User-Agent': channel.user_agent || DEFAULT_USER_AGENT,
       'Connection': 'keep-alive'
@@ -264,37 +295,6 @@ export const proxyMpd = async (req, res) => {
             console.warn('Failed to parse backup_urls (MPD):', e.message);
         }
     }
-
-    if (user.is_share_guest) {
-        if (!user.allowed_channels.includes(channel.user_channel_id)) return res.sendStatus(403);
-        const nowSec = Date.now() / 1000;
-        if ((user.share_start && nowSec < user.share_start) || (user.share_end && nowSec > user.share_end)) return res.sendStatus(403);
-    }
-
-    const sessionName = `${channel.name} (DASH)`;
-
-    // Check User connection limit first
-    if (user.max_connections > 0) {
-        const isSessionActiveForUser = await streamManager.isSessionActive(user.id, req.ip, sessionName, channel.provider_id);
-        if (!isSessionActiveForUser) {
-            const active = await streamManager.getUserConnectionCount(user.id);
-            if (active >= user.max_connections) return res.status(403).send('Max connections reached');
-        }
-    }
-
-    // Provider Pooling: Find an available provider account with the same URL
-    const availableProvider = await findAvailableProvider(user.id, channel, req.ip, sessionName);
-    if (!availableProvider) {
-        return res.status(403).send('Provider max connections reached across all accounts');
-    }
-
-    // Override channel provider credentials with the available pool account
-    channel.provider_id = availableProvider.id;
-    channel.provider_url = availableProvider.url;
-    channel.provider_user = availableProvider.username;
-    channel.provider_pass = availableProvider.password; // Encrypted password
-    channel.backup_urls = availableProvider.backup_urls;
-    channel.user_agent = availableProvider.user_agent;
 
     await streamManager.add(connectionId, user, sessionName, req.ip, res, channel.provider_id);
     try {

--- a/tests/security/provider_limit.test.js
+++ b/tests/security/provider_limit.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as streamController from '../../src/controllers/streamController.js';
 import streamManager from '../../src/services/streamManager.js';
 import { getXtreamUser } from '../../src/services/authService.js';
+import fetch from 'node-fetch';
 
 // --- Mocks ---
 
@@ -63,6 +64,18 @@ vi.mock('../../src/database/db.js', () => ({
                         if (streamId === 101 || streamId === '101') {
                             return { ...base, provider_id: 101, provider_max_connections: 1 };
                         }
+                        if (streamId === 202 || streamId === '202') {
+                            return {
+                                ...base,
+                                provider_id: 201,
+                                provider_url: 'http://example.com',
+                                provider_user: 'acctA',
+                                provider_pass: 'passA',
+                                remote_stream_id: '555',
+                                backup_urls: '["http://backup.example.com"]',
+                                user_agent: 'UA-A'
+                            };
+                        }
                         return base;
                     })
                 };
@@ -70,6 +83,12 @@ vi.mock('../../src/database/db.js', () => ({
             if (query.includes('FROM providers WHERE user_id = ? AND url LIKE ?')) {
                 return {
                     all: vi.fn().mockImplementation((userId, urlPattern) => {
+                        if (global._testMode === 'mpdPool') {
+                            return [
+                                { id: 201, url: 'http://example.com', username: 'acctA', password: 'passA', max_connections: 1, backup_urls: '["http://backup-a.example.com"]', user_agent: 'UA-A' },
+                                { id: 202, url: 'http://example.com', username: 'acctB', password: 'passB', max_connections: 2, backup_urls: '["http://backup-b.example.com"]', user_agent: 'UA-B' }
+                            ];
+                        }
                         // Return mock providers based on the pool request
                         if (urlPattern.includes('example.com')) {
                             // If we set global._testMode = 'block', make all providers limited
@@ -199,5 +218,34 @@ describe('Provider Connection Limit', () => {
 
         expect(streamManager.getProviderConnectionCount).toHaveBeenCalledWith(101);
         expect(streamManager.add).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything(), 101);
+    });
+
+    it('should build MPD upstream URL using pooled provider credentials', async () => {
+        global._testMode = 'mpdPool';
+        getXtreamUser.mockResolvedValue({ id: 1, username: 'user1', max_connections: 0 });
+        streamManager.getProviderConnectionCount.mockImplementation(async (providerId) => providerId === 201 ? 1 : 0);
+
+        const req = {
+            params: { stream_id: '202', username: 'u', password: 'p', 0: 'manifest.mpd' },
+            ip: '127.0.0.1',
+            headers: {},
+            on: vi.fn()
+        };
+        const res = {
+            sendStatus: vi.fn(),
+            setHeader: vi.fn(),
+            send: vi.fn(),
+            status: vi.fn().mockReturnThis()
+        };
+
+        await streamController.proxyMpd(req, res);
+
+        expect(streamManager.add).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything(), 202);
+        expect(fetch).toHaveBeenCalledWith(
+            'http://example.com/live/acctB/passB/555.mpd',
+            expect.objectContaining({
+                headers: expect.objectContaining({ 'User-Agent': 'UA-B' })
+            })
+        );
     });
 });


### PR DESCRIPTION
### Motivation
- The MPD proxy built `upstreamUrl`, backup URLs, and request `headers` from the original provider before provider-pooling could swap in a fallback account, allowing accounting to be charged to a different provider than the one actually contacted.
- The change ensures provider selection and connection-accounting are always aligned with the actual upstream request to prevent provider overuse or bans.

### Description
- Moved MPD request construction (`headers`, `upstreamUrl`, and `backupStreamUrls`) in `proxyMpd` to run after `findAvailableProvider` and after the `channel` credentials are overridden, so the actual fetch uses the selected pooled provider account (`src/controllers/streamController.js`).
- Added a focused regression test `should build MPD upstream URL using pooled provider credentials` and extended mocks to simulate a saturated provider and an available pooled provider (`tests/security/provider_limit.test.js`).
- Minor test adjustments include importing `fetch` and adding a `stream_id=202` channel fixture and pooled provider fixtures to the test DB mock.

### Testing
- Ran the targeted test: `npm exec vitest run tests/security/provider_limit.test.js`, and the test file passed (all tests in the file succeeded).
- Ran linters with `npm run lint`; lint produced pre-existing warnings but no new errors were introduced.
- The targeted test verifies that `streamManager.add` records the pooled provider id and that the upstream `fetch` is invoked with the pooled provider credentials and `User-Agent` as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fac8c54c64832fbe1ea5c9418c9752)