### PR TITLE
Fix EPG import crash on channels without id

### DIFF
--- a/src/services/epgService.js
+++ b/src/services/epgService.js
@@ -107,9 +107,21 @@ export async function importEpgFromUrl(url, sourceType, sourceId) {
         let currentText = '';
 
         await new Promise((resolve, reject) => {
+            let settled = false;
+            const safeReject = (err) => {
+                if (settled) return;
+                settled = true;
+                reject(err);
+            };
+            const safeResolve = (value) => {
+                if (settled) return;
+                settled = true;
+                resolve(value);
+            };
+
             parser.on('error', function (e) {
                 console.error("XML Parse Error", e);
-                reject(e);
+                safeReject(e);
             });
 
             parser.on('opentag', function (name, attrs) {
@@ -120,9 +132,15 @@ export async function importEpgFromUrl(url, sourceType, sourceId) {
                 }
 
                 if (name === 'channel') {
+                    const channelId = typeof attrs.id === 'string' ? attrs.id.trim() : '';
+                    if (!channelId) {
+                        currentChannel = null;
+                        return;
+                    }
+
                     currentChannel = {
-                        id: attrs.id,
-                        name: attrs.id,
+                        id: channelId,
+                        name: channelId,
                         logo: null,
                         sourceType,
                         sourceId,
@@ -194,16 +212,20 @@ export async function importEpgFromUrl(url, sourceType, sourceId) {
                 }
 
                 if (channelBatch.length >= BATCH_SIZE || programBatch.length >= BATCH_SIZE) {
-                    processBatches();
+                    try {
+                        processBatches();
+                    } catch (err) {
+                        safeReject(err);
+                    }
                 }
             });
 
             parser.on('finish', function () {
                 try {
                     processBatches();
-                    resolve({ success: true });
+                    safeResolve({ success: true });
                 } catch (err) {
-                    reject(err);
+                    safeReject(err);
                 }
             });
 
@@ -214,12 +236,12 @@ export async function importEpgFromUrl(url, sourceType, sourceId) {
                     console.warn(`⚠️ Ignoring unexpected end of file in GZIP stream for ${sourceType} ${sourceId}, saving parsed data...`);
                     try {
                         processBatches();
-                        resolve({ success: true });
+                        safeResolve({ success: true });
                     } catch (e) {
-                        reject(e);
+                        safeReject(e);
                     }
                 } else {
-                    reject(err);
+                    safeReject(err);
                 }
             });
         });


### PR DESCRIPTION
### Motivation
- A recent SAX-based EPG refactor constructed channel objects from `attrs.id` without validating presence, allowing empty `id` values to be queued and causing `NOT NULL` SQLite constraint errors during batched inserts that could escape SAX event callbacks and crash the process. 

### Description
- Skip `<channel>` entries that do not provide a non-empty `id` by trimming and validating `attrs.id` before creating `currentChannel` so only valid channels are queued for insertion. 
- Add guarded promise-settlement helpers `safeResolve` / `safeReject` around the XML streaming `Promise` to prevent double-settlement and to ensure asynchronous parser/stream errors are routed through the same promise flow. 
- Wrap `processBatches()` calls invoked from SAX event handlers in `try/catch` and call `safeReject` on errors so database insertion failures are surfaced as promise rejections instead of uncaught exceptions. 
- Use the guarded resolve/reject helpers for the parser `finish` and stream `error` handlers for consistent error propagation and cleanup. 

### Testing
- Ran `npm run lint` which completed (repository contains pre-existing warnings but no new lint errors). 
- Ran the targeted test suite with `npm exec vitest run tests/services/epg_service.test.js` and all tests in that file passed (8 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fad338a218832fb1434ffd35e497bb)