### PR TITLE
Ensure initial admin password is set and visible during non-interactive installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ chmod +x proxmox.sh
 
 ### First Time Setup
 - **Default Username**: `admin`
-- **Default Password**: Automatically generated (check your console output).
+- **Default Password**: Set by `scripts/install.sh` and printed at the end of the install (also saved as `INITIAL_ADMIN_PASSWORD` in `/opt/iptv-manager/.env`).
 - **Important**: Change password immediately after login.
 
 ### CORS Configuration

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -51,11 +51,20 @@ cd "$INSTALL_DIR"
 echo ">> Installing application dependencies..."
 npm install
 
-# Setup environment variables
+# Create an initial admin password so it is always visible in non-interactive installs
 if [ ! -f ".env" ]; then
     echo ">> Setting up .env file..."
     cp .env.example .env
     echo ">> .env file created. Please configure it later if needed."
+fi
+
+if ! grep -q '^INITIAL_ADMIN_PASSWORD=' .env || [ -z "$(grep '^INITIAL_ADMIN_PASSWORD=' .env | cut -d'=' -f2-)" ]; then
+    INITIAL_ADMIN_PASSWORD_GENERATED=$(openssl rand -hex 8)
+    sed -i "s|^INITIAL_ADMIN_PASSWORD=.*|INITIAL_ADMIN_PASSWORD=${INITIAL_ADMIN_PASSWORD_GENERATED}|" .env
+    echo ">> Generated initial admin password and saved it to .env"
+else
+    INITIAL_ADMIN_PASSWORD_GENERATED=$(grep '^INITIAL_ADMIN_PASSWORD=' .env | cut -d'=' -f2-)
+    echo ">> Reusing existing INITIAL_ADMIN_PASSWORD from .env"
 fi
 
 # Create a dedicated user for security
@@ -106,6 +115,11 @@ echo ">> IPTV-Manager is now running as a background service."
 echo ">> You can access the application at: http://$(hostname -I | awk '{print $1}'):3000"
 echo ">> To check the logs, run: sudo journalctl -u iptv-manager -f"
 echo ">> To update in the future, run: sudo ./scripts/update.sh from the $INSTALL_DIR directory."
+echo ""
+echo ">> Initial WebUI admin credentials:"
+echo "   Username: admin"
+echo "   Password: ${INITIAL_ADMIN_PASSWORD_GENERATED}"
+echo "   (Stored in $INSTALL_DIR/.env as INITIAL_ADMIN_PASSWORD)"
 echo ""
 echo "Note: The default port is 3000. Ensure it is open in your firewall."
 if command -v ufw > /dev/null; then


### PR DESCRIPTION
### Motivation
- The randomly generated default admin password was printed by the app at first startup and could be missed in non-interactive environments (e.g., Proxmox LXC), so installs lacked a visible admin password.
- The installer should reliably provide credentials and persist them so users can log in after a fresh automated install.

### Description
- Updated `scripts/install.sh` to create `.env` if missing and ensure `INITIAL_ADMIN_PASSWORD` is populated during fresh installs. 
- When `INITIAL_ADMIN_PASSWORD` is empty the script generates a value with `openssl rand -hex 8`, saves it into `.env`, and exposes it via `INITIAL_ADMIN_PASSWORD_GENERATED`.
- The installer now prints the initial WebUI credentials at the end of the install and documents that the password is stored in `/opt/iptv-manager/.env` as `INITIAL_ADMIN_PASSWORD`.
- Updated `README.md` First Time Setup text to reflect that `scripts/install.sh` sets and prints the initial admin password.

### Testing
- Ran `npm run lint`, which completed successfully with the repository's existing warnings and no new errors.
- Verified the modified `scripts/install.sh` prints the credentials block at the end of the script during a dry inspection of the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15c46fd61c832f959fc9ff6942a599)