### PR TITLE
fix: restrict backup restore to admins

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -82,6 +82,7 @@ this endpoint for timeline data after rendering the channel list.
 - `GET /api/users/:userId/backups`
 - `POST /api/users/:userId/backups`
 - `POST /api/users/:userId/backups/:id/restore`
+  - Admin-only: non-admin users cannot restore backups.
 - `DELETE /api/users/:userId/backups/:id`
 
 ## System, Security, and Statistics

--- a/src/controllers/backupController.js
+++ b/src/controllers/backupController.js
@@ -62,7 +62,7 @@ export const restoreBackup = (req, res) => {
     const userId = Number(req.params.userId);
     const backupId = Number(req.params.id);
 
-    if (!req.user.is_admin && req.user.id !== userId) return res.status(403).json({ error: 'Access denied' });
+    if (!req.user.is_admin) return res.status(403).json({ error: 'Access denied' });
 
     const backup = db.prepare('SELECT * FROM user_backups WHERE id = ? AND user_id = ?').get(backupId, userId);
     if (!backup) return res.status(404).json({ error: 'Backup not found' });

--- a/tests/controllers/backupController.test.js
+++ b/tests/controllers/backupController.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGet = vi.fn();
+const mockRun = vi.fn();
+
+vi.mock('../../src/database/db.js', () => ({
+  default: {
+    prepare: vi.fn((sql) => {
+      if (sql.includes('SELECT * FROM user_backups')) return { get: mockGet };
+      if (sql.includes('SELECT id FROM user_categories')) return { all: vi.fn(() => []) };
+      return { run: mockRun };
+    }),
+    transaction: vi.fn((fn) => fn)
+  }
+}));
+
+import * as backupController from '../../src/controllers/backupController.js';
+
+describe('backupController.restoreBackup authorization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockReturnValue({ id: 9001, user_id: 2, data: JSON.stringify({ userCategories: [], userChannels: [], categoryMappings: [] }) });
+  });
+
+  it('blocks non-admin users from restoring their own backup', () => {
+    const req = { params: { userId: '2', id: '9001' }, user: { id: 2, is_admin: false } };
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+
+    backupController.restoreBackup(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Access denied' });
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('allows admin users to restore backup for a target user', () => {
+    const req = { params: { userId: '2', id: '9001' }, user: { id: 1, is_admin: true } };
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+
+    backupController.restoreBackup(req, res);
+
+    expect(mockGet).toHaveBeenCalledWith(9001, 2);
+    expect(res.json).toHaveBeenCalledWith({ success: true });
+  });
+});


### PR DESCRIPTION
### Motivation
- Close an authorization rollback vulnerability where non-admin users could restore backups and reinsert `user_channels` rows that re-granted previously revoked streaming access.

### Description
- Make `restoreBackup` admin-only by rejecting requests when `req.user.is_admin` is false, leaving listing and creation endpoints unchanged.
- Update `docs/API_REFERENCE.md` to document that the restore endpoint is admin-only.
- Add a focused controller test `tests/controllers/backupController.test.js` that asserts non-admin restores are denied and admin restores are allowed.

### Testing
- Ran `npm run lint` which completed (repository contains pre-existing warnings but lint finished successfully).
- Ran `npm exec vitest run tests/controllers/backupController.test.js` and the new tests passed (2 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fad2a976b0832f9e2759b02ac0e218)