### PR TITLE
fix(security): guard EPG XML importer against oversized text nodes

### DIFF
--- a/src/services/epgService.js
+++ b/src/services/epgService.js
@@ -103,6 +103,7 @@ export async function importEpgFromUrl(url, sourceType, sourceId) {
 
         // Implement node-xml-stream for robust streaming XML parsing
         const parser = new XmlStream();
+        const MAX_XML_TEXT_NODE_LENGTH = 50 * 1024; // 50KB safeguard against unbounded text growth
 
         let currentTag = null;
         let currentChannel = null;
@@ -163,7 +164,14 @@ export async function importEpgFromUrl(url, sourceType, sourceId) {
             });
 
             const appendText = (text) => {
-                 if (currentChannel && currentTag === 'display-name') {
+                if (currentText.length + text.length > MAX_XML_TEXT_NODE_LENGTH) {
+                    reject(new Error(`EPG XML text node exceeds ${MAX_XML_TEXT_NODE_LENGTH} bytes limit`));
+                    stream.destroy();
+                    parser.end();
+                    return;
+                }
+
+                if (currentChannel && currentTag === 'display-name') {
                     currentText += text;
                 } else if (currentProgram && (currentTag === 'title' || currentTag === 'desc')) {
                     currentText += text;


### PR DESCRIPTION
### Motivation

- The streaming EPG importer parsed untrusted provider XML and accumulated text for `display-name`, `title`, and `desc` without any per-node size limit, enabling a remote provider to cause unbounded memory growth and a DoS. 

### Description

- Add a per-node text-size cap `MAX_XML_TEXT_NODE_LENGTH = 50 * 1024` to the streaming parser in `src/services/epgService.js`. 
- Enforce the cap in the shared `appendText` handler and abort the import by rejecting the parser promise, calling `stream.destroy()`, and closing the parser when the limit is exceeded. 
- This change bounds text accumulation for `display-name`, `title`, and `desc` while preserving the existing GZIP handling, streaming `node-xml-stream` flow, and batch DB insertion logic. 

### Testing

- Ran `npm run lint`, which completed successfully and reported only pre-existing warnings. 
- Ran `npm test -- epgService`, which found no matching tests in the repository. 
- Ran `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fad9717504832fa36484cd66d78f35)