### PR TITLE
Fix duplicate-session stream limit bypass

### DIFF
--- a/src/controllers/streamController.js
+++ b/src/controllers/streamController.js
@@ -91,21 +91,13 @@ function getProviderPool(userId, providerUrl) {
     return providers.filter(p => p.url.replace(/\/+$/, '') === base);
 }
 
-async function findAvailableProvider(userId, originalProvider, reqIp, sessionName) {
+async function findAvailableProvider(userId, originalProvider) {
     const pool = getProviderPool(userId, originalProvider.provider_url || originalProvider.url);
 
     for (const p of pool) {
-        let isSessionActive = false;
-
         // Handle provider object structure differences (from getChannel vs getProvider)
         const pId = p.id;
         const pMaxConnections = p.max_connections;
-
-        // If the session is already active on this provider with this IP, it's free to use
-        isSessionActive = await streamManager.isSessionActive(userId, reqIp, sessionName, pId);
-        if (isSessionActive) {
-            return p;
-        }
 
         // Check if provider has reached max connections
         if (pMaxConnections > 0) {
@@ -275,15 +267,12 @@ export const proxyMpd = async (req, res) => {
 
     // Check User connection limit first
     if (user.max_connections > 0) {
-        const isSessionActiveForUser = await streamManager.isSessionActive(user.id, req.ip, sessionName, channel.provider_id);
-        if (!isSessionActiveForUser) {
-            const active = await streamManager.getUserConnectionCount(user.id);
-            if (active >= user.max_connections) return res.status(403).send('Max connections reached');
-        }
+        const active = await streamManager.getUserConnectionCount(user.id);
+        if (active >= user.max_connections) return res.status(403).send('Max connections reached');
     }
 
     // Provider Pooling: Find an available provider account with the same URL
-    const availableProvider = await findAvailableProvider(user.id, channel, req.ip, sessionName);
+    const availableProvider = await findAvailableProvider(user.id, channel);
     if (!availableProvider) {
         return res.status(403).send('Provider max connections reached across all accounts');
     }
@@ -393,16 +382,12 @@ export const proxyLive = async (req, res) => {
     // Optimization: Skip streamManager overhead for playlist requests (unless transcoding)
     if (reqExt !== 'm3u8' || wantsTranscode) {
         await streamManager.cleanupUser(user.id, req.ip);
-
         if (user.max_connections > 0) {
-            const isSessionActiveForUser = await streamManager.isSessionActive(user.id, req.ip, channel.name, channel.provider_id);
-            if (!isSessionActiveForUser) {
-                const active = await streamManager.getUserConnectionCount(user.id);
-                if (active >= user.max_connections) return res.status(403).send('Max connections reached');
-            }
+            const active = await streamManager.getUserConnectionCount(user.id);
+            if (active >= user.max_connections) return res.status(403).send('Max connections reached');
         }
 
-        const availableProvider = await findAvailableProvider(user.id, channel, req.ip, channel.name);
+        const availableProvider = await findAvailableProvider(user.id, channel);
         if (!availableProvider) {
             return res.status(403).send('Provider max connections reached across all accounts');
         }
@@ -804,16 +789,12 @@ export const proxyMovie = async (req, res) => {
     }
 
     const sessionName = `${channel.name} (VOD)`;
-
     if (user.max_connections > 0) {
-        const isSessionActiveForUser = await streamManager.isSessionActive(user.id, req.ip, sessionName, channel.provider_id);
-        if (!isSessionActiveForUser) {
-            const active = await streamManager.getUserConnectionCount(user.id);
-            if (active >= user.max_connections) return res.status(403).send('Max connections reached');
-        }
+        const active = await streamManager.getUserConnectionCount(user.id);
+        if (active >= user.max_connections) return res.status(403).send('Max connections reached');
     }
 
-    const availableProvider = await findAvailableProvider(user.id, channel, req.ip, sessionName);
+    const availableProvider = await findAvailableProvider(user.id, channel);
     if (!availableProvider) {
         return res.status(403).send('Provider max connections reached across all accounts');
     }
@@ -1024,16 +1005,12 @@ export const proxySeries = async (req, res) => {
 
     const cachedTitle = episodeNameCache.get(epIdRaw.toString());
     const sessionName = cachedTitle ? cachedTitle : `Series Episode ${remoteEpisodeId}`;
-
     if (user.max_connections > 0) {
-        const isSessionActiveForUser = await streamManager.isSessionActive(user.id, req.ip, sessionName, provider.id);
-        if (!isSessionActiveForUser) {
-            const active = await streamManager.getUserConnectionCount(user.id);
-            if (active >= user.max_connections) return res.status(403).send('Max connections reached');
-        }
+        const active = await streamManager.getUserConnectionCount(user.id);
+        if (active >= user.max_connections) return res.status(403).send('Max connections reached');
     }
 
-    const availableProvider = await findAvailableProvider(user.id, provider, req.ip, sessionName);
+    const availableProvider = await findAvailableProvider(user.id, provider);
     if (!availableProvider) {
         return res.status(403).send('Provider max connections reached across all accounts');
     }
@@ -1204,16 +1181,12 @@ export const proxyTimeshift = async (req, res) => {
     }
 
     const sessionName = `${channel.name} (Timeshift)`;
-
     if (user.max_connections > 0) {
-        const isSessionActiveForUser = await streamManager.isSessionActive(user.id, req.ip, sessionName, channel.provider_id);
-        if (!isSessionActiveForUser) {
-            const active = await streamManager.getUserConnectionCount(user.id);
-            if (active >= user.max_connections) return res.status(403).send('Max connections reached');
-        }
+        const active = await streamManager.getUserConnectionCount(user.id);
+        if (active >= user.max_connections) return res.status(403).send('Max connections reached');
     }
 
-    const availableProvider = await findAvailableProvider(user.id, channel, req.ip, sessionName);
+    const availableProvider = await findAvailableProvider(user.id, channel);
     if (!availableProvider) {
         return res.status(403).send('Provider max connections reached across all accounts');
     }


### PR DESCRIPTION
### Motivation
- A recent change allowed an active same-user/same-IP/same-channel/same-provider tuple to skip both `user.max_connections` and provider max-connection checks while still opening new upstream/transcode work, enabling resource exhaustion and provider-account abuse.  
- The intent is to preserve smart counting for logical sessions but prevent physical duplicate requests from circumventing configured limits.

### Description
- Removed the `isSessionActive` short-circuit from provider selection so a previously-active tuple no longer auto-chooses a provider without provider-limit checks by changing `findAvailableProvider` to always check provider counts.  
- Enforced `user.max_connections` unconditionally (no `isSessionActive` exemption) at stream entry points for DASH, Live, Movie/VOD, Series, and Timeshift.  
- Updated call sites to the simplified `findAvailableProvider(userId, originalProvider)` signature and kept `streamManager.add(...)` behavior unchanged so streams are still tracked.  
- Change is localized to `src/controllers/streamController.js` and is minimal to avoid regressions in migration, DB, or runtime data handling.

### Testing
- Ran the targeted unit suites: `npm exec vitest run tests/security/user_connection_limit.test.js tests/security/provider_limit.test.js` and `npm exec vitest run tests/security/user_connection_limit.test.js tests/security/provider_limit.test.js tests/managers/stream_manager_smart.test.js`, all targeted tests passed.  
- Ran linting: `npm exec eslint src/controllers/streamController.js` and full repo lint `npm run lint`, which produced only pre-existing warnings and no new errors.  
- No other automated test failures were introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fad53cdec0832fb592ed80fe844315)