### PR TITLE
Enforce user `max_connections` for HLS playlists and segments

### DIFF
--- a/src/controllers/streamController.js
+++ b/src/controllers/streamController.js
@@ -413,7 +413,9 @@ export const proxyLive = async (req, res) => {
     channel.user_agent = availableProvider.user_agent;
 
     await new Promise(resolve => setTimeout(resolve, 100));
-    await streamManager.add(connectionId, user, channel.name, req.ip, res, channel.provider_id);
+    await streamManager.add(connectionId, user, channel.name, req.ip, res, channel.provider_id, {
+      dedupe: reqExt !== 'm3u8'
+    });
 
     try {
         const now = Math.floor(Date.now() / 1000);

--- a/src/controllers/streamController.js
+++ b/src/controllers/streamController.js
@@ -390,33 +390,30 @@ export const proxyLive = async (req, res) => {
 
     const wantsTranscode = (req.query.transcode === 'true');
 
-    // Optimization: Skip streamManager overhead for playlist requests (unless transcoding)
-    if (reqExt !== 'm3u8' || wantsTranscode) {
-        await streamManager.cleanupUser(user.id, req.ip);
+    await streamManager.cleanupUser(user.id, req.ip);
 
-        if (user.max_connections > 0) {
-            const isSessionActiveForUser = await streamManager.isSessionActive(user.id, req.ip, channel.name, channel.provider_id);
-            if (!isSessionActiveForUser) {
-                const active = await streamManager.getUserConnectionCount(user.id);
-                if (active >= user.max_connections) return res.status(403).send('Max connections reached');
-            }
+    if (user.max_connections > 0) {
+        const isSessionActiveForUser = await streamManager.isSessionActive(user.id, req.ip, channel.name, channel.provider_id);
+        if (!isSessionActiveForUser) {
+            const active = await streamManager.getUserConnectionCount(user.id);
+            if (active >= user.max_connections) return res.status(403).send('Max connections reached');
         }
-
-        const availableProvider = await findAvailableProvider(user.id, channel, req.ip, channel.name);
-        if (!availableProvider) {
-            return res.status(403).send('Provider max connections reached across all accounts');
-        }
-
-        channel.provider_id = availableProvider.id;
-        channel.provider_url = availableProvider.url;
-        channel.provider_user = availableProvider.username;
-        channel.provider_pass = availableProvider.password;
-        channel.backup_urls = availableProvider.backup_urls;
-        channel.user_agent = availableProvider.user_agent;
-
-        await new Promise(resolve => setTimeout(resolve, 100));
-        await streamManager.add(connectionId, user, channel.name, req.ip, res, channel.provider_id);
     }
+
+    const availableProvider = await findAvailableProvider(user.id, channel, req.ip, channel.name);
+    if (!availableProvider) {
+        return res.status(403).send('Provider max connections reached across all accounts');
+    }
+
+    channel.provider_id = availableProvider.id;
+    channel.provider_url = availableProvider.url;
+    channel.provider_user = availableProvider.username;
+    channel.provider_pass = availableProvider.password;
+    channel.backup_urls = availableProvider.backup_urls;
+    channel.user_agent = availableProvider.user_agent;
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+    await streamManager.add(connectionId, user, channel.name, req.ip, res, channel.provider_id);
 
     try {
         const now = Math.floor(Date.now() / 1000);
@@ -740,11 +737,14 @@ export const proxySegment = async (req, res) => {
     }
 
     if (channelName && providerId) {
-        // Technically segment proxy is mostly stateless and shouldn't hit limits,
-        // but it registers as a stream. It's better not to change providerId mid-stream,
-        // so we use the providerId passed in the payload (which was the one chosen by the playlist generator).
-        // For segments, pooling might have already happened when generating the M3U8,
-        // or we just track it against the original provider.
+        if (user.max_connections > 0) {
+            const isSessionActiveForUser = await streamManager.isSessionActive(user.id, req.ip, channelName, providerId);
+            if (!isSessionActiveForUser) {
+                const active = await streamManager.getUserConnectionCount(user.id);
+                if (active >= user.max_connections) return res.status(403).send('Max connections reached');
+            }
+        }
+
         await streamManager.add(connectionId, user, `${channelName}`, req.ip, res, providerId, { dedupe: false });
     }
 

--- a/tests/security/user_connection_limit.test.js
+++ b/tests/security/user_connection_limit.test.js
@@ -223,4 +223,55 @@ describe('User Connection Limit', () => {
         // Verify count check passed
         expect(streamManager.add).toHaveBeenCalled();
     });
+
+    it('should block HLS playlist when max_connections reached', async () => {
+        getXtreamUser.mockResolvedValue({ id: 1, username: 'user1', max_connections: 1 });
+        streamManager.getUserConnectionCount.mockResolvedValue(1);
+
+        const req = {
+            params: { stream_id: '1', username: 'u', password: 'p' },
+            ip: '127.0.0.1',
+            query: {},
+            path: '/live/u/p/1.m3u8',
+            on: vi.fn()
+        };
+        const res = {
+            sendStatus: vi.fn(),
+            setHeader: vi.fn(),
+            send: vi.fn(),
+            status: vi.fn().mockReturnThis()
+        };
+
+        await streamController.proxyLive(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(403);
+        expect(res.send).toHaveBeenCalledWith(expect.stringContaining('Max connections'));
+        expect(streamManager.add).not.toHaveBeenCalled();
+    });
+
+    it('should block HLS segment when max_connections reached', async () => {
+        getXtreamUser.mockResolvedValue({ id: 1, username: 'user1', max_connections: 1 });
+        streamManager.getUserConnectionCount.mockResolvedValue(1);
+
+        const req = {
+            params: { username: 'u', password: 'p' },
+            ip: '127.0.0.1',
+            query: {
+                data: JSON.stringify({ u: 'http://example.com/seg.ts', c: 'Test Channel', p: 100 })
+            },
+            on: vi.fn()
+        };
+        const res = {
+            sendStatus: vi.fn(),
+            setHeader: vi.fn(),
+            send: vi.fn(),
+            status: vi.fn().mockReturnThis()
+        };
+
+        await streamController.proxySegment(req, res);
+
+        expect(streamManager.getUserConnectionCount).toHaveBeenCalledWith(1);
+        expect(res.status).toHaveBeenCalledWith(403);
+        expect(res.send).toHaveBeenCalledWith(expect.stringContaining('Max connections'));
+    });
 });

--- a/tests/security/user_connection_limit.test.js
+++ b/tests/security/user_connection_limit.test.js
@@ -249,6 +249,37 @@ describe('User Connection Limit', () => {
         expect(streamManager.add).not.toHaveBeenCalled();
     });
 
+    it('should register HLS playlist session without dedupe cleanup', async () => {
+        getXtreamUser.mockResolvedValue({ id: 1, username: 'user1', max_connections: 2 });
+        streamManager.getUserConnectionCount.mockResolvedValue(0);
+
+        const req = {
+            params: { stream_id: '1', username: 'u', password: 'p' },
+            ip: '127.0.0.1',
+            query: {},
+            path: '/live/u/p/1.m3u8',
+            on: vi.fn()
+        };
+        const res = {
+            sendStatus: vi.fn(),
+            setHeader: vi.fn(),
+            send: vi.fn(),
+            status: vi.fn().mockReturnThis()
+        };
+
+        await streamController.proxyLive(req, res);
+
+        expect(streamManager.add).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({ id: 1 }),
+            'Test Channel',
+            '127.0.0.1',
+            res,
+            100,
+            { dedupe: false }
+        );
+    });
+
     it('should block HLS segment when max_connections reached', async () => {
         getXtreamUser.mockResolvedValue({ id: 1, username: 'user1', max_connections: 1 });
         streamManager.getUserConnectionCount.mockResolvedValue(1);


### PR DESCRIPTION
### Motivation
- Close a security gap where HLS/DASH playback could bypass per-user `max_connections` limits and thereby exhaust provider or server resources.

### Description
- Always run user cleanup and `max_connections` checks for live requests so `.m3u8` playlist requests no longer skip enforcement by removing the previous playlist-only optimization in `src/controllers/streamController.js` and ensuring provider-pool selection and `streamManager.add` are applied for all live entry points.
- Enforce `max_connections` in the segment proxy (`proxySegment`) before registering/serving HLS media or key segments when channel/provider context is present, and only then call `streamManager.add` (updated in `src/controllers/streamController.js`).
- Preserve existing HLS playlist URL rewriting behavior while adding the above checks so the runtime behavior remains compatible but not bypassable.
- Add regression tests that assert HLS playlist (`.m3u8`) and HLS segment requests are blocked with `403` when the user has reached `max_connections` (changes in `tests/security/user_connection_limit.test.js`).

### Testing
- Ran `npm test -- --run tests/security/user_connection_limit.test.js` which passed (1 file, 6 tests all green).
- Ran `npm run lint`; linter completed with existing repository warnings but introduced no new lint errors and no blocking failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fad718b868832f97c00b9e3d2520bc)