### PR TITLE
Bind optimized HLS base/data segment tokens

### DIFF
--- a/src/controllers/streamController.js
+++ b/src/controllers/streamController.js
@@ -562,7 +562,8 @@ export const proxyLive = async (req, res) => {
       if (cookies) headersToForward['Cookie'] = cookies;
 
       // Optimization: Encrypt headers and safe-check once
-      const basePayload = { h: headersToForward, s: isProviderSafe };
+      const bindingId = crypto.randomUUID();
+      const basePayload = { h: headersToForward, s: isProviderSafe, b: bindingId };
       const baseEncrypted = encrypt(JSON.stringify(basePayload));
       const baseEncoded = encodeURIComponent(baseEncrypted);
 
@@ -572,7 +573,7 @@ export const proxyLive = async (req, res) => {
         try {
           const absoluteUrl = new URL(line, baseUrl).toString();
           // Only encrypt the changing URL part
-          const payload = { u: absoluteUrl, c: channel.name, p: channel.provider_id };
+          const payload = { u: absoluteUrl, c: channel.name, p: channel.provider_id, b: bindingId };
           const encrypted = encrypt(JSON.stringify(payload));
           return `/live/segment/${encodeURIComponent(req.params.username)}/${encodeURIComponent(req.params.password)}/seg.ts?data=${encodeURIComponent(encrypted)}&base=${baseEncoded}${tokenParam}`;
         } catch (e) {
@@ -582,7 +583,7 @@ export const proxyLive = async (req, res) => {
         try {
           const absoluteUrl = new URL(p1, baseUrl).toString();
           // Only encrypt the changing URL part
-          const payload = { u: absoluteUrl, c: channel.name, p: channel.provider_id };
+          const payload = { u: absoluteUrl, c: channel.name, p: channel.provider_id, b: bindingId };
           const encrypted = encrypt(JSON.stringify(payload));
           return `URI="/live/segment/${encodeURIComponent(req.params.username)}/${encodeURIComponent(req.params.password)}/seg.key?data=${encodeURIComponent(encrypted)}&base=${baseEncoded}${tokenParam}"`;
         } catch (e) {
@@ -669,6 +670,8 @@ export const proxySegment = async (req, res) => {
 
     let isOriginSafe = true;
 
+    let baseBindingId = null;
+
     // Handle 'base' param for optimized static headers/settings
     if (req.query.base) {
         try {
@@ -677,6 +680,7 @@ export const proxySegment = async (req, res) => {
                 const basePayload = JSON.parse(decryptedBase);
                 if (basePayload.h) Object.assign(headers, basePayload.h);
                 if (basePayload.s === false) isOriginSafe = false;
+                if (basePayload.b) baseBindingId = basePayload.b;
             }
         } catch(e) {}
     }
@@ -690,6 +694,9 @@ export const proxySegment = async (req, res) => {
             if (payload.u) targetUrl = payload.u;
             if (payload.c) channelName = payload.c;
             if (payload.p) providerId = payload.p;
+            if (req.query.base) {
+                if (!payload.b || !baseBindingId || payload.b !== baseBindingId) return res.sendStatus(400);
+            }
             // Merge per-segment overrides (if any, legacy support)
             if (payload.h) Object.assign(headers, payload.h);
             if (payload.s !== undefined) {
@@ -1289,7 +1296,8 @@ export const proxyTimeshift = async (req, res) => {
       if (cookies) headersToForward['Cookie'] = cookies;
 
       // Optimization: Encrypt headers and safe-check once
-      const basePayload = { h: headersToForward, s: isProviderSafe };
+      const bindingId = crypto.randomUUID();
+      const basePayload = { h: headersToForward, s: isProviderSafe, b: bindingId };
       const baseEncrypted = encrypt(JSON.stringify(basePayload));
       const baseEncoded = encodeURIComponent(baseEncrypted);
 
@@ -1299,7 +1307,7 @@ export const proxyTimeshift = async (req, res) => {
         try {
           const absoluteUrl = new URL(line, baseUrl).toString();
           // Only encrypt the changing URL part
-          const payload = { u: absoluteUrl, c: channel.name, p: channel.provider_id };
+          const payload = { u: absoluteUrl, c: channel.name, p: channel.provider_id, b: bindingId };
           const encrypted = encrypt(JSON.stringify(payload));
           return `/live/segment/${encodeURIComponent(req.params.username)}/${encodeURIComponent(req.params.password)}/seg.ts?data=${encodeURIComponent(encrypted)}&base=${baseEncoded}${tokenParam}`;
         } catch (e) {

--- a/tests/performance/segment_encryption.test.js
+++ b/tests/performance/segment_encryption.test.js
@@ -101,14 +101,17 @@ describe('Segment Encryption Format', () => {
 
     it('should support OPTIMIZED format (url in "data", headers in "base")', async () => {
         const targetUrl = 'http://example.com/optimized.ts';
+        const bindingId = 'binding-id-1';
         const basePayload = {
             h: { 'X-Custom-Header': 'OptimizedHeader' },
-            s: true
+            s: true,
+            b: bindingId
         };
         const baseEncrypted = encrypt(JSON.stringify(basePayload));
 
         const dataPayload = {
-            u: targetUrl
+            u: targetUrl,
+            b: bindingId
         };
         const dataEncrypted = encrypt(JSON.stringify(dataPayload));
 
@@ -122,5 +125,25 @@ describe('Segment Encryption Format', () => {
         const lastCall = fetch.mock.calls[fetch.mock.calls.length - 1];
         expect(lastCall[0]).toBe(targetUrl);
         expect(lastCall[1].headers).toHaveProperty('X-Custom-Header', 'OptimizedHeader');
+    });
+
+
+    it('should reject OPTIMIZED format when base/data binding does not match', async () => {
+        const baseEncrypted = encrypt(JSON.stringify({
+            h: { 'X-Custom-Header': 'OptimizedHeader' },
+            s: true,
+            b: 'base-binding'
+        }));
+
+        const dataEncrypted = encrypt(JSON.stringify({
+            u: 'http://example.com/mismatch.ts',
+            b: 'different-binding'
+        }));
+
+        const res = await request(app)
+            .get(`/live/segment/${username}/password/seg.ts`)
+            .query({ token: userToken, data: dataEncrypted, base: baseEncrypted });
+
+        expect(res.status).toBe(400);
     });
 });


### PR DESCRIPTION
### Motivation
- A security issue allowed replay/mix-and-match of split HLS encrypted `base` and `data` blobs, letting attackers combine headers/safety flags from one playlist with a URL from another to bypass `isSafeUrl` and exfiltrate/internal-request sensitive data. 
- The change must preserve the optimized split format while preventing cross-playlist token recombination.

### Description
- Generate a per-playlist `bindingId` (`b`) in the HLS rewriting paths (`proxyLive` and `proxyTimeshift`) and include it in both the encrypted `base` and per-segment `data` payloads in `src/controllers/streamController.js`.
- Validate in `proxySegment` that when a `base` is supplied the decrypted `data.b` matches the `base.b`, returning HTTP `400` on missing/mismatched binding, while keeping legacy single-payload (`data` only) behavior intact.
- Add/update targeted tests in `tests/performance/segment_encryption.test.js` to include binding-aware optimized payloads and a negative test that ensures mismatched bindings are rejected.

### Testing
- Added/updated `tests/performance/segment_encryption.test.js` to cover legacy, optimized, and mismatched-binding cases (new negative test asserts `400` for mismatch). 
- Attempted to run the targeted suite with `npm exec vitest run tests/performance/segment_encryption.test.js` but the run failed in this environment due to missing native `better-sqlite3` bindings (`better_sqlite3.node`), so the test suite could not execute here. 
- The fix is minimal and localized to `src/controllers/streamController.js` and the added assertions, preserving existing behaviors; please run CI (or `npm exec vitest ...`) in an environment with `better-sqlite3` native bindings to verify tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fad932fa04832f9a54f6afecd8d233)