### PR TITLE
Prevent self-service backup restore from re-granting revoked provider channels

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -82,6 +82,7 @@ this endpoint for timeline data after rendering the channel list.
 - `GET /api/users/:userId/backups`
 - `POST /api/users/:userId/backups`
 - `POST /api/users/:userId/backups/:id/restore`
+  - Self-service for own user is allowed, but restore cannot re-grant revoked channels.
 - `DELETE /api/users/:userId/backups/:id`
 
 ## System, Security, and Statistics

--- a/src/controllers/backupController.js
+++ b/src/controllers/backupController.js
@@ -70,6 +70,19 @@ export const restoreBackup = (req, res) => {
     const data = JSON.parse(backup.data);
 
     db.transaction(() => {
+      // Snapshot currently authorized provider channels for non-admin self-service restores.
+      // This prevents restoring stale/revoked channel access from backup data.
+      let allowedProviderChannelIds = null;
+      if (!req.user.is_admin) {
+        const currentProviderChannels = db.prepare(`
+          SELECT uc.provider_channel_id
+          FROM user_channels uc
+          JOIN user_categories cat ON cat.id = uc.user_category_id
+          WHERE cat.user_id = ?
+        `).all(userId);
+        allowedProviderChannelIds = new Set(currentProviderChannels.map(row => row.provider_channel_id));
+      }
+
       // Get current category ids for user
       const currentCategories = db.prepare('SELECT id FROM user_categories WHERE user_id = ?').all(userId);
       const currentCategoryIds = currentCategories.map(c => c.id);
@@ -91,7 +104,11 @@ export const restoreBackup = (req, res) => {
         insertCategory.run(cat.id, cat.user_id, cat.name, cat.sort_order, cat.is_adult, cat.type);
       }
 
-      for (const chan of data.userChannels) {
+      const restorableChannels = allowedProviderChannelIds
+        ? data.userChannels.filter(chan => allowedProviderChannelIds.has(chan.provider_channel_id))
+        : data.userChannels;
+
+      for (const chan of restorableChannels) {
         insertChannel.run(chan.id, chan.user_category_id, chan.provider_channel_id, chan.sort_order);
       }
 

--- a/src/controllers/backupController.js
+++ b/src/controllers/backupController.js
@@ -78,7 +78,7 @@ export const restoreBackup = (req, res) => {
           SELECT uc.provider_channel_id
           FROM user_channels uc
           JOIN user_categories cat ON cat.id = uc.user_category_id
-          WHERE cat.user_id = ?
+          WHERE cat.user_id = ? AND uc.is_hidden = 0
         `).all(userId);
         allowedProviderChannelIds = new Set(currentProviderChannels.map(row => row.provider_channel_id));
       }

--- a/tests/controllers/backupController.test.js
+++ b/tests/controllers/backupController.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetBackup = vi.fn();
+const mockSelectUserCategories = vi.fn();
+const mockSelectAuthorizedProviderChannels = vi.fn();
+const mockDeleteUserChannels = vi.fn();
+const mockUpdateMappings = vi.fn();
+const mockDeleteCategories = vi.fn();
+const mockInsertCategory = vi.fn();
+const mockInsertChannel = vi.fn();
+const mockUpdateMapping = vi.fn();
+
+vi.mock('../../src/database/db.js', () => ({
+  default: {
+    prepare: vi.fn((sql) => {
+      if (sql.includes('SELECT * FROM user_backups')) return { get: mockGetBackup };
+      if (sql.includes('SELECT uc.provider_channel_id')) return { all: mockSelectAuthorizedProviderChannels };
+      if (sql.includes('SELECT id FROM user_categories')) return { all: mockSelectUserCategories };
+      if (sql.includes('DELETE FROM user_channels')) return { run: mockDeleteUserChannels };
+      if (sql.includes('UPDATE category_mappings SET user_category_id = NULL')) return { run: mockUpdateMappings };
+      if (sql.includes('DELETE FROM user_categories')) return { run: mockDeleteCategories };
+      if (sql.includes('INSERT INTO user_categories')) return { run: mockInsertCategory };
+      if (sql.includes('INSERT INTO user_channels')) return { run: mockInsertChannel };
+      if (sql.includes('UPDATE category_mappings SET user_category_id = ?')) return { run: mockUpdateMapping };
+      return { run: vi.fn(), all: vi.fn(), get: vi.fn() };
+    }),
+    transaction: vi.fn((fn) => fn)
+  }
+}));
+
+import * as backupController from '../../src/controllers/backupController.js';
+
+describe('backupController.restoreBackup security behavior', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSelectUserCategories.mockReturnValue([{ id: 10 }]);
+    mockSelectAuthorizedProviderChannels.mockReturnValue([{ provider_channel_id: 1 }]);
+
+    mockGetBackup.mockReturnValue({
+      id: 9001,
+      user_id: 2,
+      data: JSON.stringify({
+        userCategories: [{ id: 10, user_id: 2, name: 'News', sort_order: 1, is_adult: 0, type: 'live' }],
+        userChannels: [
+          { id: 1000, user_category_id: 10, provider_channel_id: 1, sort_order: 1 },
+          { id: 1001, user_category_id: 10, provider_channel_id: 999, sort_order: 2 }
+        ],
+        categoryMappings: []
+      })
+    });
+  });
+
+  it('allows non-admin self-restore but filters out revoked provider channels', () => {
+    const req = { params: { userId: '2', id: '9001' }, user: { id: 2, is_admin: false } };
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+
+    backupController.restoreBackup(req, res);
+
+    expect(res.status).not.toHaveBeenCalledWith(403);
+    expect(mockGetBackup).toHaveBeenCalledWith(9001, 2);
+    expect(mockInsertChannel).toHaveBeenCalledTimes(1);
+    expect(mockInsertChannel).toHaveBeenCalledWith(1000, 10, 1, 1);
+    expect(res.json).toHaveBeenCalledWith({ success: true });
+  });
+
+  it('allows admin users to restore all backed up channels', () => {
+    const req = { params: { userId: '2', id: '9001' }, user: { id: 1, is_admin: true } };
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+
+    backupController.restoreBackup(req, res);
+
+    expect(mockGetBackup).toHaveBeenCalledWith(9001, 2);
+    expect(mockSelectAuthorizedProviderChannels).not.toHaveBeenCalled();
+    expect(mockInsertChannel).toHaveBeenCalledTimes(2);
+    expect(res.json).toHaveBeenCalledWith({ success: true });
+  });
+});


### PR DESCRIPTION
### Motivation

- Prevent non-admin users from regaining access to provider channels that have been revoked by filtering backup restores against the user's current authorized channels.
- Keep admin restore behavior unchanged so administrators can fully restore backups when needed.
- Clarify the API reference to note that self-service restores cannot re-grant revoked channels.

### Description

- Add a snapshot of currently authorized provider channel ids for non-admin restores in `restoreBackup` and use it to filter `data.userChannels` before reinserting channels.
- Preserve existing behavior for admins so the filtering step is skipped when `req.user.is_admin` is true.
- Update `docs/API_REFERENCE.md` to state that self-service restores are allowed but cannot re-grant revoked channels.
- Add unit tests in `tests/controllers/backupController.test.js` that verify non-admin restores filter out revoked provider channels and admins restore all backed up channels.

### Testing

- Ran unit tests under `tests/controllers/backupController.test.js` with `vitest` and the new tests passed.
- Verified the new restore logic by mocking database responses and asserting the number and parameters of `INSERT` calls for channels.
- No automated tests failed during the rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fad81493bc832f9350ca3b891fe931)