### PR TITLE
fix: harden channel authorization and stream compatibility

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -12,6 +12,37 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test with isolated runtime data
+        run: |
+          test_data_dir="$(mktemp -d)"
+          trap 'rm -rf "$test_data_dir"' EXIT
+          DATA_DIR="$test_data_dir" npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Audit production dependencies
+        run: npm audit --omit=dev --audit-level=high
+
   build-docker:
     runs-on: ubuntu-latest
     permissions:
@@ -21,6 +52,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Log in to the Container registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Audit all dependencies
+        run: npm audit --audit-level=high
+
       - name: Audit production dependencies
         run: npm audit --omit=dev --audit-level=high
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -47,6 +47,7 @@ jobs:
         run: npm audit --omit=dev --audit-level=high
 
   build-docker:
+    needs: validate
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -80,7 +81,9 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
   release-package:
-    needs: build-docker
+    needs:
+      - validate
+      - build-docker
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+## Unreleased
+
+- Hardened tenant-scoped category and channel operations.
+- Validated category mapping targets before writes.
+- Preserved explicit cross-owner provider selection priority.
+- Kept stored movie extensions authoritative for playback links.
+- Cleaned up series alias lifecycle with cascading assignment removal.
+- Added a one-time authorization migration marker.
+- Made bulk channel deletion atomic with validated IDs and accurate counts.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -105,6 +105,13 @@ all providers.
 - `POST /api/users/:userId/backups/:id/restore`
 - `DELETE /api/users/:userId/backups/:id`
 
+Restore recalculates channel authorization from current category and provider
+ownership. A normal user's backup cannot recreate a historical administrator
+grant: valid cross-owner rows are restored hidden and ungranted, while missing
+references are skipped. An authenticated admin restore may deliberately create
+a current cross-owner grant. The restore response includes non-sensitive
+`channels_restored`, `channels_hidden`, and `channels_skipped` counters.
+
 ## System, Security, and Statistics
 
 - `GET /api/settings`
@@ -135,6 +142,13 @@ When enabled, each provider sync also fetches series episodes via
 is stored once per upstream panel (keyed by the normalized provider URL):
 provider entries that point at the same panel with different credentials
 share the episode catalog instead of fetching and storing it per account.
+
+Cross-owner sync configs require an explicit administrator approval. Send
+`allow_cross_owner: true` when an admin intentionally creates or updates such a
+config; the server persists this as `granted_by_admin = 1`. Unapproved
+cross-owner configs remain disabled, and scheduled syncs never infer approval
+from an owner mismatch. Same-owner configs are always normalized to
+`granted_by_admin = 0`.
 - `GET /api/sync-logs`
 - `GET /api/statistics`
 - `POST /api/statistics/streams/:streamId/terminate`
@@ -153,6 +167,11 @@ needed. Pass `force: true` to force the underlying updater.
 - `GET /api/shares`
 - `DELETE /api/shares/:token`
 - `GET /share/:slug`
+
+New short-link slugs keep a readable name prefix and add a cryptographically
+random suffix. Existing stored slugs remain valid. Public slugs and share
+management tokens are treated as bearer credentials and redacted from request
+logs.
 
 ## Proxy
 
@@ -187,6 +206,12 @@ extension `xmltv.php?gzip=1`; this is not an Xtream-specific parameter.
 the provider episode sync (see `sync_series_episodes` on sync configs). Series
 whose episodes have not been synced yet fall back to a single series-level
 entry.
+
+Expanded episode IDs bind the upstream episode to the exact authorized
+`user_channel_id`. `get_series_info`, generated M3U entries, normal credentials,
+and token-authenticated share routes use the same format. Provider-based legacy
+episode IDs are rejected fail-closed; clients should refresh series metadata or
+their playlist after upgrading. Live and movie stream IDs are unchanged.
 
 ## Stream Proxy
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -109,8 +109,10 @@ Restore recalculates channel authorization from current category and provider
 ownership. A normal user's backup cannot recreate a historical administrator
 grant: valid cross-owner rows are restored hidden and ungranted, while missing
 references are skipped. An authenticated admin restore may deliberately create
-a current cross-owner grant. The restore response includes non-sensitive
-`channels_restored`, `channels_hidden`, and `channels_skipped` counters.
+a current cross-owner grant only by sending `allow_cross_owner: true`; omitted
+or false values keep those rows hidden with grant `0`. The restore response
+includes non-sensitive `channels_restored`, `channels_hidden`, and
+`channels_skipped` counters.
 
 ## System, Security, and Statistics
 
@@ -146,8 +148,9 @@ share the episode catalog instead of fetching and storing it per account.
 Cross-owner sync configs require an explicit administrator approval. Send
 `allow_cross_owner: true` when an admin intentionally creates or updates such a
 config; the server persists this as `granted_by_admin = 1`. Unapproved
-cross-owner configs remain disabled, and scheduled syncs never infer approval
-from an owner mismatch. Same-owner configs are always normalized to
+cross-owner creates are rejected with HTTP 400, existing unapproved configs
+remain disabled, and scheduled syncs never infer approval from an owner
+mismatch. Same-owner configs are always normalized to
 `granted_by_admin = 0`.
 - `GET /api/sync-logs`
 - `GET /api/statistics`
@@ -207,11 +210,22 @@ the provider episode sync (see `sync_series_episodes` on sync configs). Series
 whose episodes have not been synced yet fall back to a single series-level
 entry.
 
-Expanded episode IDs bind the upstream episode to the exact authorized
-`user_channel_id`. `get_series_info`, generated M3U entries, normal credentials,
-and token-authenticated share routes use the same format. Provider-based legacy
-episode IDs are rejected fail-closed; clients should refresh series metadata or
-their playlist after upgrading. Live and movie stream IDs are unchanged.
+Expanded episodes use compact persistent alias IDs from `900,000,001` through
+`999,999,999`, safely within the signed 32-bit range and below the legacy ID
+namespace. Each alias binds the upstream source, series, episode, and exact
+authorized `user_channel_id`; `get_series_info`, generated M3U entries, normal
+credentials, and token-authenticated share routes use the same IDs. Cached
+provider- or assignment-based legacy IDs are accepted only when they resolve to
+exactly one currently authorized series and episode, otherwise playback fails
+closed.
+Clients should refresh series metadata or playlists when a stale ID is
+ambiguous. Live and movie stream IDs are unchanged.
+
+The public episode URL suffix is compatibility metadata. Upstream and backup
+requests use the normalized `container_extension` stored for the exact episode.
+On first startup after upgrading, the rebuildable episode cache is recreated
+when its old source-wide uniqueness key is detected; the next provider sync
+repopulates it with series-scoped keys.
 
 ## Stream Proxy
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -107,10 +107,11 @@ all providers.
 
 Restore recalculates channel authorization from current category and provider
 ownership. A normal user's backup cannot recreate a historical administrator
-grant: valid cross-owner rows are restored hidden and ungranted, while missing
-references are skipped. An authenticated admin restore may deliberately create
-a current cross-owner grant only by sending `allow_cross_owner: true`; omitted
-or false values keep those rows hidden with grant `0`. The restore response
+grant: cross-owner rows are restored with `authorization_revoked = 1`, while
+their user-selected `is_hidden` value remains separate and missing references
+are skipped. An authenticated admin restore may deliberately create a current
+cross-owner grant only by sending `allow_cross_owner: true`; omitted or false
+values keep those rows revoked with grant `0`. The restore response
 includes non-sensitive `channels_restored`, `channels_hidden`, and
 `channels_skipped` counters.
 
@@ -152,6 +153,19 @@ cross-owner creates are rejected with HTTP 400, existing unapproved configs
 remain disabled, and scheduled syncs never infer approval from an owner
 mismatch. Same-owner configs are always normalized to
 `granted_by_admin = 0`.
+
+Manual cross-owner provider syncs likewise require `allow_cross_owner: true`.
+Adding `restore_revoked_assignments: true` clears only
+`authorization_revoked` on assignments covered by that approved sync and sets
+their administrator grant; it does not clear `is_hidden`. An administrator can
+explicitly restore one legacy pre-release row through the normal channel
+assignment endpoint, which clears both states for that selected channel only.
+
+Full system imports validate stored grant and revocation flags against the
+rebuilt ownership relationships. Imported cross-owner administrator grants are
+restored only when the admin import request also includes
+`allow_cross_owner: true`; otherwise their sync configs remain disabled and
+their channel assignments remain authorization-revoked.
 - `GET /api/sync-logs`
 - `GET /api/statistics`
 - `POST /api/statistics/streams/:streamId/terminate`
@@ -207,8 +221,14 @@ extension `xmltv.php?gzip=1`; this is not an Xtream-specific parameter.
 `get.php` expands each series into one playlist entry per episode
 (`<Series Name> SXX EXX`) like a native Xtream panel, using episodes cached by
 the provider episode sync (see `sync_series_episodes` on sync configs). Series
-whose episodes have not been synced yet fall back to a single series-level
-entry.
+whose episodes have not been synced yet are omitted because a series assignment
+ID is not a playable episode ID. Provider synchronization populates the episode
+cache in the background; playlist requests never wait indefinitely for it.
+
+Provider-controlled container extensions are normalized when stored and again
+when a public or upstream URL is generated. Known MIME types are mapped to
+their standard suffixes, and values containing path, query, fragment, percent,
+control, or playlist-injection characters fall back to a safe extension.
 
 Expanded episodes use compact persistent alias IDs from `900,000,001` through
 `999,999,999`, safely within the signed 32-bit range and below the legacy ID
@@ -218,6 +238,12 @@ credentials, and token-authenticated share routes use the same IDs. Cached
 provider- or assignment-based legacy IDs are accepted only when they resolve to
 exactly one currently authorized series and episode, otherwise playback fails
 closed.
+
+Channel visibility requires `is_hidden = 0`, `authorization_revoked = 0`, and
+either matching provider/category ownership or `granted_by_admin = 1`.
+Ownership changes revoke ordinary assignments without changing the user's
+hidden preference. Same-owner assignments normalize to grant `0`; explicit
+cross-owner administrator assignments normalize to grant `1`.
 Clients should refresh series metadata or playlists when a stale ID is
 ambiguous. Live and movie stream IDs are unchanged.
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -68,6 +68,13 @@ base URLs across all users, for example `from_url: "http://provider1.com"` to
 - `GET /api/category-mappings/:providerId/:userId`
 - `PUT /api/category-mappings/:id`
 
+Reorder requests accept unique positive integer IDs only. Category reorder IDs
+must all belong to the route user, and channel reorder IDs must all belong to
+the route category; otherwise the complete request is rejected without writes.
+Category mappings accept `null` for an explicit unmap, or a category owned by
+the mapping user with the same content type. Invalid, foreign, and mixed-type
+targets are rejected without changing the mapping.
+
 ## EPG and Mapping
 
 - `GET /api/epg/now`

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -13,6 +13,15 @@
 The Docker image and release workflow use `package-lock.json` and `npm ci`.
 If dependencies change, keep `package.json` and `package-lock.json` in sync.
 
+## Pull Request Validation
+
+Pull requests to `main` must pass the Node.js 24 validation job before merge.
+It installs from `package-lock.json` with `npm ci`, runs ESLint, executes the
+full test suite with an isolated temporary `DATA_DIR`, runs the build command,
+and fails on high or critical production dependency vulnerabilities. The
+temporary test directory is removed even when a test fails. Pull-request Docker
+builds verify the image without logging in to the registry or publishing it.
+
 Node.js 24 or newer is the supported runtime. `better-sqlite3` is a native
 dependency and `geoip-lite` requires Node.js 24+, so reinstall dependencies with
 `npm install` after changing Node versions to keep native bindings aligned with

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -58,6 +58,15 @@ external WebVTT `<track>` via `subtitle_track=<ffmpeg_stream_index>` and
 server-side audio track still uses the FFmpeg MP4 output path with
 `audio_track=<ffmpeg_stream_index>`.
 
+For an explicit cross-owner channel grant, stream reservation always evaluates
+the exact source provider first and applies that provider's connection limit and
+backup URLs. A target-user provider account is eligible as account-level
+failover only when its normalized primary URL appears in the exact source
+provider's configured backup URL list. Merely sharing the same panel URL does
+not make another account compatible. Movie URL suffixes remain accepted for
+client compatibility, but the upstream extension comes only from stored channel
+metadata and falls back to `mp4`.
+
 ## Local Data
 
 By default the app stores runtime data in the repo root unless `DATA_DIR` is set.
@@ -121,6 +130,17 @@ migration keep any rows that migration hid; an approved sync can clear only
 their authorization revocation, while an administrator must explicitly restore
 a selected channel to clear its hidden state. Re-running the migration is
 idempotent and does not infer administrator grants.
+
+## Series Episode Cache Identity
+
+Series episode metadata is keyed by the normalized upstream panel URL. Provider
+accounts that use the same normalized URL therefore share one episode catalog.
+This assumes that series IDs, episode IDs, metadata, and container extensions
+are panel-global and do not vary by account. The first successful sync remains
+authoritative while its `last_modified` state is current; a later eligible and
+successful refresh for the same panel and series becomes the new authoritative
+record. Failed or unchanged sibling-account syncs do not overwrite cached
+metadata.
 
 ## Web Player Performance
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -20,7 +20,9 @@ It installs from `package-lock.json` with `npm ci`, runs ESLint, executes the
 full test suite with an isolated temporary `DATA_DIR`, runs the build command,
 and fails on high or critical production dependency vulnerabilities. The
 temporary test directory is removed even when a test fails. Pull-request Docker
-builds verify the image without logging in to the registry or publishing it.
+builds run only after validation and verify the image without logging in to the
+registry or publishing it. Tagged release archives depend on both validation
+and the Docker job, so failed lint, tests, builds, or audits block publishing.
 
 Node.js 24 or newer is the supported runtime. `better-sqlite3` is a native
 dependency and `geoip-lite` requires Node.js 24+, so reinstall dependencies with
@@ -111,6 +113,14 @@ Heavy one-time migrations should:
 - mark completion in `settings`
 - avoid repeated `VACUUM`
 - preserve existing user/provider data
+
+The channel-authorization migration preserves assignment IDs and the existing
+`is_hidden` value, adds `authorization_revoked`, and marks ungranted ownership
+mismatches as revoked. Databases that ran the earlier pre-release grant
+migration keep any rows that migration hid; an approved sync can clear only
+their authorization revocation, while an administrator must explicitly restore
+a selected channel to clear its hidden state. Re-running the migration is
+idempotent and does not infer administrator grants.
 
 ## Web Player Performance
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,8 @@
         "@iptv/xtream-api": "^1.2.1",
         "bcrypt": "^6.0.0",
         "better-sqlite3": "^12.10.0",
-        "body-parser": "^2.2.2",
-        "bootstrap": "^5.3.0",
         "cors": "^2.8.5",
         "dotenv": "^17.3.1",
-        "esbuild": "^0.28.0",
         "express": "^5.2.1",
         "express-rate-limit": "^8.5.2",
         "ffmpeg-static": "^5.3.0",
@@ -24,14 +21,12 @@
         "iso-639-1": "^3.1.5",
         "jsonwebtoken": "^9.0.3",
         "morgan": "^1.11.0",
-        "multer": "^2.1.1",
+        "multer": "^2.2.0",
         "node-fetch": "^3.3.2",
         "node-xml-stream": "^1.0.2",
         "otplib": "^13.4.1",
         "qrcode": "^1.5.4",
         "redis": "^6.0.0",
-        "sax": "^1.6.0",
-        "sortablejs": "^1.15.0",
         "systeminformation": "^5.31.7"
       },
       "devDependencies": {
@@ -61,12 +56,13 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -77,12 +73,13 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -93,12 +90,13 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -109,12 +107,13 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -125,12 +124,13 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -141,12 +141,13 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -157,12 +158,13 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -173,12 +175,13 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -189,12 +192,13 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -205,12 +209,13 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -221,12 +226,13 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -237,12 +243,13 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -253,12 +260,13 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -269,12 +277,13 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -285,12 +294,13 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -301,12 +311,13 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -317,12 +328,13 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -333,12 +345,13 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -349,12 +362,13 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -365,12 +379,13 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -381,12 +396,13 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -397,12 +413,13 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -413,12 +430,13 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -429,12 +447,13 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -445,12 +464,13 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -461,12 +481,13 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -779,17 +800,6 @@
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.5"
-      }
-    },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@redis/bloom": {
@@ -1817,25 +1827,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/bootstrap": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
-      "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/twbs"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/bootstrap"
-        }
-      ],
-      "license": "MIT",
-      "peerDependencies": {
-        "@popperjs/core": "^2.11.8"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
@@ -2404,9 +2395,10 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -2416,32 +2408,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escape-html": {
@@ -3046,17 +3038,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -3284,9 +3276,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3827,9 +3819,9 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
-      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",
@@ -4576,15 +4568,6 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
-    "node_modules/sax": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=11.0.0"
-      }
-    },
     "node_modules/semver": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
@@ -4848,12 +4831,6 @@
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
       }
-    },
-    "node_modules/sortablejs": {
-      "version": "1.15.7",
-      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.7.tgz",
-      "integrity": "sha512-Kk8wLQPlS+yi1ZEf48a4+fzHa4yxjC30M/Sr2AnQu+f/MPwvvX9XjZ6OWejiz8crBsLwSq8GHqaxaET7u6ux0A==",
-      "license": "MIT"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -5224,13 +5201,13 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
-      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
@@ -5296,490 +5273,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/vite/node_modules/fsevents": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1700,21 +1700,34 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -1814,30 +1827,17 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/body-parser/node_modules/type-is/node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer": {
@@ -3838,9 +3838,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -4207,9 +4207,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -4227,7 +4227,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -16,11 +16,8 @@
     "@iptv/xtream-api": "^1.2.1",
     "bcrypt": "^6.0.0",
     "better-sqlite3": "^12.10.0",
-    "body-parser": "^2.2.2",
-    "bootstrap": "^5.3.0",
     "cors": "^2.8.5",
     "dotenv": "^17.3.1",
-    "esbuild": "^0.28.0",
     "express": "^5.2.1",
     "express-rate-limit": "^8.5.2",
     "ffmpeg-static": "^5.3.0",
@@ -31,14 +28,12 @@
     "iso-639-1": "^3.1.5",
     "jsonwebtoken": "^9.0.3",
     "morgan": "^1.11.0",
-    "multer": "^2.1.1",
+    "multer": "^2.2.0",
     "node-fetch": "^3.3.2",
     "node-xml-stream": "^1.0.2",
     "otplib": "^13.4.1",
     "qrcode": "^1.5.4",
     "redis": "^6.0.0",
-    "sax": "^1.6.0",
-    "sortablejs": "^1.15.0",
     "systeminformation": "^5.31.7"
   },
   "devDependencies": {
@@ -49,6 +44,6 @@
     "vitest": "^4.1.8"
   },
   "overrides": {
-    "vite": "7.3.3"
+    "vite": "7.3.6"
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,4 @@
 import express from 'express';
-import bodyParser from 'body-parser';
 import cors from 'cors';
 import morgan from 'morgan';
 import path from 'path';
@@ -47,7 +46,7 @@ if (process.env.TRUST_PROXY) {
 app.use(securityHeaders);
 
 // Middleware
-app.use(bodyParser.json({ limit: '1mb' }));
+app.use(express.json({ limit: '1mb' }));
 app.use(cors({
   origin: process.env.ALLOWED_ORIGINS ? process.env.ALLOWED_ORIGINS.split(',') : false,
   credentials: true

--- a/src/controllers/backupController.js
+++ b/src/controllers/backupController.js
@@ -84,7 +84,11 @@ export const restoreBackup = (req, res) => {
 
       // Insert backup data
       const insertCategory = db.prepare('INSERT INTO user_categories (id, user_id, name, sort_order, is_adult, type) VALUES (?, ?, ?, ?, ?, ?)');
-      const insertChannel = db.prepare('INSERT INTO user_channels (id, user_category_id, provider_channel_id, sort_order) VALUES (?, ?, ?, ?)');
+      const insertChannel = db.prepare(`
+        INSERT INTO user_channels
+          (id, user_category_id, provider_channel_id, sort_order, custom_name, is_hidden, granted_by_admin)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+      `);
       const updateMapping = db.prepare('UPDATE category_mappings SET user_category_id = ?, auto_created = ? WHERE id = ?');
 
       for (const cat of data.userCategories) {
@@ -92,7 +96,15 @@ export const restoreBackup = (req, res) => {
       }
 
       for (const chan of data.userChannels) {
-        insertChannel.run(chan.id, chan.user_category_id, chan.provider_channel_id, chan.sort_order);
+        insertChannel.run(
+          chan.id,
+          chan.user_category_id,
+          chan.provider_channel_id,
+          chan.sort_order,
+          chan.custom_name || '',
+          Number(chan.is_hidden) === 1 ? 1 : 0,
+          Number(chan.granted_by_admin) === 1 ? 1 : 0
+        );
       }
 
       for (const map of data.categoryMappings) {

--- a/src/controllers/backupController.js
+++ b/src/controllers/backupController.js
@@ -1,4 +1,6 @@
 import db from '../database/db.js';
+import { clearChannelsCache } from '../services/cacheService.js';
+import { resolveAssignmentGrant } from '../utils/helpers.js';
 
 export const getBackups = (req, res) => {
   try {
@@ -68,6 +70,15 @@ export const restoreBackup = (req, res) => {
     if (!backup) return res.status(404).json({ error: 'Backup not found' });
 
     const data = JSON.parse(backup.data);
+    if (!Array.isArray(data.userCategories) || !Array.isArray(data.userChannels) || !Array.isArray(data.categoryMappings)) {
+      return res.status(400).json({ error: 'Invalid backup data' });
+    }
+    const restoredCategoryIds = new Set(data.userCategories.map(cat => Number(cat.id)));
+    if ([...restoredCategoryIds].some(id => !Number.isInteger(id) || id <= 0)) {
+      return res.status(400).json({ error: 'Invalid backup data' });
+    }
+
+    const stats = { channels_restored: 0, channels_hidden: 0, channels_skipped: 0 };
 
     db.transaction(() => {
       // Get current category ids for user
@@ -89,37 +100,66 @@ export const restoreBackup = (req, res) => {
           (id, user_category_id, provider_channel_id, sort_order, custom_name, is_hidden, granted_by_admin)
         VALUES (?, ?, ?, ?, ?, ?, ?)
       `);
-      const updateMapping = db.prepare('UPDATE category_mappings SET user_category_id = ?, auto_created = ? WHERE id = ?');
+      const getProviderOwner = db.prepare(`
+        SELECT p.user_id AS provider_owner_id
+        FROM provider_channels pc
+        JOIN providers p ON p.id = pc.provider_id
+        WHERE pc.id = ?
+      `);
+      const updateMapping = db.prepare('UPDATE category_mappings SET user_category_id = ?, auto_created = ? WHERE id = ? AND user_id = ?');
 
       for (const cat of data.userCategories) {
-        insertCategory.run(cat.id, cat.user_id, cat.name, cat.sort_order, cat.is_adult, cat.type);
+        insertCategory.run(cat.id, userId, cat.name, cat.sort_order, cat.is_adult, cat.type);
       }
 
       for (const chan of data.userChannels) {
+        const categoryId = Number(chan.user_category_id);
+        const providerChannelId = Number(chan.provider_channel_id);
+        if (!restoredCategoryIds.has(categoryId) || !Number.isInteger(providerChannelId) || providerChannelId <= 0) {
+          stats.channels_skipped++;
+          continue;
+        }
+
+        const provider = getProviderOwner.get(providerChannelId);
+        if (!provider) {
+          stats.channels_skipped++;
+          continue;
+        }
+
+        const grant = resolveAssignmentGrant({
+          categoryOwnerId: userId,
+          providerOwnerId: provider.provider_owner_id,
+          isAdmin: req.user.is_admin,
+          allowExplicitAdminGrant: true
+        });
+        const isHidden = Number(chan.is_hidden) === 1 || grant === null ? 1 : 0;
+
         insertChannel.run(
           chan.id,
-          chan.user_category_id,
-          chan.provider_channel_id,
+          categoryId,
+          providerChannelId,
           chan.sort_order,
           chan.custom_name || '',
-          Number(chan.is_hidden) === 1 ? 1 : 0,
-          Number(chan.granted_by_admin) === 1 ? 1 : 0
+          isHidden,
+          grant === 1 ? 1 : 0
         );
+        if (isHidden) stats.channels_hidden++;
+        else stats.channels_restored++;
       }
 
       for (const map of data.categoryMappings) {
-        updateMapping.run(map.user_category_id, map.auto_created, map.id);
+        const categoryId = Number(map.user_category_id);
+        if (restoredCategoryIds.has(categoryId)) {
+          updateMapping.run(categoryId, map.auto_created ? 1 : 0, map.id, userId);
+        }
       }
     })();
 
-    // Need to clear cache after modifying channels
-    import('../services/cacheService.js').then(({ clearChannelsCache }) => {
-        clearChannelsCache(userId);
-    }).catch(console.error);
-
-    res.json({ success: true });
+    clearChannelsCache(userId);
+    res.json({ success: true, ...stats });
   } catch (error) {
-    res.status(500).json({ error: error.message });
+    console.error('Restore backup error:', error);
+    res.status(500).json({ error: 'Restore failed' });
   }
 };
 

--- a/src/controllers/backupController.js
+++ b/src/controllers/backupController.js
@@ -97,8 +97,9 @@ export const restoreBackup = (req, res) => {
       const insertCategory = db.prepare('INSERT INTO user_categories (id, user_id, name, sort_order, is_adult, type) VALUES (?, ?, ?, ?, ?, ?)');
       const insertChannel = db.prepare(`
         INSERT INTO user_channels
-          (id, user_category_id, provider_channel_id, sort_order, custom_name, is_hidden, granted_by_admin)
-        VALUES (?, ?, ?, ?, ?, ?, ?)
+          (id, user_category_id, provider_channel_id, sort_order, custom_name, is_hidden,
+           granted_by_admin, authorization_revoked)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
       `);
       const getProviderOwner = db.prepare(`
         SELECT p.user_id AS provider_owner_id
@@ -132,7 +133,8 @@ export const restoreBackup = (req, res) => {
           isAdmin: req.user.is_admin,
           allowExplicitAdminGrant: req.body?.allow_cross_owner === true
         });
-        const isHidden = Number(chan.is_hidden) === 1 || grant === null ? 1 : 0;
+        const isHidden = Number(chan.is_hidden) === 1 ? 1 : 0;
+        const authorizationRevoked = grant === null ? 1 : 0;
 
         insertChannel.run(
           chan.id,
@@ -141,9 +143,10 @@ export const restoreBackup = (req, res) => {
           chan.sort_order,
           chan.custom_name || '',
           isHidden,
-          grant === 1 ? 1 : 0
+          grant === 1 ? 1 : 0,
+          authorizationRevoked
         );
-        if (isHidden) stats.channels_hidden++;
+        if (isHidden || authorizationRevoked) stats.channels_hidden++;
         else stats.channels_restored++;
       }
 

--- a/src/controllers/backupController.js
+++ b/src/controllers/backupController.js
@@ -130,7 +130,7 @@ export const restoreBackup = (req, res) => {
           categoryOwnerId: userId,
           providerOwnerId: provider.provider_owner_id,
           isAdmin: req.user.is_admin,
-          allowExplicitAdminGrant: true
+          allowExplicitAdminGrant: req.body?.allow_cross_owner === true
         });
         const isHidden = Number(chan.is_hidden) === 1 || grant === null ? 1 : 0;
 

--- a/src/controllers/channelController.js
+++ b/src/controllers/channelController.js
@@ -192,7 +192,7 @@ export const getCategoryChannels = (req, res) => {
 
     const rows = db.prepare(`
       SELECT uc.id as user_channel_id, uc.custom_name, pc.*, map.epg_channel_id as manual_epg_id, p.use_mapped_epg_icon
-      FROM user_channels uc
+      FROM authorized_user_channels uc
       JOIN provider_channels pc ON pc.id = uc.provider_channel_id
       LEFT JOIN epg_channel_mappings map ON map.provider_channel_id = pc.id
       LEFT JOIN providers p ON p.id = pc.provider_id
@@ -233,9 +233,12 @@ export const addUserChannel = (req, res) => {
       JOIN providers p ON p.id = pc.provider_id
       WHERE pc.id = ?
     `).get(Number(provider_channel_id));
-    if (!providerChannel || (!req.user.is_admin && providerChannel.user_id !== cat.user_id)) {
+    if (!providerChannel) return res.status(404).json({error: 'Channel not found'});
+    if (!req.user.is_admin && providerChannel.user_id !== cat.user_id) {
       return res.status(403).json({error: 'Access denied'});
     }
+
+    const grantedByAdmin = providerChannel.user_id === cat.user_id ? 0 : 1;
 
     const maxSort = db.prepare('SELECT COALESCE(MAX(sort_order), -1) as max_sort FROM user_channels WHERE user_category_id = ?').get(catId);
     const newSortOrder = (maxSort?.max_sort ?? -1) + 1;
@@ -244,10 +247,10 @@ export const addUserChannel = (req, res) => {
 
     let insertId;
     if (existingHidden) {
-        db.prepare('UPDATE user_channels SET is_hidden = 0, sort_order = ? WHERE id = ?').run(newSortOrder, existingHidden.id);
+        db.prepare('UPDATE user_channels SET is_hidden = 0, sort_order = ?, granted_by_admin = ? WHERE id = ?').run(newSortOrder, grantedByAdmin, existingHidden.id);
         insertId = existingHidden.id;
     } else {
-        const info = db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, sort_order) VALUES (?, ?, ?)').run(catId, Number(provider_channel_id), newSortOrder);
+        const info = db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, sort_order, granted_by_admin) VALUES (?, ?, ?, ?)').run(catId, Number(provider_channel_id), newSortOrder, grantedByAdmin);
         insertId = info.lastInsertRowid;
     }
 

--- a/src/controllers/channelController.js
+++ b/src/controllers/channelController.js
@@ -1,6 +1,6 @@
 import { clearChannelsCache } from '../services/cacheService.js';
 import db from '../database/db.js';
-import { isAdultCategory } from '../utils/helpers.js';
+import { isAdultCategory, resolveAssignmentGrant } from '../utils/helpers.js';
 import { getEpgLogo, loadEpgLogosCache } from '../services/logoResolver.js';
 
 export const getUserCategories = (req, res) => {
@@ -234,11 +234,13 @@ export const addUserChannel = (req, res) => {
       WHERE pc.id = ?
     `).get(Number(provider_channel_id));
     if (!providerChannel) return res.status(404).json({error: 'Channel not found'});
-    if (!req.user.is_admin && providerChannel.user_id !== cat.user_id) {
-      return res.status(403).json({error: 'Access denied'});
-    }
-
-    const grantedByAdmin = providerChannel.user_id === cat.user_id ? 0 : 1;
+    const grantedByAdmin = resolveAssignmentGrant({
+      categoryOwnerId: cat.user_id,
+      providerOwnerId: providerChannel.user_id,
+      isAdmin: req.user.is_admin,
+      allowExplicitAdminGrant: true
+    });
+    if (grantedByAdmin === null) return res.status(403).json({error: 'Access denied'});
 
     const maxSort = db.prepare('SELECT COALESCE(MAX(sort_order), -1) as max_sort FROM user_channels WHERE user_category_id = ?').get(catId);
     const newSortOrder = (maxSort?.max_sort ?? -1) + 1;

--- a/src/controllers/channelController.js
+++ b/src/controllers/channelController.js
@@ -22,7 +22,7 @@ export const createUserCategory = (req, res) => {
     const catType = type || 'live';
 
     const maxSort = db.prepare('SELECT COALESCE(MAX(sort_order), -1) as max_sort FROM user_categories WHERE user_id = ?').get(userId);
-    const newSortOrder = (maxSort?.max_sort || -1) + 1;
+    const newSortOrder = (maxSort?.max_sort ?? -1) + 1;
 
     const info = db.prepare('INSERT INTO user_categories (user_id, name, is_adult, sort_order, type) VALUES (?, ?, ?, ?, ?)').run(userId, name.trim(), isAdult, newSortOrder, catType);
 
@@ -227,8 +227,18 @@ export const addUserChannel = (req, res) => {
     const { provider_channel_id } = req.body;
     if (!provider_channel_id) return res.status(400).json({error: 'channel required'});
 
+    const providerChannel = db.prepare(`
+      SELECT pc.id, p.user_id
+      FROM provider_channels pc
+      JOIN providers p ON p.id = pc.provider_id
+      WHERE pc.id = ?
+    `).get(Number(provider_channel_id));
+    if (!providerChannel || (!req.user.is_admin && providerChannel.user_id !== cat.user_id)) {
+      return res.status(403).json({error: 'Access denied'});
+    }
+
     const maxSort = db.prepare('SELECT COALESCE(MAX(sort_order), -1) as max_sort FROM user_channels WHERE user_category_id = ?').get(catId);
-    const newSortOrder = (maxSort?.max_sort || -1) + 1;
+    const newSortOrder = (maxSort?.max_sort ?? -1) + 1;
 
     const existingHidden = db.prepare('SELECT id FROM user_channels WHERE user_category_id = ? AND provider_channel_id = ? AND is_hidden = 1').get(catId, Number(provider_channel_id));
 

--- a/src/controllers/channelController.js
+++ b/src/controllers/channelController.js
@@ -98,33 +98,26 @@ export const bulkDeleteUserCategories = (req, res) => {
     const { ids } = req.body;
     if (!Array.isArray(ids) || ids.length === 0) return res.status(400).json({error: 'ids array required'});
 
-    // ⚡ Bolt: Use Array(n).fill('?').join(',') instead of .map(() => '?') to avoid closure allocation overhead in V8
-    const placeholders = Array(ids.length).fill('?').join(',');
+    const categoryIds = parseUniquePositiveIds(ids);
+    if (!categoryIds) return res.status(400).json({error: 'Invalid ids'});
+    const placeholders = Array(categoryIds.length).fill('?').join(',');
+    const categories = db.prepare(`SELECT id, user_id FROM user_categories WHERE id IN (${placeholders})`).all(...categoryIds);
+    if (categories.length !== categoryIds.length) return res.status(400).json({error: 'Category not found'});
+    if (!req.user.is_admin && categories.some(category => category.user_id !== req.user.id)) {
+      return res.status(403).json({error: 'Access denied'});
+    }
 
-    const cats = db.prepare(`SELECT DISTINCT user_id FROM user_categories WHERE id IN (${placeholders})`).all(...ids);
-    const userIdsToClear = cats.map(c => c.user_id);
-
-    db.transaction(() => {
-      if (!req.user.is_admin) {
-        const checkCats = db.prepare(`SELECT id, user_id FROM user_categories WHERE id IN (${placeholders})`).all(...ids);
-        const catMap = new Map(checkCats.map(c => [c.id, c.user_id]));
-        for (const id of ids) {
-          const catUserId = catMap.get(Number(id));
-          if (catUserId === undefined || catUserId !== req.user.id) {
-            throw new Error('Access denied');
-          }
-        }
-      }
-
-      db.prepare(`DELETE FROM user_channels WHERE user_category_id IN (${placeholders})`).run(...ids);
-      db.prepare(`UPDATE category_mappings SET user_category_id = NULL, auto_created = 0 WHERE user_category_id IN (${placeholders})`).run(...ids);
-      db.prepare(`DELETE FROM user_categories WHERE id IN (${placeholders})`).run(...ids);
+    const userIdsToClear = [...new Set(categories.map(category => category.user_id))];
+    const deleted = db.transaction(() => {
+      db.prepare(`DELETE FROM user_channels WHERE user_category_id IN (${placeholders})`).run(...categoryIds);
+      db.prepare(`UPDATE category_mappings SET user_category_id = NULL, auto_created = 0 WHERE user_category_id IN (${placeholders})`).run(...categoryIds);
+      return db.prepare(`DELETE FROM user_categories WHERE id IN (${placeholders})`).run(...categoryIds).changes;
     })();
 
     db.prepare('INSERT INTO security_logs (ip, action, details, timestamp) VALUES (?, ?, ?, ?)').run(req.ip, 'category_bulk_deleted', `User ${req.user.username} bulk deleted ${ids.length} categories`, Math.floor(Date.now() / 1000));
 
     userIdsToClear.forEach(uId => clearChannelsCache(uId));
-    res.json({success: true, deleted: ids.length});
+    res.json({success: true, deleted});
   } catch (e) { res.status(500).json({error: e.message}); }
 };
 
@@ -371,34 +364,27 @@ export const bulkDeleteUserChannels = (req, res) => {
     const { ids } = req.body;
     if (!Array.isArray(ids) || ids.length === 0) return res.status(400).json({error: 'ids array required'});
 
-    // ⚡ Bolt: Use Array(n).fill('?').join(',') instead of .map(() => '?') to avoid closure allocation overhead in V8
-    const placeholders = Array(ids.length).fill('?').join(',');
-
+    const channelIds = parseUniquePositiveIds(ids);
+    if (!channelIds) return res.status(400).json({error: 'Invalid ids'});
+    const placeholders = Array(channelIds.length).fill('?').join(',');
     const channels = db.prepare(`
-        SELECT DISTINCT cat.user_id
+        SELECT uc.id, uc.is_hidden, cat.user_id
         FROM user_channels uc
         JOIN user_categories cat ON cat.id = uc.user_category_id
         WHERE uc.id IN (${placeholders})
-    `).all(...ids);
-    const userIdsToClear = channels.map(c => c.user_id);
-
-    if (!req.user.is_admin) {
-        const checkChannels = db.prepare(`
-            SELECT cat.user_id
-            FROM user_channels uc
-            JOIN user_categories cat ON cat.id = uc.user_category_id
-            WHERE uc.id IN (${placeholders})
-        `).all(...ids);
-
-        for (const ch of checkChannels) {
-            if (ch.user_id !== req.user.id) return res.status(403).json({error: 'Access denied'});
-        }
+    `).all(...channelIds);
+    if (channels.length !== channelIds.length) return res.status(400).json({error: 'Channel not found'});
+    if (!req.user.is_admin && channels.some(channel => channel.user_id !== req.user.id)) {
+      return res.status(403).json({error: 'Access denied'});
     }
 
-    db.prepare(`UPDATE user_channels SET is_hidden = 1 WHERE id IN (${placeholders})`).run(...ids);
+    const userIdsToClear = [...new Set(channels.map(channel => channel.user_id))];
+    const deleted = db.transaction(() => db.prepare(
+      `UPDATE user_channels SET is_hidden = 1 WHERE id IN (${placeholders}) AND is_hidden <> 1`
+    ).run(...channelIds).changes)();
 
     userIdsToClear.forEach(uId => clearChannelsCache(uId));
-    res.json({success: true, deleted: ids.length});
+    res.json({success: true, deleted});
   } catch (e) { res.status(500).json({error: e.message}); }
 };
 

--- a/src/controllers/channelController.js
+++ b/src/controllers/channelController.js
@@ -3,6 +3,19 @@ import db from '../database/db.js';
 import { isAdultCategory, resolveAssignmentGrant } from '../utils/helpers.js';
 import { getEpgLogo, loadEpgLogosCache } from '../services/logoResolver.js';
 
+function parsePositiveSafeInteger(value) {
+  if (typeof value === 'string' && !/^[1-9]\d*$/.test(value)) return null;
+  if (typeof value !== 'string' && typeof value !== 'number') return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function parseUniquePositiveIds(values) {
+  const ids = values.map(parsePositiveSafeInteger);
+  if (ids.some(id => id === null) || new Set(ids).size !== ids.length) return null;
+  return ids;
+}
+
 export const getUserCategories = (req, res) => {
   try {
     const userId = Number(req.params.userId);
@@ -117,19 +130,35 @@ export const bulkDeleteUserCategories = (req, res) => {
 
 export const reorderUserCategories = (req, res) => {
   try {
-    const userId = Number(req.params.userId);
+    const userId = parsePositiveSafeInteger(req.params.userId);
+    if (!userId) return res.status(400).json({error: 'Invalid user ID'});
     if (!req.user.is_admin && req.user.id !== userId) return res.status(403).json({error: 'Access denied'});
 
     const { category_ids } = req.body;
     if (!Array.isArray(category_ids)) return res.status(400).json({error: 'category_ids must be array'});
+    const categoryIds = parseUniquePositiveIds(category_ids);
+    if (!categoryIds) return res.status(400).json({error: 'Invalid category_ids'});
 
-    const update = db.prepare('UPDATE user_categories SET sort_order = ? WHERE id = ?');
+    const update = db.prepare('UPDATE user_categories SET sort_order = ? WHERE id = ? AND user_id = ?');
 
-    db.transaction(() => {
-      category_ids.forEach((catId, index) => {
-        update.run(index, catId);
+    const reordered = db.transaction(() => {
+      if (categoryIds.length === 0) return true;
+      const placeholders = Array(categoryIds.length).fill('?').join(',');
+      const matched = db.prepare(`
+        SELECT id FROM user_categories
+        WHERE user_id = ? AND id IN (${placeholders})
+      `).all(userId, ...categoryIds);
+      if (matched.length !== categoryIds.length) return false;
+
+      categoryIds.forEach((catId, index) => {
+        if (update.run(index, catId, userId).changes !== 1) {
+          throw new Error('Category reorder scope changed');
+        }
       });
+      return true;
     })();
+
+    if (!reordered) return res.status(400).json({error: 'Invalid category_ids'});
 
     clearChannelsCache(userId);
     res.json({success: true});
@@ -271,7 +300,8 @@ export const addUserChannel = (req, res) => {
 
 export const reorderUserChannels = (req, res) => {
   try {
-    const catId = Number(req.params.catId);
+    const catId = parsePositiveSafeInteger(req.params.catId);
+    if (!catId) return res.status(400).json({error: 'Invalid category ID'});
     const cat = db.prepare('SELECT user_id FROM user_categories WHERE id = ?').get(catId);
     if (!cat) return res.status(404).json({error: 'Category not found'});
     if (!req.user.is_admin && cat.user_id !== req.user.id) {
@@ -280,14 +310,29 @@ export const reorderUserChannels = (req, res) => {
 
     const { channel_ids } = req.body;
     if (!Array.isArray(channel_ids)) return res.status(400).json({error: 'channel_ids must be array'});
+    const channelIds = parseUniquePositiveIds(channel_ids);
+    if (!channelIds) return res.status(400).json({error: 'Invalid channel_ids'});
 
-    const update = db.prepare('UPDATE user_channels SET sort_order = ? WHERE id = ?');
+    const update = db.prepare('UPDATE user_channels SET sort_order = ? WHERE id = ? AND user_category_id = ?');
 
-    db.transaction(() => {
-      channel_ids.forEach((chId, index) => {
-        update.run(index, chId);
+    const reordered = db.transaction(() => {
+      if (channelIds.length === 0) return true;
+      const placeholders = Array(channelIds.length).fill('?').join(',');
+      const matched = db.prepare(`
+        SELECT id FROM user_channels
+        WHERE user_category_id = ? AND id IN (${placeholders})
+      `).all(catId, ...channelIds);
+      if (matched.length !== channelIds.length) return false;
+
+      channelIds.forEach((chId, index) => {
+        if (update.run(index, chId, catId).changes !== 1) {
+          throw new Error('Channel reorder scope changed');
+        }
       });
+      return true;
     })();
+
+    if (!reordered) return res.status(400).json({error: 'Invalid channel_ids'});
 
     clearChannelsCache(cat.user_id);
     res.json({success: true});
@@ -379,18 +424,49 @@ export const getCategoryMappings = (req, res) => {
 
 export const updateCategoryMapping = (req, res) => {
   try {
-    const id = Number(req.params.id);
+    const id = parsePositiveSafeInteger(req.params.id);
+    if (!id) return res.status(400).json({error: 'Invalid mapping ID'});
+    if (!Object.prototype.hasOwnProperty.call(req.body || {}, 'user_category_id')) {
+      return res.status(400).json({error: 'user_category_id required'});
+    }
     const { user_category_id } = req.body;
 
-    const mapping = db.prepare('SELECT user_id FROM category_mappings WHERE id = ?').get(id);
+    const mapping = db.prepare(`
+      SELECT id, user_id, provider_id, COALESCE(category_type, 'live') AS category_type
+      FROM category_mappings
+      WHERE id = ?
+    `).get(id);
     if (!mapping) return res.status(404).json({error: 'Mapping not found'});
 
     if (!req.user.is_admin && mapping.user_id !== req.user.id) {
         return res.status(403).json({error: 'Access denied'});
     }
 
-    db.prepare('UPDATE category_mappings SET user_category_id = ? WHERE id = ?')
-      .run(user_category_id ? Number(user_category_id) : null, id);
+    const targetId = user_category_id === null ? null : parsePositiveSafeInteger(user_category_id);
+    if (user_category_id !== null && !targetId) {
+      return res.status(400).json({error: 'Invalid user_category_id'});
+    }
+
+    const updated = db.transaction(() => {
+      if (targetId !== null) {
+        const target = db.prepare(`
+          SELECT id, user_id, COALESCE(type, 'live') AS type
+          FROM user_categories
+          WHERE id = ?
+        `).get(targetId);
+        if (!target || target.user_id !== mapping.user_id || target.type !== mapping.category_type) {
+          return false;
+        }
+      }
+
+      return db.prepare(`
+        UPDATE category_mappings
+        SET user_category_id = ?
+        WHERE id = ? AND user_id = ?
+      `).run(targetId, id, mapping.user_id).changes === 1;
+    })();
+
+    if (!updated) return res.status(400).json({error: 'Invalid user_category_id'});
 
     clearChannelsCache(mapping.user_id);
     res.json({success: true});

--- a/src/controllers/channelController.js
+++ b/src/controllers/channelController.js
@@ -245,14 +245,22 @@ export const addUserChannel = (req, res) => {
     const maxSort = db.prepare('SELECT COALESCE(MAX(sort_order), -1) as max_sort FROM user_channels WHERE user_category_id = ?').get(catId);
     const newSortOrder = (maxSort?.max_sort ?? -1) + 1;
 
-    const existingHidden = db.prepare('SELECT id FROM user_channels WHERE user_category_id = ? AND provider_channel_id = ? AND is_hidden = 1').get(catId, Number(provider_channel_id));
+    const existing = db.prepare('SELECT id FROM user_channels WHERE user_category_id = ? AND provider_channel_id = ?').get(catId, Number(provider_channel_id));
 
     let insertId;
-    if (existingHidden) {
-        db.prepare('UPDATE user_channels SET is_hidden = 0, sort_order = ?, granted_by_admin = ? WHERE id = ?').run(newSortOrder, grantedByAdmin, existingHidden.id);
-        insertId = existingHidden.id;
+    if (existing) {
+        db.prepare(`
+          UPDATE user_channels
+          SET is_hidden = 0, sort_order = ?, granted_by_admin = ?, authorization_revoked = 0
+          WHERE id = ?
+        `).run(newSortOrder, grantedByAdmin, existing.id);
+        insertId = existing.id;
     } else {
-        const info = db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, sort_order, granted_by_admin) VALUES (?, ?, ?, ?)').run(catId, Number(provider_channel_id), newSortOrder, grantedByAdmin);
+        const info = db.prepare(`
+          INSERT INTO user_channels
+            (user_category_id, provider_channel_id, sort_order, granted_by_admin, authorization_revoked)
+          VALUES (?, ?, ?, ?, 0)
+        `).run(catId, Number(provider_channel_id), newSortOrder, grantedByAdmin);
         insertId = info.lastInsertRowid;
     }
 

--- a/src/controllers/epgController.js
+++ b/src/controllers/epgController.js
@@ -74,7 +74,7 @@ const pruneMappingJobs = () => {
 const getUserEpgChannelIds = (user) => {
   let query = `
     SELECT DISTINCT COALESCE(map.epg_channel_id, pc.epg_channel_id) as epg_id
-    FROM user_channels uc
+    FROM authorized_user_channels uc
     JOIN user_categories cat ON cat.id = uc.user_category_id
     JOIN provider_channels pc ON pc.id = uc.provider_channel_id
     LEFT JOIN epg_channel_mappings map ON map.provider_channel_id = pc.id
@@ -373,7 +373,7 @@ export const manualMapping = async (req, res) => {
 
     if (!req.user.is_admin) {
         const used = db.prepare(`
-            SELECT 1 FROM user_channels uc
+            SELECT 1 FROM authorized_user_channels uc
             JOIN user_categories cat ON cat.id = uc.user_category_id
             WHERE uc.provider_channel_id = ? AND cat.user_id = ?
         `).get(Number(provider_channel_id), req.user.id);
@@ -401,7 +401,7 @@ export const deleteMapping = async (req, res) => {
     const id = Number(req.params.id);
     if (!req.user.is_admin) {
         const used = db.prepare(`
-            SELECT 1 FROM user_channels uc
+            SELECT 1 FROM authorized_user_channels uc
             JOIN user_categories cat ON cat.id = uc.user_category_id
             WHERE uc.provider_channel_id = ? AND cat.user_id = ?
         `).get(id, req.user.id);
@@ -450,7 +450,7 @@ export const resetMapping = async (req, res) => {
                 DELETE FROM epg_channel_mappings
                 WHERE provider_channel_id IN (
                     SELECT provider_channel_id
-                    FROM user_channels
+                    FROM authorized_user_channels
                     WHERE user_category_id = ?
                 )
             `).run(Number(category_id));
@@ -459,7 +459,7 @@ export const resetMapping = async (req, res) => {
                 DELETE FROM epg_channel_mappings
                 WHERE provider_channel_id IN (
                     SELECT uc.provider_channel_id
-                    FROM user_channels uc
+                    FROM authorized_user_channels uc
                     JOIN user_categories cat ON cat.id = uc.user_category_id
                     WHERE uc.user_category_id = ? AND cat.user_id = ?
                 )
@@ -495,13 +495,13 @@ const selectAutoMappingChannels = ({ provider_id, category_id, only_used, all_pr
   const params = [];
 
   if (all_providers) {
-    if (only_used) query += ' AND pc.id IN (SELECT provider_channel_id FROM user_channels)';
+    if (only_used) query += ' AND pc.id IN (SELECT provider_channel_id FROM authorized_user_channels)';
   } else if (category_id) {
     if (user.is_admin) {
       query += `
         AND pc.id IN (
           SELECT provider_channel_id
-          FROM user_channels
+          FROM authorized_user_channels
           WHERE user_category_id = ?
         )
       `;
@@ -510,7 +510,7 @@ const selectAutoMappingChannels = ({ provider_id, category_id, only_used, all_pr
       query += `
         AND pc.id IN (
           SELECT uc.provider_channel_id
-          FROM user_channels uc
+          FROM authorized_user_channels uc
           JOIN user_categories cat ON cat.id = uc.user_category_id
           WHERE uc.user_category_id = ? AND cat.user_id = ?
         )
@@ -520,13 +520,13 @@ const selectAutoMappingChannels = ({ provider_id, category_id, only_used, all_pr
   } else if (user.is_admin) {
     query += ' AND pc.provider_id = ?';
     params.push(Number(provider_id));
-    if (only_used) query += ' AND pc.id IN (SELECT provider_channel_id FROM user_channels)';
+    if (only_used) query += ' AND pc.id IN (SELECT provider_channel_id FROM authorized_user_channels)';
   } else {
     query += `
       AND pc.provider_id = ?
       AND pc.id IN (
         SELECT uc.provider_channel_id
-        FROM user_channels uc
+        FROM authorized_user_channels uc
         JOIN user_categories cat ON cat.id = uc.user_category_id
         WHERE cat.user_id = ?
       )

--- a/src/controllers/hdhrController.js
+++ b/src/controllers/hdhrController.js
@@ -73,7 +73,7 @@ export const lineup = async (req, res) => {
         pc.stream_type,
         pc.mime_type,
         cat.name as category_name
-      FROM user_channels uc
+      FROM authorized_user_channels uc
       JOIN provider_channels pc ON pc.id = uc.provider_channel_id
       JOIN user_categories cat ON cat.id = uc.user_category_id
       WHERE cat.user_id = ? AND pc.stream_type = 'live' AND uc.is_hidden = 0
@@ -115,7 +115,7 @@ export const auto = async (req, res) => {
     // Verify channel belongs to user
     const channel = db.prepare(`
       SELECT uc.id as user_channel_id, pc.stream_type, pc.mime_type
-      FROM user_channels uc
+      FROM authorized_user_channels uc
       JOIN provider_channels pc ON pc.id = uc.provider_channel_id
       JOIN user_categories cat ON cat.id = uc.user_category_id
       WHERE uc.id = ? AND cat.user_id = ? AND uc.is_hidden = 0

--- a/src/controllers/hdhrController.js
+++ b/src/controllers/hdhrController.js
@@ -1,6 +1,7 @@
 import db from '../database/db.js';
 import { getXtreamUser } from '../services/authService.js';
 import { getBaseUrl } from '../utils/helpers.js';
+import { normalizeContainerExtension } from '../utils/containerExtension.js';
 
 export const discover = async (req, res) => {
   try {
@@ -128,7 +129,7 @@ export const auto = async (req, res) => {
 
     if (channel.stream_type === 'movie') {
         typePath = 'movie'; // maps to proxyMovie
-        ext = channel.mime_type || 'mp4';
+        ext = normalizeContainerExtension(channel.mime_type);
     }
 
     const host = getBaseUrl(req);

--- a/src/controllers/providerController.js
+++ b/src/controllers/providerController.js
@@ -608,7 +608,7 @@ export const importCategory = async (req, res) => {
     const isAdult = isAdultCategory(category_name) ? 1 : 0;
 
     const maxSort = db.prepare('SELECT COALESCE(MAX(sort_order), -1) as max_sort FROM user_categories WHERE user_id = ?').get(user_id);
-    const newSortOrder = (maxSort?.max_sort || -1) + 1;
+    const newSortOrder = (maxSort?.max_sort ?? -1) + 1;
 
     const catInfo = db.prepare('INSERT INTO user_categories (user_id, name, is_adult, sort_order, type) VALUES (?, ?, ?, ?, ?)').run(user_id, category_name, isAdult, newSortOrder, catType);
     const newCategoryId = catInfo.lastInsertRowid;

--- a/src/controllers/providerController.js
+++ b/src/controllers/providerController.js
@@ -238,6 +238,15 @@ export const updateProvider = async (req, res) => {
     const existing = db.prepare('SELECT * FROM providers WHERE id = ?').get(id);
     if (!existing) return res.status(404).json({error: 'provider not found'});
 
+    const nextUserId = user_id !== undefined ? (user_id ? Number(user_id) : null) : existing.user_id;
+    if (nextUserId !== null && !Number.isInteger(nextUserId)) {
+      return res.status(400).json({error: 'invalid user_id'});
+    }
+    if (user_id !== undefined && nextUserId !== null && !db.prepare('SELECT id FROM users WHERE id = ?').get(nextUserId)) {
+      return res.status(404).json({error: 'User not found'});
+    }
+    const ownerChanged = nextUserId !== existing.user_id;
+
     // Process backup URLs
     let processedBackupUrls = existing.backup_urls || '[]';
     if (backup_urls !== undefined) {
@@ -302,25 +311,55 @@ export const updateProvider = async (req, res) => {
         }
     }
 
-    db.prepare(`
-      UPDATE providers
-      SET name = ?, url = ?, username = ?, password = ?, epg_url = ?, user_id = ?, epg_update_interval = ?, epg_enabled = ?, backup_urls = ?, user_agent = ?, max_connections = ?, use_mapped_epg_icon = ?
-      WHERE id = ?
-    `).run(
-      name.trim(),
-      url.trim(),
-      username.trim(),
-      finalPassword,
-      finalEpgUrl,
-      user_id !== undefined ? (user_id ? Number(user_id) : null) : existing.user_id,
-      epg_update_interval ? Number(epg_update_interval) : existing.epg_update_interval,
-      epg_enabled !== undefined ? (epg_enabled ? 1 : 0) : existing.epg_enabled,
-      processedBackupUrls,
-      user_agent ? user_agent.trim() : null,
-      finalMaxConnections,
-      use_mapped_epg_icon !== undefined ? (use_mapped_epg_icon ? 1 : 0) : existing.use_mapped_epg_icon,
-      id
-    );
+    let revokedAssignments = 0;
+    db.transaction(() => {
+      db.prepare(`
+        UPDATE providers
+        SET name = ?, url = ?, username = ?, password = ?, epg_url = ?, user_id = ?, epg_update_interval = ?, epg_enabled = ?, backup_urls = ?, user_agent = ?, max_connections = ?, use_mapped_epg_icon = ?
+        WHERE id = ?
+      `).run(
+        name.trim(),
+        url.trim(),
+        username.trim(),
+        finalPassword,
+        finalEpgUrl,
+        nextUserId,
+        epg_update_interval ? Number(epg_update_interval) : existing.epg_update_interval,
+        epg_enabled !== undefined ? (epg_enabled ? 1 : 0) : existing.epg_enabled,
+        processedBackupUrls,
+        user_agent ? user_agent.trim() : null,
+        finalMaxConnections,
+        use_mapped_epg_icon !== undefined ? (use_mapped_epg_icon ? 1 : 0) : existing.use_mapped_epg_icon,
+        id
+      );
+
+      if (ownerChanged) {
+        revokedAssignments = db.prepare(`
+          UPDATE user_channels
+          SET is_hidden = 1
+          WHERE is_hidden = 0
+            AND granted_by_admin = 0
+            AND provider_channel_id IN (
+              SELECT id FROM provider_channels WHERE provider_id = ?
+            )
+            AND NOT EXISTS (
+              SELECT 1
+              FROM user_categories cat
+              WHERE cat.id = user_channels.user_category_id
+                AND cat.user_id IS ?
+            )
+        `).run(id, nextUserId).changes;
+
+        db.prepare('INSERT INTO security_logs (ip, action, details, timestamp) VALUES (?, ?, ?, ?)').run(
+          req.ip || 'unknown',
+          'provider_owner_changed',
+          `Provider ${id} owner changed; revoked ${revokedAssignments} ungranted assignment(s)`,
+          Math.floor(Date.now() / 1000)
+        );
+      }
+    })();
+
+    if (ownerChanged) clearChannelsCache();
 
     // Check expiry
     await checkProviderExpiry(id);
@@ -599,18 +638,26 @@ export const importCategory = async (req, res) => {
       return res.status(400).json({error: 'Missing required fields'});
     }
 
-    if (!req.user.is_admin) {
-        if (Number(user_id) !== req.user.id) return res.status(403).json({error: 'Access denied'});
-        const provider = db.prepare('SELECT user_id FROM providers WHERE id = ?').get(providerId);
-        if (!provider || provider.user_id !== req.user.id) return res.status(403).json({error: 'Access denied'});
+    const targetUserId = Number(user_id);
+    if (!Number.isInteger(targetUserId) || targetUserId <= 0) {
+      return res.status(400).json({error: 'Invalid user_id'});
     }
+    if (!db.prepare('SELECT id FROM users WHERE id = ?').get(targetUserId)) {
+      return res.status(404).json({error: 'User not found'});
+    }
+    const provider = db.prepare('SELECT user_id FROM providers WHERE id = ?').get(providerId);
+    if (!provider) return res.status(404).json({error: 'Provider not found'});
+    if (!req.user.is_admin && (targetUserId !== req.user.id || provider.user_id !== req.user.id)) {
+      return res.status(403).json({error: 'Access denied'});
+    }
+    const grantedByAdmin = provider.user_id === targetUserId ? 0 : 1;
 
     const isAdult = isAdultCategory(category_name) ? 1 : 0;
 
-    const maxSort = db.prepare('SELECT COALESCE(MAX(sort_order), -1) as max_sort FROM user_categories WHERE user_id = ?').get(user_id);
+    const maxSort = db.prepare('SELECT COALESCE(MAX(sort_order), -1) as max_sort FROM user_categories WHERE user_id = ?').get(targetUserId);
     const newSortOrder = (maxSort?.max_sort ?? -1) + 1;
 
-    const catInfo = db.prepare('INSERT INTO user_categories (user_id, name, is_adult, sort_order, type) VALUES (?, ?, ?, ?, ?)').run(user_id, category_name, isAdult, newSortOrder, catType);
+    const catInfo = db.prepare('INSERT INTO user_categories (user_id, name, is_adult, sort_order, type) VALUES (?, ?, ?, ?, ?)').run(targetUserId, category_name, isAdult, newSortOrder, catType);
     const newCategoryId = catInfo.lastInsertRowid;
 
     db.prepare(`
@@ -618,7 +665,7 @@ export const importCategory = async (req, res) => {
       VALUES (?, ?, ?, ?, ?, 0, ?)
       ON CONFLICT(provider_id, user_id, provider_category_id, category_type)
       DO UPDATE SET user_category_id = excluded.user_category_id
-    `).run(providerId, user_id, Number(category_id), category_name, newCategoryId, catType);
+    `).run(providerId, targetUserId, Number(category_id), category_name, newCategoryId, catType);
 
     if (import_channels) {
       let streamType = 'live';
@@ -631,12 +678,12 @@ export const importCategory = async (req, res) => {
         ORDER BY original_sort_order ASC, name ASC
       `);
 
-      const insertChannel = db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, sort_order) VALUES (?, ?, ?)');
+      const insertChannel = db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, sort_order, granted_by_admin) VALUES (?, ?, ?, ?)');
       const channels = stmt.all(providerId, Number(category_id), streamType);
       const importedCount = channels.length;
       db.transaction(() => {
         channels.forEach((ch, idx) => {
-          insertChannel.run(newCategoryId, ch.id, idx);
+          insertChannel.run(newCategoryId, ch.id, idx, grantedByAdmin);
         });
       })();
 
@@ -669,18 +716,26 @@ export const importCategories = async (req, res) => {
       return res.status(400).json({error: 'Missing required fields or invalid categories'});
     }
 
-    if (!req.user.is_admin) {
-        if (Number(user_id) !== req.user.id) return res.status(403).json({error: 'Access denied'});
-        const provider = db.prepare('SELECT user_id FROM providers WHERE id = ?').get(providerId);
-        if (!provider || provider.user_id !== req.user.id) return res.status(403).json({error: 'Access denied'});
+    const targetUserId = Number(user_id);
+    if (!Number.isInteger(targetUserId) || targetUserId <= 0) {
+      return res.status(400).json({error: 'Invalid user_id'});
     }
+    if (!db.prepare('SELECT id FROM users WHERE id = ?').get(targetUserId)) {
+      return res.status(404).json({error: 'User not found'});
+    }
+    const provider = db.prepare('SELECT user_id FROM providers WHERE id = ?').get(providerId);
+    if (!provider) return res.status(404).json({error: 'Provider not found'});
+    if (!req.user.is_admin && (targetUserId !== req.user.id || provider.user_id !== req.user.id)) {
+      return res.status(403).json({error: 'Access denied'});
+    }
+    const grantedByAdmin = provider.user_id === targetUserId ? 0 : 1;
 
     const results = [];
     let totalChannels = 0;
     let totalCategories = 0;
 
     const insertUserCategory = db.prepare('INSERT INTO user_categories (user_id, name, is_adult, sort_order, type) VALUES (?, ?, ?, ?, ?)');
-    const insertChannel = db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, sort_order) VALUES (?, ?, ?)');
+    const insertChannel = db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, sort_order, granted_by_admin) VALUES (?, ?, ?, ?)');
     const getMaxSort = db.prepare('SELECT COALESCE(MAX(sort_order), -1) as max_sort FROM user_categories WHERE user_id = ?');
 
     // Pre-fetch channels for all categories being imported to avoid N+1 queries
@@ -707,7 +762,7 @@ export const importCategories = async (req, res) => {
     }
 
     db.transaction(() => {
-      let maxSort = getMaxSort.get(user_id).max_sort;
+      let maxSort = getMaxSort.get(targetUserId).max_sort;
 
       // ⚡ Bolt: Hoist the prepared statement outside the loop to prevent parsing/compiling the SQL on every iteration.
       const insertCategoryMapping = db.prepare(`
@@ -724,11 +779,11 @@ export const importCategories = async (req, res) => {
         const isAdult = isAdultCategory(cat.name) ? 1 : 0;
         maxSort++;
 
-        const catInfo = insertUserCategory.run(user_id, cat.name, isAdult, maxSort, catType);
+        const catInfo = insertUserCategory.run(targetUserId, cat.name, isAdult, maxSort, catType);
         const newCategoryId = catInfo.lastInsertRowid;
         totalCategories++;
 
-        insertCategoryMapping.run(providerId, user_id, Number(cat.id), cat.name, newCategoryId, catType);
+        insertCategoryMapping.run(providerId, targetUserId, Number(cat.id), cat.name, newCategoryId, catType);
 
         let channelsImported = 0;
         if (cat.import_channels) {
@@ -739,7 +794,7 @@ export const importCategories = async (req, res) => {
           const channels = channelsMap.get(`${Number(cat.id)}_${streamType}`) || [];
 
           channels.forEach((ch, idx) => {
-            insertChannel.run(newCategoryId, ch.id, idx);
+            insertChannel.run(newCategoryId, ch.id, idx, grantedByAdmin);
           });
           channelsImported = channels.length;
           totalChannels += channelsImported;

--- a/src/controllers/providerController.js
+++ b/src/controllers/providerController.js
@@ -1,7 +1,7 @@
 import db from '../database/db.js';
 import { fetchSafe } from '../utils/network.js';
 import { encrypt, decrypt } from '../utils/crypto.js';
-import { isSafeUrl, isAdultCategory, redactUrl, providerSourceKey } from '../utils/helpers.js';
+import { isSafeUrl, isAdultCategory, redactUrl, providerSourceKey, resolveAssignmentGrant } from '../utils/helpers.js';
 import { performSync, checkProviderExpiry } from '../services/syncService.js';
 import { updateProviderEpg } from '../services/epgService.js';
 import { clearChannelsCache } from '../services/cacheService.js';
@@ -312,6 +312,8 @@ export const updateProvider = async (req, res) => {
     }
 
     let revokedAssignments = 0;
+    let disabledSyncConfigs = 0;
+    let retainedSyncGrants = 0;
     db.transaction(() => {
       db.prepare(`
         UPDATE providers
@@ -350,10 +352,34 @@ export const updateProvider = async (req, res) => {
             )
         `).run(id, nextUserId).changes;
 
+        db.prepare(`
+          UPDATE sync_configs
+          SET granted_by_admin = 0
+          WHERE provider_id = ? AND user_id IS ?
+        `).run(id, nextUserId);
+
+        disabledSyncConfigs = db.prepare(`
+          UPDATE sync_configs
+          SET enabled = 0
+          WHERE provider_id = ?
+            AND user_id IS NOT ?
+            AND granted_by_admin = 0
+            AND enabled = 1
+        `).run(id, nextUserId).changes;
+
+        retainedSyncGrants = db.prepare(`
+          SELECT COUNT(*) AS count
+          FROM sync_configs
+          WHERE provider_id = ?
+            AND user_id IS NOT ?
+            AND granted_by_admin = 1
+            AND enabled = 1
+        `).get(id, nextUserId).count;
+
         db.prepare('INSERT INTO security_logs (ip, action, details, timestamp) VALUES (?, ?, ?, ?)').run(
           req.ip || 'unknown',
           'provider_owner_changed',
-          `Provider ${id} owner changed; revoked ${revokedAssignments} ungranted assignment(s)`,
+          `Provider ${id} owner changed; revoked ${revokedAssignments} ungranted assignment(s); disabled ${disabledSyncConfigs} ungranted sync config(s); retained ${retainedSyncGrants} explicit sync grant(s)`,
           Math.floor(Date.now() / 1000)
         );
       }
@@ -467,7 +493,7 @@ export const syncProvider = async (req, res) => {
         return res.status(403).json({error: 'Access denied'});
     }
 
-    const result = await performSync(id, user_id, true);
+    const result = await performSync(id, user_id, { mode: 'manual', allowCrossOwner: true });
 
     // Also trigger EPG update
     updateProviderEpg(id).catch(err => console.error(`Manual sync EPG update failed for provider ${id}:`, err.message));
@@ -647,10 +673,14 @@ export const importCategory = async (req, res) => {
     }
     const provider = db.prepare('SELECT user_id FROM providers WHERE id = ?').get(providerId);
     if (!provider) return res.status(404).json({error: 'Provider not found'});
-    if (!req.user.is_admin && (targetUserId !== req.user.id || provider.user_id !== req.user.id)) {
-      return res.status(403).json({error: 'Access denied'});
-    }
-    const grantedByAdmin = provider.user_id === targetUserId ? 0 : 1;
+    if (!req.user.is_admin && targetUserId !== req.user.id) return res.status(403).json({error: 'Access denied'});
+    const grantedByAdmin = resolveAssignmentGrant({
+      categoryOwnerId: targetUserId,
+      providerOwnerId: provider.user_id,
+      isAdmin: req.user.is_admin,
+      allowExplicitAdminGrant: true
+    });
+    if (grantedByAdmin === null) return res.status(403).json({error: 'Access denied'});
 
     const isAdult = isAdultCategory(category_name) ? 1 : 0;
 
@@ -725,10 +755,14 @@ export const importCategories = async (req, res) => {
     }
     const provider = db.prepare('SELECT user_id FROM providers WHERE id = ?').get(providerId);
     if (!provider) return res.status(404).json({error: 'Provider not found'});
-    if (!req.user.is_admin && (targetUserId !== req.user.id || provider.user_id !== req.user.id)) {
-      return res.status(403).json({error: 'Access denied'});
-    }
-    const grantedByAdmin = provider.user_id === targetUserId ? 0 : 1;
+    if (!req.user.is_admin && targetUserId !== req.user.id) return res.status(403).json({error: 'Access denied'});
+    const grantedByAdmin = resolveAssignmentGrant({
+      categoryOwnerId: targetUserId,
+      providerOwnerId: provider.user_id,
+      isAdmin: req.user.is_admin,
+      allowExplicitAdminGrant: true
+    });
+    if (grantedByAdmin === null) return res.status(403).json({error: 'Access denied'});
 
     const results = [];
     let totalChannels = 0;

--- a/src/controllers/providerController.js
+++ b/src/controllers/providerController.js
@@ -336,10 +336,34 @@ export const updateProvider = async (req, res) => {
       );
 
       if (ownerChanged) {
+        db.prepare(`
+          UPDATE user_channels
+          SET granted_by_admin = 0,
+              authorization_revoked = 0
+          WHERE provider_channel_id IN (
+            SELECT id FROM provider_channels WHERE provider_id = ?
+          )
+            AND EXISTS (
+              SELECT 1
+              FROM user_categories cat
+              WHERE cat.id = user_channels.user_category_id
+                AND cat.user_id IS ?
+            )
+        `).run(id, nextUserId);
+
+        db.prepare(`
+          UPDATE user_channels
+          SET authorization_revoked = 0
+          WHERE granted_by_admin = 1
+            AND provider_channel_id IN (
+              SELECT id FROM provider_channels WHERE provider_id = ?
+            )
+        `).run(id);
+
         revokedAssignments = db.prepare(`
           UPDATE user_channels
-          SET is_hidden = 1
-          WHERE is_hidden = 0
+          SET authorization_revoked = 1
+          WHERE authorization_revoked = 0
             AND granted_by_admin = 0
             AND provider_channel_id IN (
               SELECT id FROM provider_channels WHERE provider_id = ?
@@ -483,7 +507,7 @@ export const deleteProvider = (req, res) => {
 export const syncProvider = async (req, res) => {
   try {
     const id = Number(req.params.id);
-    const { user_id } = req.body;
+    const { user_id, allow_cross_owner, restore_revoked_assignments } = req.body;
 
     if (!user_id) {
       return res.status(400).json({error: 'user_id required'});
@@ -493,7 +517,11 @@ export const syncProvider = async (req, res) => {
         return res.status(403).json({error: 'Access denied'});
     }
 
-    const result = await performSync(id, user_id, { mode: 'manual', allowCrossOwner: true });
+    const result = await performSync(id, user_id, {
+      mode: 'manual',
+      allowCrossOwner: allow_cross_owner === true,
+      restoreRevokedAssignments: restore_revoked_assignments === true
+    });
 
     // Also trigger EPG update
     updateProviderEpg(id).catch(err => console.error(`Manual sync EPG update failed for provider ${id}:`, err.message));
@@ -708,7 +736,11 @@ export const importCategory = async (req, res) => {
         ORDER BY original_sort_order ASC, name ASC
       `);
 
-      const insertChannel = db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, sort_order, granted_by_admin) VALUES (?, ?, ?, ?)');
+      const insertChannel = db.prepare(`
+        INSERT INTO user_channels
+          (user_category_id, provider_channel_id, sort_order, granted_by_admin, authorization_revoked)
+        VALUES (?, ?, ?, ?, 0)
+      `);
       const channels = stmt.all(providerId, Number(category_id), streamType);
       const importedCount = channels.length;
       db.transaction(() => {
@@ -769,7 +801,11 @@ export const importCategories = async (req, res) => {
     let totalCategories = 0;
 
     const insertUserCategory = db.prepare('INSERT INTO user_categories (user_id, name, is_adult, sort_order, type) VALUES (?, ?, ?, ?, ?)');
-    const insertChannel = db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, sort_order, granted_by_admin) VALUES (?, ?, ?, ?)');
+    const insertChannel = db.prepare(`
+      INSERT INTO user_channels
+        (user_category_id, provider_channel_id, sort_order, granted_by_admin, authorization_revoked)
+      VALUES (?, ?, ?, ?, 0)
+    `);
     const getMaxSort = db.prepare('SELECT COALESCE(MAX(sort_order), -1) as max_sort FROM user_categories WHERE user_id = ?');
 
     // Pre-fetch channels for all categories being imported to avoid N+1 queries

--- a/src/controllers/shareController.js
+++ b/src/controllers/shareController.js
@@ -36,13 +36,11 @@ export const createShare = (req, res) => {
     let baseSlug = generateSlug(normalizedName);
     if (!baseSlug) baseSlug = 'share';
 
-    let slug = baseSlug;
-    let counter = 1;
+    let slug;
     while (true) {
+        slug = `${baseSlug}-${crypto.randomBytes(8).toString('hex')}`;
         const existing = db.prepare('SELECT token FROM shared_links WHERE slug = ?').get(slug);
         if (!existing) break;
-        slug = `${baseSlug}-${counter}`;
-        counter++;
     }
 
     db.prepare(`

--- a/src/controllers/streamController.js
+++ b/src/controllers/streamController.js
@@ -46,7 +46,7 @@ function getChannel(streamId, userId) {
         p.backup_urls,
         p.user_agent,
         p.max_connections as provider_max_connections
-      FROM user_channels uc
+      FROM authorized_user_channels uc
       JOIN provider_channels pc ON pc.id = uc.provider_channel_id
       JOIN providers p ON p.id = pc.provider_id
       JOIN user_categories cat ON cat.id = uc.user_category_id
@@ -76,9 +76,24 @@ function insertStat(channelId, lastViewed) {
     return stmts.insertStat.run(channelId, lastViewed);
 }
 
-function getProvider(id) {
-    if (!stmts.getProvider) stmts.getProvider = db.prepare('SELECT * FROM providers WHERE id = ?');
-    return stmts.getProvider.get(id);
+function getSeriesProvider(id, userId) {
+    if (!stmts.getProvider) {
+        stmts.getProvider = db.prepare(`
+          SELECT p.*
+          FROM providers p
+          WHERE p.id = ?
+            AND EXISTS (
+              SELECT 1
+              FROM authorized_user_channels uc
+              JOIN provider_channels pc ON pc.id = uc.provider_channel_id
+              JOIN user_categories cat ON cat.id = uc.user_category_id
+              WHERE pc.provider_id = p.id
+                AND pc.stream_type = 'series'
+                AND cat.user_id = ?
+            )
+        `);
+    }
+    return stmts.getProvider.get(id, userId);
 }
 
 function getProviderPool(userId, providerUrl) {
@@ -95,6 +110,22 @@ function getProviderPool(userId, providerUrl) {
 
 async function findAvailableProvider(userId, originalProvider, reqIp, sessionName) {
     const pool = getProviderPool(userId, originalProvider.provider_url || originalProvider.url);
+    const normalizedOriginal = originalProvider.id ? originalProvider : {
+        id: originalProvider.provider_id,
+        url: originalProvider.provider_url,
+        username: originalProvider.provider_user,
+        password: originalProvider.provider_pass,
+        backup_urls: originalProvider.backup_urls,
+        user_agent: originalProvider.user_agent,
+        max_connections: originalProvider.provider_max_connections
+    };
+
+    // Cross-user assignments reach this point only through the authorized
+    // assignment view. Keep the explicitly granted source provider available
+    // even though it is intentionally absent from the user's provider pool.
+    if (!pool.some(provider => provider.id === normalizedOriginal.id)) {
+        pool.push(normalizedOriginal);
+    }
 
     for (const p of pool) {
         let isSessionActive = false;
@@ -1099,7 +1130,7 @@ export const proxySeries = async (req, res) => {
 
     if (!providerId || !remoteEpisodeId) return res.sendStatus(404);
 
-    const provider = getProvider(providerId);
+    const provider = getSeriesProvider(providerId, user.id);
     if (!provider) return res.sendStatus(404);
 
     if (user.is_share_guest) return res.sendStatus(403);

--- a/src/controllers/streamController.js
+++ b/src/controllers/streamController.js
@@ -435,6 +435,7 @@ async function fetchWithBackups(primaryUrl, backupUrls, options) {
             if (res.ok) {
                 return { response: res, successfulUrl: res.url || u };
             }
+            res.body?.destroy?.();
             // If 404/403/407/etc, we might want to try backup? Yes.
             console.warn(`Connection failed to ${redactUrl(u)}: ${res.status}`);
 

--- a/src/controllers/streamController.js
+++ b/src/controllers/streamController.js
@@ -13,6 +13,7 @@ import { fetchSafe } from '../utils/network.js';
 import { episodeNameCache } from '../services/episodeCache.js';
 import { decrypt, encrypt } from '../utils/crypto.js';
 import { DEFAULT_USER_AGENT } from '../config/constants.js';
+import { decodeSeriesEpisodeId } from '../utils/seriesEpisodeId.js';
 
 // Custom Agents with DNS Rebinding Protection
 const httpAgent = new http.Agent({ lookup: safeLookup });
@@ -26,7 +27,8 @@ const stmts = {
     updateStat: null,
     updateStatTimeOnly: null,
     insertStat: null,
-    getProvider: null,
+    getSeriesAssignment: null,
+    getSeriesEpisode: null,
     getProviderPool: null
 };
 
@@ -76,24 +78,39 @@ function insertStat(channelId, lastViewed) {
     return stmts.insertStat.run(channelId, lastViewed);
 }
 
-function getSeriesProvider(id, userId) {
-    if (!stmts.getProvider) {
-        stmts.getProvider = db.prepare(`
-          SELECT p.*
-          FROM providers p
-          WHERE p.id = ?
-            AND EXISTS (
-              SELECT 1
-              FROM authorized_user_channels uc
-              JOIN provider_channels pc ON pc.id = uc.provider_channel_id
-              JOIN user_categories cat ON cat.id = uc.user_category_id
-              WHERE pc.provider_id = p.id
-                AND pc.stream_type = 'series'
-                AND cat.user_id = ?
-            )
+function getSeriesEpisode(encodedId, userId) {
+    const decoded = decodeSeriesEpisodeId(encodedId);
+    if (!decoded) return null;
+
+    if (!stmts.getSeriesAssignment) {
+        stmts.getSeriesAssignment = db.prepare(`
+          SELECT p.*, uc.id AS user_channel_id,
+                 pc.remote_stream_id AS series_remote_id,
+                 COALESCE(NULLIF(uc.custom_name, ''), pc.name) AS series_name
+          FROM authorized_user_channels uc
+          JOIN provider_channels pc ON pc.id = uc.provider_channel_id
+          JOIN providers p ON p.id = pc.provider_id
+          JOIN user_categories cat ON cat.id = uc.user_category_id
+          WHERE uc.id = ? AND cat.user_id = ? AND pc.stream_type = 'series'
         `);
     }
-    return stmts.getProvider.get(id, userId);
+    if (!stmts.getSeriesEpisode) {
+        stmts.getSeriesEpisode = db.prepare(`
+          SELECT season, episode_num, title, container_extension, logo
+          FROM provider_series_episodes
+          WHERE source_key = ? AND series_remote_id = ? AND remote_episode_id = ?
+        `);
+    }
+
+    const assignment = stmts.getSeriesAssignment.get(decoded.assignmentId, userId);
+    if (!assignment) return null;
+
+    const episode = stmts.getSeriesEpisode.get(
+      providerSourceKey(assignment.url),
+      assignment.series_remote_id,
+      decoded.remoteEpisodeId
+    );
+    return episode ? { ...assignment, ...episode, remote_episode_id: decoded.remoteEpisodeId } : null;
 }
 
 function getProviderPool(userId, providerUrl) {
@@ -1116,42 +1133,26 @@ export const proxySeries = async (req, res) => {
   const cleanup = createSafeCleanup(connectionId);
 
   try {
-    const epIdRaw = Number(req.params.episode_id || 0);
+    const epIdRaw = req.params.episode_id;
     const ext = req.params.ext;
 
-    if (!epIdRaw) return res.sendStatus(404);
+    if (!decodeSeriesEpisodeId(epIdRaw)) return res.sendStatus(404);
 
     const user = await getXtreamUser(req);
     if (!user) return res.sendStatus(401);
 
-    const OFFSET = 1000000000;
-    const providerId = Math.floor(epIdRaw / OFFSET);
-    const remoteEpisodeId = epIdRaw % OFFSET;
+    const seriesEpisode = getSeriesEpisode(epIdRaw, user.id);
+    if (!seriesEpisode) return res.sendStatus(404);
+    if (!shareGuestAllowed(user, seriesEpisode)) return res.sendStatus(403);
 
-    if (!providerId || !remoteEpisodeId) return res.sendStatus(404);
+    const provider = seriesEpisode;
+    const remoteEpisodeId = seriesEpisode.remote_episode_id;
 
-    const provider = getSeriesProvider(providerId, user.id);
-    if (!provider) return res.sendStatus(404);
-
-    if (user.is_share_guest) return res.sendStatus(403);
-
-    let sessionName = episodeNameCache.get(epIdRaw.toString());
+    let sessionName = episodeNameCache.get(String(epIdRaw));
     if (!sessionName) {
-      // Fallback to synced episode data (M3U playback skips get_series_info)
-      try {
-        const epRow = db.prepare(`
-          SELECT e.season, e.episode_num, e.title, pc.name as series_name
-          FROM provider_series_episodes e
-          LEFT JOIN provider_channels pc ON pc.provider_id = ? AND pc.remote_stream_id = e.series_remote_id AND pc.stream_type = 'series'
-          WHERE e.source_key = ? AND e.remote_episode_id = ?
-        `).get(providerId, providerSourceKey(provider.url), remoteEpisodeId);
-        if (epRow) {
-          const epCode = `S${String(epRow.season || 0).padStart(2, '0')} E${String(epRow.episode_num || 0).padStart(2, '0')}`;
-          sessionName = `${epRow.series_name || 'Series'} ${epCode}${epRow.title ? ` - ${epRow.title}` : ''}`;
-        }
-      } catch { /* name lookup is cosmetic only */ }
+      const epCode = `S${String(seriesEpisode.season || 0).padStart(2, '0')} E${String(seriesEpisode.episode_num || 0).padStart(2, '0')}`;
+      sessionName = `${seriesEpisode.series_name || 'Series'} ${epCode}${seriesEpisode.title ? ` - ${seriesEpisode.title}` : ''}`;
     }
-    if (!sessionName) sessionName = `Series Episode ${remoteEpisodeId}`;
 
     const sourceProvider = { ...provider, password: decrypt(provider.password) };
     let base = sourceProvider.url.replace(/\/+$/, '');

--- a/src/controllers/streamController.js
+++ b/src/controllers/streamController.js
@@ -43,6 +43,7 @@ function getChannel(streamId, userId) {
         stmts.getChannel = db.prepare(`
       SELECT
         uc.id as user_channel_id,
+        uc.granted_by_admin,
         pc.id as provider_channel_id,
         pc.remote_stream_id,
         pc.name,
@@ -54,7 +55,9 @@ function getChannel(streamId, userId) {
         p.password as provider_pass,
         p.backup_urls,
         p.user_agent,
-        p.max_connections as provider_max_connections
+        p.max_connections as provider_max_connections,
+        cat.user_id as category_owner_id,
+        p.user_id as provider_owner_id
       FROM authorized_user_channels uc
       JOIN provider_channels pc ON pc.id = uc.provider_channel_id
       JOIN providers p ON p.id = pc.provider_id
@@ -101,7 +104,9 @@ function getSeriesEpisode(encodedId, userId) {
         if (!stmts.getSeriesAlias) {
             stmts.getSeriesAlias = db.prepare(`
               SELECT a.source_key AS episode_source_key, a.remote_episode_id,
-                     p.*, uc.id AS user_channel_id,
+                     p.*, uc.id AS user_channel_id, uc.granted_by_admin,
+                     cat.user_id AS category_owner_id,
+                     p.user_id AS provider_owner_id,
                      pc.remote_stream_id AS series_remote_id,
                      COALESCE(NULLIF(uc.custom_name, ''), pc.name) AS series_name
               FROM series_episode_aliases a
@@ -129,7 +134,9 @@ function getSeriesEpisode(encodedId, userId) {
     if (!decoded) return null;
     if (!stmts.getLegacySeriesAssignments) {
         stmts.getLegacySeriesAssignments = db.prepare(`
-          SELECT p.*, uc.id AS user_channel_id,
+          SELECT p.*, uc.id AS user_channel_id, uc.granted_by_admin,
+                 cat.user_id AS category_owner_id,
+                 p.user_id AS provider_owner_id,
                  pc.remote_stream_id AS series_remote_id,
                  COALESCE(NULLIF(uc.custom_name, ''), pc.name) AS series_name
           FROM authorized_user_channels uc
@@ -165,11 +172,21 @@ function getProviderPool(userId, providerUrl) {
     // Fetch all providers for the same user with the same base url
     const providers = stmts.getProviderPool.all(userId, `${base}%`);
     // Filter strictly by normalized base URL in case of LIKE edge cases
-    return providers.filter(p => p.url.replace(/\/+$/, '') === base);
+    const sourceKey = providerSourceKey(providerUrl);
+    return providers.filter(p => providerSourceKey(p.url) === sourceKey);
 }
 
-async function findAvailableProvider(userId, originalProvider, reqIp, sessionName) {
-    const pool = getProviderPool(userId, originalProvider.provider_url || originalProvider.url);
+function parseProviderBackupUrls(value) {
+    if (!value) return [];
+    try {
+        const parsed = JSON.parse(value);
+        return Array.isArray(parsed) ? parsed.filter(url => typeof url === 'string' && url.trim()) : [];
+    } catch {
+        return [];
+    }
+}
+
+export function getProviderCandidates(userId, originalProvider) {
     const normalizedOriginal = originalProvider.id ? originalProvider : {
         id: originalProvider.provider_id,
         url: originalProvider.provider_url,
@@ -179,13 +196,32 @@ async function findAvailableProvider(userId, originalProvider, reqIp, sessionNam
         user_agent: originalProvider.user_agent,
         max_connections: originalProvider.provider_max_connections
     };
+    const categoryOwnerId = Number(originalProvider.category_owner_id);
+    const providerOwnerId = Number(originalProvider.provider_owner_id);
+    const explicitCrossOwner = Number(originalProvider.granted_by_admin) === 1 &&
+        Number.isSafeInteger(categoryOwnerId) && Number.isSafeInteger(providerOwnerId) &&
+        providerOwnerId !== categoryOwnerId;
 
-    // Cross-user assignments reach this point only through the authorized
-    // assignment view. Keep the explicitly granted source provider available
-    // even though it is intentionally absent from the user's provider pool.
+    if (explicitCrossOwner) {
+        const candidates = [normalizedOriginal];
+        for (const backupUrl of parseProviderBackupUrls(normalizedOriginal.backup_urls)) {
+            for (const provider of getProviderPool(userId, backupUrl)) {
+                if (!candidates.some(candidate => candidate.id === provider.id)) candidates.push(provider);
+            }
+        }
+        return candidates;
+    }
+
+    const pool = getProviderPool(userId, normalizedOriginal.url);
+
     if (!pool.some(provider => provider.id === normalizedOriginal.id)) {
         pool.push(normalizedOriginal);
     }
+    return pool;
+}
+
+export async function findAvailableProvider(userId, originalProvider, reqIp, sessionName) {
+    const pool = getProviderCandidates(userId, originalProvider);
 
     for (const p of pool) {
         let isSessionActive = false;
@@ -241,6 +277,7 @@ function applyProviderToChannel(channel, provider) {
   channel.provider_pass = provider.password;
   channel.backup_urls = provider.backup_urls;
   channel.user_agent = provider.user_agent;
+  channel.provider_max_connections = provider.max_connections;
 }
 
 async function reserveChannelSession(connectionId, user, channel, req, res, sessionName, options = {}) {
@@ -1015,8 +1052,6 @@ export const proxyMovie = async (req, res) => {
 
   try {
     const streamId = Number(req.params.stream_id || 0);
-    const requestedExtension = req.params.ext;
-
     if (!streamId) return res.sendStatus(404);
 
     const user = await getXtreamUser(req);
@@ -1027,20 +1062,19 @@ export const proxyMovie = async (req, res) => {
     if (!channel) return res.sendStatus(404);
 
     if (!shareGuestAllowed(user, channel)) return res.sendStatus(403);
-    const ext = normalizeContainerExtension(channel.mime_type || requestedExtension);
+    const ext = normalizeContainerExtension(channel.mime_type, 'mp4');
 
     const sessionName = `${channel.name} (VOD)`;
 
-    channel.provider_pass = decrypt(channel.provider_pass);
+    const sourcePassword = decrypt(channel.provider_pass);
+    let base = channel.provider_url.replace(/\/+$/, '');
+    let remoteUrl = `${base}/movie/${encodeURIComponent(channel.provider_user)}/${encodeURIComponent(sourcePassword)}/${channel.remote_stream_id}.${ext}`;
 
-    const base = channel.provider_url.replace(/\/+$/, '');
-    const remoteUrl = `${base}/movie/${encodeURIComponent(channel.provider_user)}/${encodeURIComponent(channel.provider_pass)}/${channel.remote_stream_id}.${ext}`;
-
-    const backupStreamUrls = buildBackupUrls(channel.backup_urls, (bBase) => {
-        return `${bBase}/movie/${encodeURIComponent(channel.provider_user)}/${encodeURIComponent(channel.provider_pass)}/${channel.remote_stream_id}.${ext}`;
+    let backupStreamUrls = buildBackupUrls(channel.backup_urls, (bBase) => {
+        return `${bBase}/movie/${encodeURIComponent(channel.provider_user)}/${encodeURIComponent(sourcePassword)}/${channel.remote_stream_id}.${ext}`;
     }, 'Movie');
 
-    const { headers } = buildStreamHeaders(channel.user_agent, channel.metadata, 'Movie');
+    let { headers } = buildStreamHeaders(channel.user_agent, channel.metadata, 'Movie');
 
     if (req.query.subtitle_format === 'vtt') {
       await sendSubtitleTrack(res, remoteUrl, backupStreamUrls, headers, req);
@@ -1053,6 +1087,14 @@ export const proxyMovie = async (req, res) => {
     }
 
     if (!await reserveChannelSession(connectionId, user, channel, req, res, sessionName)) return;
+
+    channel.provider_pass = decrypt(channel.provider_pass);
+    base = channel.provider_url.replace(/\/+$/, '');
+    remoteUrl = `${base}/movie/${encodeURIComponent(channel.provider_user)}/${encodeURIComponent(channel.provider_pass)}/${channel.remote_stream_id}.${ext}`;
+    backupStreamUrls = buildBackupUrls(channel.backup_urls, (bBase) => {
+        return `${bBase}/movie/${encodeURIComponent(channel.provider_user)}/${encodeURIComponent(channel.provider_pass)}/${channel.remote_stream_id}.${ext}`;
+    }, 'Movie');
+    ({ headers } = buildStreamHeaders(channel.user_agent, channel.metadata, 'Movie'));
 
     recordStreamStat(channel.provider_channel_id, 'Movie');
 

--- a/src/controllers/streamController.js
+++ b/src/controllers/streamController.js
@@ -9,6 +9,7 @@ import db from '../database/db.js';
 import streamManager from '../services/streamManager.js';
 import { getXtreamUser } from '../services/authService.js';
 import { getBaseUrl, isSafeUrl, safeLookup, redactUrl, providerSourceKey } from '../utils/helpers.js';
+import { normalizeContainerExtension } from '../utils/containerExtension.js';
 import { fetchSafe } from '../utils/network.js';
 import { episodeNameCache } from '../services/episodeCache.js';
 import { decrypt, encrypt } from '../utils/crypto.js';
@@ -46,6 +47,7 @@ function getChannel(streamId, userId) {
         pc.remote_stream_id,
         pc.name,
         pc.metadata,
+        pc.mime_type,
         p.id as provider_id,
         p.url as provider_url,
         p.username as provider_user,
@@ -152,11 +154,6 @@ function getSeriesEpisode(encodedId, userId) {
         if (episode) matches.push({ ...assignment, ...episode, remote_episode_id: decoded.remoteEpisodeId });
     }
     return matches.length === 1 ? matches[0] : null;
-}
-
-function normalizeSeriesExtension(value) {
-    const extension = String(value || '').trim().toLowerCase().replace(/^\.+/, '');
-    return /^[a-z0-9]{1,10}$/.test(extension) ? extension : 'mp4';
 }
 
 function getProviderPool(userId, providerUrl) {
@@ -1018,7 +1015,7 @@ export const proxyMovie = async (req, res) => {
 
   try {
     const streamId = Number(req.params.stream_id || 0);
-    const ext = req.params.ext;
+    const requestedExtension = req.params.ext;
 
     if (!streamId) return res.sendStatus(404);
 
@@ -1030,6 +1027,7 @@ export const proxyMovie = async (req, res) => {
     if (!channel) return res.sendStatus(404);
 
     if (!shareGuestAllowed(user, channel)) return res.sendStatus(403);
+    const ext = normalizeContainerExtension(channel.mime_type || requestedExtension);
 
     const sessionName = `${channel.name} (VOD)`;
 
@@ -1190,7 +1188,7 @@ export const proxySeries = async (req, res) => {
 
     const provider = seriesEpisode;
     const remoteEpisodeId = seriesEpisode.remote_episode_id;
-    const ext = normalizeSeriesExtension(seriesEpisode.container_extension);
+    const ext = normalizeContainerExtension(seriesEpisode.container_extension);
 
     let sessionName = episodeNameCache.get(String(epIdRaw));
     if (!sessionName) {

--- a/src/controllers/streamController.js
+++ b/src/controllers/streamController.js
@@ -13,7 +13,11 @@ import { fetchSafe } from '../utils/network.js';
 import { episodeNameCache } from '../services/episodeCache.js';
 import { decrypt, encrypt } from '../utils/crypto.js';
 import { DEFAULT_USER_AGENT } from '../config/constants.js';
-import { decodeSeriesEpisodeId } from '../utils/seriesEpisodeId.js';
+import {
+  decodeSeriesEpisodeId,
+  SERIES_EPISODE_ALIAS_MIN,
+  SERIES_EPISODE_OFFSET
+} from '../utils/seriesEpisodeId.js';
 
 // Custom Agents with DNS Rebinding Protection
 const httpAgent = new http.Agent({ lookup: safeLookup });
@@ -27,7 +31,8 @@ const stmts = {
     updateStat: null,
     updateStatTimeOnly: null,
     insertStat: null,
-    getSeriesAssignment: null,
+    getSeriesAlias: null,
+    getLegacySeriesAssignments: null,
     getSeriesEpisode: null,
     getProviderPool: null
 };
@@ -79,21 +84,9 @@ function insertStat(channelId, lastViewed) {
 }
 
 function getSeriesEpisode(encodedId, userId) {
-    const decoded = decodeSeriesEpisodeId(encodedId);
-    if (!decoded) return null;
+    const publicId = Number(encodedId);
+    if (!Number.isSafeInteger(publicId) || publicId <= 0) return null;
 
-    if (!stmts.getSeriesAssignment) {
-        stmts.getSeriesAssignment = db.prepare(`
-          SELECT p.*, uc.id AS user_channel_id,
-                 pc.remote_stream_id AS series_remote_id,
-                 COALESCE(NULLIF(uc.custom_name, ''), pc.name) AS series_name
-          FROM authorized_user_channels uc
-          JOIN provider_channels pc ON pc.id = uc.provider_channel_id
-          JOIN providers p ON p.id = pc.provider_id
-          JOIN user_categories cat ON cat.id = uc.user_category_id
-          WHERE uc.id = ? AND cat.user_id = ? AND pc.stream_type = 'series'
-        `);
-    }
     if (!stmts.getSeriesEpisode) {
         stmts.getSeriesEpisode = db.prepare(`
           SELECT season, episode_num, title, container_extension, logo
@@ -102,15 +95,68 @@ function getSeriesEpisode(encodedId, userId) {
         `);
     }
 
-    const assignment = stmts.getSeriesAssignment.get(decoded.assignmentId, userId);
-    if (!assignment) return null;
+    if (publicId >= SERIES_EPISODE_ALIAS_MIN && publicId < SERIES_EPISODE_OFFSET) {
+        if (!stmts.getSeriesAlias) {
+            stmts.getSeriesAlias = db.prepare(`
+              SELECT a.source_key AS episode_source_key, a.remote_episode_id,
+                     p.*, uc.id AS user_channel_id,
+                     pc.remote_stream_id AS series_remote_id,
+                     COALESCE(NULLIF(uc.custom_name, ''), pc.name) AS series_name
+              FROM series_episode_aliases a
+              JOIN authorized_user_channels uc ON uc.id = a.user_channel_id
+              JOIN provider_channels pc ON pc.id = uc.provider_channel_id
+              JOIN providers p ON p.id = pc.provider_id
+              JOIN user_categories cat ON cat.id = uc.user_category_id
+              WHERE a.id = ? AND cat.user_id = ? AND pc.stream_type = 'series'
+                AND pc.remote_stream_id = a.series_remote_id
+            `);
+        }
 
-    const episode = stmts.getSeriesEpisode.get(
-      providerSourceKey(assignment.url),
-      assignment.series_remote_id,
-      decoded.remoteEpisodeId
-    );
-    return episode ? { ...assignment, ...episode, remote_episode_id: decoded.remoteEpisodeId } : null;
+        const assignment = stmts.getSeriesAlias.get(publicId, userId);
+        if (!assignment || providerSourceKey(assignment.url) !== assignment.episode_source_key) return null;
+        const episode = stmts.getSeriesEpisode.get(
+          assignment.episode_source_key,
+          assignment.series_remote_id,
+          assignment.remote_episode_id
+        );
+        return episode ? { ...assignment, ...episode } : null;
+    }
+    if (publicId < SERIES_EPISODE_OFFSET) return null;
+
+    const decoded = decodeSeriesEpisodeId(publicId);
+    if (!decoded) return null;
+    if (!stmts.getLegacySeriesAssignments) {
+        stmts.getLegacySeriesAssignments = db.prepare(`
+          SELECT p.*, uc.id AS user_channel_id,
+                 pc.remote_stream_id AS series_remote_id,
+                 COALESCE(NULLIF(uc.custom_name, ''), pc.name) AS series_name
+          FROM authorized_user_channels uc
+          JOIN provider_channels pc ON pc.id = uc.provider_channel_id
+          JOIN providers p ON p.id = pc.provider_id
+          JOIN user_categories cat ON cat.id = uc.user_category_id
+          WHERE (uc.id = ? OR p.id = ?) AND cat.user_id = ? AND pc.stream_type = 'series'
+        `);
+    }
+
+    const matches = [];
+    for (const assignment of stmts.getLegacySeriesAssignments.all(
+      decoded.assignmentId,
+      decoded.assignmentId,
+      userId
+    )) {
+        const episode = stmts.getSeriesEpisode.get(
+          providerSourceKey(assignment.url),
+          assignment.series_remote_id,
+          decoded.remoteEpisodeId
+        );
+        if (episode) matches.push({ ...assignment, ...episode, remote_episode_id: decoded.remoteEpisodeId });
+    }
+    return matches.length === 1 ? matches[0] : null;
+}
+
+function normalizeSeriesExtension(value) {
+    const extension = String(value || '').trim().toLowerCase().replace(/^\.+/, '');
+    return /^[a-z0-9]{1,10}$/.test(extension) ? extension : 'mp4';
 }
 
 function getProviderPool(userId, providerUrl) {
@@ -1134,9 +1180,6 @@ export const proxySeries = async (req, res) => {
 
   try {
     const epIdRaw = req.params.episode_id;
-    const ext = req.params.ext;
-
-    if (!decodeSeriesEpisodeId(epIdRaw)) return res.sendStatus(404);
 
     const user = await getXtreamUser(req);
     if (!user) return res.sendStatus(401);
@@ -1147,6 +1190,7 @@ export const proxySeries = async (req, res) => {
 
     const provider = seriesEpisode;
     const remoteEpisodeId = seriesEpisode.remote_episode_id;
+    const ext = normalizeSeriesExtension(seriesEpisode.container_extension);
 
     let sessionName = episodeNameCache.get(String(epIdRaw));
     if (!sessionName) {

--- a/src/controllers/systemController.js
+++ b/src/controllers/systemController.js
@@ -600,14 +600,25 @@ export const importData = async (req, res) => {
       }
 
       const userAssignments = importData.channels.filter(c => c.type === 'user_assignment');
-      const insertUserChannel = db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, sort_order, custom_name) VALUES (?, ?, ?, ?)');
+      const insertUserChannel = db.prepare(`
+        INSERT INTO user_channels
+          (user_category_id, provider_channel_id, sort_order, custom_name, is_hidden, granted_by_admin)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `);
 
       for (const ua of userAssignments) {
         const newUserCatId = categoryIdMap.get(ua.user_category_id);
         const newProvChannelId = providerChannelIdMap.get(ua.provider_channel_id);
 
         if (newUserCatId && newProvChannelId) {
-          insertUserChannel.run(newUserCatId, newProvChannelId, ua.sort_order, ua.custom_name || '');
+          insertUserChannel.run(
+            newUserCatId,
+            newProvChannelId,
+            ua.sort_order,
+            ua.custom_name || '',
+            Number(ua.is_hidden) === 1 ? 1 : 0,
+            Number(ua.granted_by_admin) === 1 ? 1 : 0
+          );
           stats.channels++;
         }
       }

--- a/src/controllers/systemController.js
+++ b/src/controllers/systemController.js
@@ -5,9 +5,8 @@ import db from '../database/db.js';
 import streamManager from '../services/streamManager.js';
 import { encryptWithPassword, decryptWithPassword, decrypt, encrypt } from '../utils/crypto.js';
 import { calculateNextSync } from '../services/syncService.js';
-import { clearSettingsCache } from '../utils/helpers.js';
 import { isIP } from 'net';
-import { isSafeUrl, cleanIp } from '../utils/helpers.js';
+import { clearSettingsCache, isSafeUrl, cleanIp, resolveAssignmentGrant } from '../utils/helpers.js';
 import si from 'systeminformation';
 import geoip from 'geoip-lite';
 import { getEpgLogo, loadEpgLogosCache } from '../services/logoResolver.js';
@@ -439,6 +438,9 @@ export const importData = async (req, res) => {
       const providerIdMap = new Map();
       const categoryIdMap = new Map();
       const providerChannelIdMap = new Map();
+      const providerOwnerMap = new Map();
+      const categoryOwnerMap = new Map();
+      const providerChannelOwnerMap = new Map();
 
       // Pre-fetch existing users to avoid N+1 query
       const existingUsers = db.prepare('SELECT id, username FROM users').all();
@@ -515,6 +517,7 @@ export const importData = async (req, res) => {
         );
 
         providerIdMap.set(p.id, info.lastInsertRowid);
+        providerOwnerMap.set(info.lastInsertRowid, newUserId);
         stats.providers++;
       }
 
@@ -556,6 +559,7 @@ export const importData = async (req, res) => {
           ch.episode_run_time || null
         );
         providerChannelIdMap.set(ch.id, info.lastInsertRowid);
+        providerChannelOwnerMap.set(info.lastInsertRowid, providerOwnerMap.get(newProvId));
       }
 
       const insertCategoryStmt = db.prepare('INSERT INTO user_categories (user_id, name, is_adult, sort_order, type) VALUES (?, ?, ?, ?, ?)');
@@ -567,6 +571,7 @@ export const importData = async (req, res) => {
         const catType = cat.type || 'live';
         const info = insertCategoryStmt.run(newUserId, cat.name, cat.is_adult, cat.sort_order, catType);
         categoryIdMap.set(cat.id, info.lastInsertRowid);
+        categoryOwnerMap.set(info.lastInsertRowid, newUserId);
         stats.categories++;
       }
 
@@ -586,8 +591,8 @@ export const importData = async (req, res) => {
       }
 
       const insertSyncConfigStmt = db.prepare(`
-        INSERT INTO sync_configs (provider_id, user_id, enabled, sync_interval, last_sync, next_sync, auto_add_categories, auto_add_channels)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO sync_configs (provider_id, user_id, enabled, sync_interval, last_sync, next_sync, auto_add_categories, auto_add_channels, sync_series_episodes, granted_by_admin)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `);
 
       for (const s of importData.sync_configs) {
@@ -595,7 +600,24 @@ export const importData = async (req, res) => {
         const newUserId = userIdMap.get(s.user_id);
 
         if (newProvId && newUserId) {
-          insertSyncConfigStmt.run(newProvId, newUserId, s.enabled, s.sync_interval, 0, 0, s.auto_add_categories, s.auto_add_channels);
+          const grant = resolveAssignmentGrant({
+            categoryOwnerId: newUserId,
+            providerOwnerId: providerOwnerMap.get(newProvId),
+            isAdmin: true,
+            allowExplicitAdminGrant: Number(s.granted_by_admin) === 1
+          });
+          insertSyncConfigStmt.run(
+            newProvId,
+            newUserId,
+            grant === null ? 0 : (s.enabled ? 1 : 0),
+            s.sync_interval,
+            0,
+            0,
+            s.auto_add_categories,
+            s.auto_add_channels,
+            s.sync_series_episodes === undefined ? 1 : (s.sync_series_episodes ? 1 : 0),
+            grant === 1 ? 1 : 0
+          );
         }
       }
 
@@ -611,13 +633,19 @@ export const importData = async (req, res) => {
         const newProvChannelId = providerChannelIdMap.get(ua.provider_channel_id);
 
         if (newUserCatId && newProvChannelId) {
+          const grant = resolveAssignmentGrant({
+            categoryOwnerId: categoryOwnerMap.get(newUserCatId),
+            providerOwnerId: providerChannelOwnerMap.get(newProvChannelId),
+            isAdmin: true,
+            allowExplicitAdminGrant: Number(ua.granted_by_admin) === 1
+          });
           insertUserChannel.run(
             newUserCatId,
             newProvChannelId,
             ua.sort_order,
             ua.custom_name || '',
-            Number(ua.is_hidden) === 1 ? 1 : 0,
-            Number(ua.granted_by_admin) === 1 ? 1 : 0
+            Number(ua.is_hidden) === 1 || grant === null ? 1 : 0,
+            grant === 1 ? 1 : 0
           );
           stats.channels++;
         }
@@ -667,26 +695,42 @@ export const getSyncConfig = (req, res) => {
 export const createSyncConfig = (req, res) => {
   try {
     if (!req.user.is_admin) return res.status(403).json({error: 'Access denied'});
-    const { provider_id, user_id, enabled, sync_interval, auto_add_categories, auto_add_channels, sync_series_episodes } = req.body;
+    const { provider_id, user_id, enabled, sync_interval, auto_add_categories, auto_add_channels, sync_series_episodes, allow_cross_owner } = req.body;
 
     if (!provider_id || !user_id) {
       return res.status(400).json({error: 'provider_id and user_id required'});
     }
 
+    const providerId = Number(provider_id);
+    const userId = Number(user_id);
+    const provider = db.prepare('SELECT user_id FROM providers WHERE id = ?').get(providerId);
+    if (!provider) return res.status(404).json({error: 'Provider not found'});
+    if (!db.prepare('SELECT id FROM users WHERE id = ?').get(userId)) {
+      return res.status(404).json({error: 'User not found'});
+    }
+
+    const grantedByAdmin = resolveAssignmentGrant({
+      categoryOwnerId: userId,
+      providerOwnerId: provider.user_id,
+      isAdmin: true,
+      allowExplicitAdminGrant: allow_cross_owner !== false
+    });
+
     const nextSync = calculateNextSync(sync_interval || 'daily');
 
     const info = db.prepare(`
-      INSERT INTO sync_configs (provider_id, user_id, enabled, sync_interval, next_sync, auto_add_categories, auto_add_channels, sync_series_episodes)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO sync_configs (provider_id, user_id, enabled, sync_interval, next_sync, auto_add_categories, auto_add_channels, sync_series_episodes, granted_by_admin)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
-      provider_id,
-      user_id,
-      enabled ? 1 : 0,
+      providerId,
+      userId,
+      grantedByAdmin === null ? 0 : (enabled ? 1 : 0),
       sync_interval || 'daily',
       nextSync,
       auto_add_categories ? 1 : 0,
       auto_add_channels ? 1 : 0,
-      sync_series_episodes === undefined ? 1 : (sync_series_episodes ? 1 : 0)
+      sync_series_episodes === undefined ? 1 : (sync_series_episodes ? 1 : 0),
+      grantedByAdmin === 1 ? 1 : 0
     );
 
     res.json({id: info.lastInsertRowid});
@@ -699,24 +743,49 @@ export const updateSyncConfig = (req, res) => {
   try {
     if (!req.user.is_admin) return res.status(403).json({error: 'Access denied'});
     const id = Number(req.params.id);
-    const { enabled, sync_interval, auto_add_categories, auto_add_channels, sync_series_episodes } = req.body;
+    const { enabled, sync_interval, auto_add_categories, auto_add_channels, sync_series_episodes, allow_cross_owner } = req.body;
 
-    const config = db.prepare('SELECT * FROM sync_configs WHERE id = ?').get(id);
+    const config = db.prepare(`
+      SELECT sc.*, p.user_id AS provider_owner_id
+      FROM sync_configs sc
+      JOIN providers p ON p.id = sc.provider_id
+      WHERE sc.id = ?
+    `).get(id);
     if (!config) return res.status(404).json({error: 'not found'});
+    if (!db.prepare('SELECT id FROM users WHERE id = ?').get(config.user_id)) {
+      return res.status(404).json({error: 'User not found'});
+    }
+
+    let allowExplicitAdminGrant = Number(config.granted_by_admin) === 1;
+    if (allow_cross_owner === true) allowExplicitAdminGrant = true;
+    if (allow_cross_owner === false) allowExplicitAdminGrant = false;
+    const grantedByAdmin = resolveAssignmentGrant({
+      categoryOwnerId: config.user_id,
+      providerOwnerId: config.provider_owner_id,
+      isAdmin: true,
+      allowExplicitAdminGrant
+    });
+
+    let nextEnabled = enabled !== undefined ? (enabled ? 1 : 0) : config.enabled;
+    if (allow_cross_owner === false && grantedByAdmin === null) nextEnabled = 0;
+    if (grantedByAdmin === null && nextEnabled === 1) {
+      return res.status(400).json({error: 'Cross-owner sync requires explicit admin approval'});
+    }
 
     const nextSync = calculateNextSync(sync_interval || config.sync_interval);
 
     db.prepare(`
       UPDATE sync_configs
-      SET enabled = ?, sync_interval = ?, next_sync = ?, auto_add_categories = ?, auto_add_channels = ?, sync_series_episodes = ?
+      SET enabled = ?, sync_interval = ?, next_sync = ?, auto_add_categories = ?, auto_add_channels = ?, sync_series_episodes = ?, granted_by_admin = ?
       WHERE id = ?
     `).run(
-      enabled !== undefined ? (enabled ? 1 : 0) : config.enabled,
+      nextEnabled,
       sync_interval || config.sync_interval,
       nextSync,
       auto_add_categories !== undefined ? (auto_add_categories ? 1 : 0) : config.auto_add_categories,
       auto_add_channels !== undefined ? (auto_add_channels ? 1 : 0) : config.auto_add_channels,
       sync_series_episodes !== undefined ? (sync_series_episodes ? 1 : 0) : (config.sync_series_episodes === undefined || config.sync_series_episodes === null ? 1 : config.sync_series_episodes),
+      grantedByAdmin === 1 ? 1 : 0,
       id
     );
 

--- a/src/controllers/systemController.js
+++ b/src/controllers/systemController.js
@@ -7,6 +7,7 @@ import { encryptWithPassword, decryptWithPassword, decrypt, encrypt } from '../u
 import { calculateNextSync } from '../services/syncService.js';
 import { isIP } from 'net';
 import { clearSettingsCache, isSafeUrl, cleanIp, resolveAssignmentGrant } from '../utils/helpers.js';
+import { normalizeContainerExtension } from '../utils/containerExtension.js';
 import si from 'systeminformation';
 import geoip from 'geoip-lite';
 import { getEpgLogo, loadEpgLogosCache } from '../services/logoResolver.js';
@@ -545,7 +546,7 @@ export const importData = async (req, res) => {
           ch.original_sort_order,
           ch.tv_archive || 0,
           ch.tv_archive_duration || 0,
-          ch.mime_type || null,
+          normalizeContainerExtension(ch.mime_type, ch.stream_type === 'live' ? 'ts' : 'mp4'),
           ch.metadata || null,
           ch.rating || null,
           ch.rating_5based || 0,
@@ -604,7 +605,8 @@ export const importData = async (req, res) => {
             categoryOwnerId: newUserId,
             providerOwnerId: providerOwnerMap.get(newProvId),
             isAdmin: true,
-            allowExplicitAdminGrant: Number(s.granted_by_admin) === 1
+            allowExplicitAdminGrant: req.body?.allow_cross_owner === true &&
+              Number(s.granted_by_admin) === 1
           });
           insertSyncConfigStmt.run(
             newProvId,
@@ -624,8 +626,9 @@ export const importData = async (req, res) => {
       const userAssignments = importData.channels.filter(c => c.type === 'user_assignment');
       const insertUserChannel = db.prepare(`
         INSERT INTO user_channels
-          (user_category_id, provider_channel_id, sort_order, custom_name, is_hidden, granted_by_admin)
-        VALUES (?, ?, ?, ?, ?, ?)
+          (user_category_id, provider_channel_id, sort_order, custom_name, is_hidden,
+           granted_by_admin, authorization_revoked)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
       `);
 
       for (const ua of userAssignments) {
@@ -637,15 +640,17 @@ export const importData = async (req, res) => {
             categoryOwnerId: categoryOwnerMap.get(newUserCatId),
             providerOwnerId: providerChannelOwnerMap.get(newProvChannelId),
             isAdmin: true,
-            allowExplicitAdminGrant: Number(ua.granted_by_admin) === 1
+            allowExplicitAdminGrant: req.body?.allow_cross_owner === true &&
+              Number(ua.granted_by_admin) === 1
           });
           insertUserChannel.run(
             newUserCatId,
             newProvChannelId,
             ua.sort_order,
             ua.custom_name || '',
-            Number(ua.is_hidden) === 1 || grant === null ? 1 : 0,
-            grant === 1 ? 1 : 0
+            Number(ua.is_hidden) === 1 ? 1 : 0,
+            grant === 1 ? 1 : 0,
+            grant === null ? 1 : 0
           );
           stats.channels++;
         }

--- a/src/controllers/systemController.js
+++ b/src/controllers/systemController.js
@@ -713,8 +713,11 @@ export const createSyncConfig = (req, res) => {
       categoryOwnerId: userId,
       providerOwnerId: provider.user_id,
       isAdmin: true,
-      allowExplicitAdminGrant: allow_cross_owner !== false
+      allowExplicitAdminGrant: allow_cross_owner === true
     });
+    if (grantedByAdmin === null) {
+      return res.status(400).json({error: 'allow_cross_owner=true is required for a cross-owner sync config'});
+    }
 
     const nextSync = calculateNextSync(sync_interval || 'daily');
 
@@ -724,7 +727,7 @@ export const createSyncConfig = (req, res) => {
     `).run(
       providerId,
       userId,
-      grantedByAdmin === null ? 0 : (enabled ? 1 : 0),
+      enabled ? 1 : 0,
       sync_interval || 'daily',
       nextSync,
       auto_add_categories ? 1 : 0,

--- a/src/controllers/systemController.js
+++ b/src/controllers/systemController.js
@@ -366,6 +366,8 @@ export const importData = async (req, res) => {
   let tempPath = null;
   try {
     const { password } = req.body;
+    const allowCrossOwner = req.body?.allow_cross_owner === true ||
+      req.body?.allow_cross_owner === 'true';
     if (!req.file || !password) {
       return res.status(400).json({error: 'File and password required'});
     }
@@ -605,7 +607,7 @@ export const importData = async (req, res) => {
             categoryOwnerId: newUserId,
             providerOwnerId: providerOwnerMap.get(newProvId),
             isAdmin: true,
-            allowExplicitAdminGrant: req.body?.allow_cross_owner === true &&
+            allowExplicitAdminGrant: allowCrossOwner &&
               Number(s.granted_by_admin) === 1
           });
           insertSyncConfigStmt.run(
@@ -640,7 +642,7 @@ export const importData = async (req, res) => {
             categoryOwnerId: categoryOwnerMap.get(newUserCatId),
             providerOwnerId: providerChannelOwnerMap.get(newProvChannelId),
             isAdmin: true,
-            allowExplicitAdminGrant: req.body?.allow_cross_owner === true &&
+            allowExplicitAdminGrant: allowCrossOwner &&
               Number(ua.granted_by_admin) === 1
           });
           insertUserChannel.run(

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -191,8 +191,8 @@ export const createUser = async (req, res) => {
                     const placeholders = Array(oldProviderIdsForSync.length).fill('?').join(',');
                     const sourceSyncs = db.prepare(`SELECT * FROM sync_configs WHERE provider_id IN (${placeholders})`).all(...oldProviderIdsForSync);
                     const insertSync = db.prepare(`
-                        INSERT OR IGNORE INTO sync_configs (provider_id, user_id, enabled, sync_interval, auto_add_categories, auto_add_channels)
-                        VALUES (?, ?, ?, ?, ?, ?)
+                        INSERT OR IGNORE INTO sync_configs (provider_id, user_id, enabled, sync_interval, auto_add_categories, auto_add_channels, sync_series_episodes, granted_by_admin)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, 0)
                     `);
                     for (const sync of sourceSyncs) {
                         insertSync.run(
@@ -201,7 +201,8 @@ export const createUser = async (req, res) => {
                             sync.enabled,
                             sync.sync_interval,
                             sync.auto_add_categories,
-                            sync.auto_add_channels
+                            sync.auto_add_channels,
+                            sync.sync_series_episodes === undefined ? 1 : sync.sync_series_episodes
                         );
                     }
                 }
@@ -324,8 +325,8 @@ export const createUser = async (req, res) => {
                 // We need to iterate over source user's categories to find channels
                 // Or simply select all user_channels linked to source user's categories
                 const insertUserChan = db.prepare(`
-                    INSERT INTO user_channels (user_category_id, provider_channel_id, sort_order, custom_name, is_hidden)
-                    VALUES (?, ?, ?, ?, ?)
+                    INSERT INTO user_channels (user_category_id, provider_channel_id, sort_order, custom_name, is_hidden, granted_by_admin)
+                    VALUES (?, ?, ?, ?, ?, 0)
                 `);
 
                 // Fetch all user channels for source user categories

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -7,6 +7,7 @@ import bcrypt from 'bcrypt';
 import crypto from 'crypto';
 import { BCRYPT_ROUNDS } from '../config/constants.js';
 import { providerSourceKey } from '../utils/helpers.js';
+import { normalizeContainerExtension } from '../utils/containerExtension.js';
 
 const getClonedProviderChannelName = (channel) => {
   if (typeof channel.name === 'string' && channel.name.trim()) return channel.name;
@@ -240,7 +241,7 @@ export const createUser = async (req, res) => {
                             ch.tv_archive,
                             ch.tv_archive_duration,
                             ch.metadata,
-                            ch.mime_type,
+                            normalizeContainerExtension(ch.mime_type, ch.stream_type === 'live' ? 'ts' : 'mp4'),
                             ch.rating,
                             ch.rating_5based,
                             ch.added,
@@ -325,8 +326,10 @@ export const createUser = async (req, res) => {
                 // We need to iterate over source user's categories to find channels
                 // Or simply select all user_channels linked to source user's categories
                 const insertUserChan = db.prepare(`
-                    INSERT INTO user_channels (user_category_id, provider_channel_id, sort_order, custom_name, is_hidden, granted_by_admin)
-                    VALUES (?, ?, ?, ?, ?, 0)
+                    INSERT INTO user_channels
+                      (user_category_id, provider_channel_id, sort_order, custom_name, is_hidden,
+                       granted_by_admin, authorization_revoked)
+                    VALUES (?, ?, ?, ?, ?, 0, 0)
                 `);
 
                 // Fetch all user channels for source user categories

--- a/src/controllers/xtreamController.js
+++ b/src/controllers/xtreamController.js
@@ -237,7 +237,7 @@ export const playerApi = async (req, res) => {
       let query = `
         SELECT DISTINCT cat.*
         FROM user_categories cat
-        JOIN user_channels uc ON uc.user_category_id = cat.id
+        JOIN authorized_user_channels uc ON uc.user_category_id = cat.id
         JOIN provider_channels pc ON pc.id = uc.provider_channel_id
         WHERE cat.user_id = ? AND pc.stream_type = ? AND uc.is_hidden = 0
       `;
@@ -276,7 +276,7 @@ export const playerApi = async (req, res) => {
         SELECT uc.id as user_channel_id, uc.custom_name, uc.user_category_id, pc.*, cat.is_adult as category_is_adult,
                map.epg_channel_id as manual_epg_id
         FROM user_categories cat
-        JOIN user_channels uc ON cat.id = uc.user_category_id
+        JOIN authorized_user_channels uc ON cat.id = uc.user_category_id
         JOIN provider_channels pc ON pc.id = uc.provider_channel_id
         LEFT JOIN epg_channel_mappings map ON map.provider_channel_id = pc.id
         WHERE cat.user_id = ? AND pc.stream_type = 'live' AND uc.is_hidden = 0`;
@@ -324,7 +324,7 @@ export const playerApi = async (req, res) => {
       let query = `
         SELECT uc.id as user_channel_id, uc.custom_name, uc.user_category_id, pc.*, cat.is_adult as category_is_adult
         FROM user_categories cat
-        JOIN user_channels uc ON cat.id = uc.user_category_id
+        JOIN authorized_user_channels uc ON cat.id = uc.user_category_id
         JOIN provider_channels pc ON pc.id = uc.provider_channel_id
         WHERE cat.user_id = ? AND pc.stream_type = 'movie' AND uc.is_hidden = 0`;
       let params = [user.id];
@@ -370,7 +370,7 @@ export const playerApi = async (req, res) => {
                json_extract(pc.metadata, '$.backdrop_path') as backdrop_path,
                cat.is_adult as category_is_adult
         FROM user_categories cat
-        JOIN user_channels uc ON cat.id = uc.user_category_id
+        JOIN authorized_user_channels uc ON cat.id = uc.user_category_id
         JOIN provider_channels pc ON pc.id = uc.provider_channel_id
         WHERE cat.user_id = ? AND pc.stream_type = 'series' AND uc.is_hidden = 0`;
       let params = [user.id];
@@ -428,7 +428,7 @@ export const playerApi = async (req, res) => {
 
       const channel = db.prepare(`
         SELECT uc.id as user_channel_id, uc.custom_name, pc.*, p.url, p.username, p.password
-        FROM user_channels uc
+        FROM authorized_user_channels uc
         JOIN provider_channels pc ON pc.id = uc.provider_channel_id
         JOIN providers p ON p.id = pc.provider_id
         JOIN user_categories cat ON cat.id = uc.user_category_id
@@ -487,7 +487,7 @@ export const playerApi = async (req, res) => {
 
       const channel = db.prepare(`
         SELECT uc.id as user_channel_id, uc.custom_name, pc.*, p.url, p.username, p.password
-        FROM user_channels uc
+        FROM authorized_user_channels uc
         JOIN provider_channels pc ON pc.id = uc.provider_channel_id
         JOIN providers p ON p.id = pc.provider_id
         JOIN user_categories cat ON cat.id = uc.user_category_id
@@ -535,7 +535,7 @@ export const playerApi = async (req, res) => {
 
       const channel = db.prepare(`
         SELECT pc.epg_channel_id, map.epg_channel_id as manual_epg_id
-        FROM user_channels uc
+        FROM authorized_user_channels uc
         JOIN provider_channels pc ON pc.id = uc.provider_channel_id
         JOIN user_categories cat ON cat.id = uc.user_category_id
         LEFT JOIN epg_channel_mappings map ON map.provider_channel_id = pc.id
@@ -570,7 +570,7 @@ export const playerApi = async (req, res) => {
 
       const channel = db.prepare(`
         SELECT pc.epg_channel_id, map.epg_channel_id as manual_epg_id
-        FROM user_channels uc
+        FROM authorized_user_channels uc
         JOIN provider_channels pc ON pc.id = uc.provider_channel_id
         JOIN user_categories cat ON cat.id = uc.user_category_id
         LEFT JOIN epg_channel_mappings map ON map.provider_channel_id = pc.id
@@ -604,7 +604,7 @@ export const playerApi = async (req, res) => {
       const placeholders = streamIds.map(() => '?').join(',');
       const channels = db.prepare(`
         SELECT uc.id as user_channel_id, pc.epg_channel_id, map.epg_channel_id as manual_epg_id
-        FROM user_channels uc
+        FROM authorized_user_channels uc
         JOIN provider_channels pc ON pc.id = uc.provider_channel_id
         JOIN user_categories cat ON cat.id = uc.user_category_id
         LEFT JOIN epg_channel_mappings map ON map.provider_channel_id = pc.id
@@ -668,7 +668,7 @@ export const getPlaylist = async (req, res) => {
         pc.provider_id, pc.remote_stream_id,
              cat.name as category_name, map.epg_channel_id as manual_epg_id
       FROM user_categories cat
-      JOIN user_channels uc ON cat.id = uc.user_category_id
+      JOIN authorized_user_channels uc ON cat.id = uc.user_category_id
       JOIN provider_channels pc ON pc.id = uc.provider_channel_id
       LEFT JOIN epg_channel_mappings map ON map.provider_channel_id = pc.id
       WHERE cat.user_id = ? AND uc.is_hidden = 0`;
@@ -823,7 +823,7 @@ export const xmltv = async (req, res) => {
     const allowedIds = new Set();
     let query = `
         SELECT DISTINCT COALESCE(map.epg_channel_id, pc.epg_channel_id) as epg_id
-        FROM user_channels uc
+        FROM authorized_user_channels uc
         JOIN provider_channels pc ON pc.id = uc.provider_channel_id
         JOIN user_categories cat ON cat.id = uc.user_category_id
         LEFT JOIN epg_channel_mappings map ON map.provider_channel_id = pc.id
@@ -906,7 +906,7 @@ export const playerChannelsJson = async (req, res) => {
         map.epg_channel_id as manual_epg_id,
         p.use_mapped_epg_icon
       FROM user_categories cat
-      JOIN user_channels uc ON cat.id = uc.user_category_id
+      JOIN authorized_user_channels uc ON cat.id = uc.user_category_id
       JOIN provider_channels pc ON pc.id = uc.provider_channel_id
       LEFT JOIN epg_channel_mappings map ON map.provider_channel_id = pc.id
       LEFT JOIN providers p ON p.id = pc.provider_id
@@ -1045,7 +1045,7 @@ export const playerPlaylist = async (req, res) => {
         cat.name as category_name,
         map.epg_channel_id as manual_epg_id
       FROM user_categories cat
-      JOIN user_channels uc ON cat.id = uc.user_category_id
+      JOIN authorized_user_channels uc ON cat.id = uc.user_category_id
       JOIN provider_channels pc ON pc.id = uc.provider_channel_id
       LEFT JOIN epg_channel_mappings map ON map.provider_channel_id = pc.id
       WHERE cat.user_id = ? AND pc.stream_type != 'series' AND uc.is_hidden = 0

--- a/src/controllers/xtreamController.js
+++ b/src/controllers/xtreamController.js
@@ -9,6 +9,7 @@ import { fetchSafe } from '../utils/network.js';
 import { PORT } from '../config/constants.js';
 import { episodeNameCache } from '../services/episodeCache.js';
 import { getEpgLogo, loadEpgLogosCache } from '../services/logoResolver.js';
+import { encodeSeriesEpisodeId } from '../utils/seriesEpisodeId.js';
 
 const sanitizeM3uTag = (val) => {
   if (val === null || val === undefined) return '';
@@ -432,7 +433,7 @@ export const playerApi = async (req, res) => {
         JOIN provider_channels pc ON pc.id = uc.provider_channel_id
         JOIN providers p ON p.id = pc.provider_id
         JOIN user_categories cat ON cat.id = uc.user_category_id
-        WHERE uc.id = ? AND cat.user_id = ? AND uc.is_hidden = 0
+        WHERE uc.id = ? AND cat.user_id = ? AND uc.is_hidden = 0 AND pc.stream_type = 'series'
       `).get(seriesId, user.id);
 
       if (!channel) return res.json({});
@@ -448,29 +449,54 @@ export const playerApi = async (req, res) => {
 
         const data = await resp.json();
 
-        const OFFSET = 1000000000;
-        const providerId = channel.provider_id;
-
         if (data.info && channel.custom_name) {
             data.info.name = channel.custom_name;
         }
 
         if (data.episodes) {
-           for (const seasonKey in data.episodes) {
-              const episodes = data.episodes[seasonKey];
-              if (Array.isArray(episodes)) {
-                 episodes.forEach(ep => {
+           const sourceKey = providerSourceKey(channel.url);
+           const upsertEpisode = db.prepare(`
+             INSERT INTO provider_series_episodes
+               (source_key, series_remote_id, remote_episode_id, season, episode_num, title, container_extension, logo, added)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+             ON CONFLICT(source_key, remote_episode_id) DO UPDATE SET
+               series_remote_id = excluded.series_remote_id,
+               season = excluded.season,
+               episode_num = excluded.episode_num,
+               title = excluded.title,
+               container_extension = excluded.container_extension,
+               logo = excluded.logo,
+               added = excluded.added
+           `);
+           db.transaction(() => {
+             for (const seasonKey in data.episodes) {
+                const episodes = data.episodes[seasonKey];
+                if (!Array.isArray(episodes)) continue;
+                data.episodes[seasonKey] = episodes.filter(ep => {
                     const originalId = Number(ep.id);
-                    const newId = (providerId * OFFSET + originalId).toString();
+                    const newId = encodeSeriesEpisodeId(channel.user_channel_id, originalId);
+                    if (!newId) return false;
+                    upsertEpisode.run(
+                      sourceKey,
+                      remoteSeriesId,
+                      originalId,
+                      Number(ep.season ?? seasonKey) || 0,
+                      Number(ep.episode_num) || 0,
+                      ep.title || '',
+                      ep.container_extension || 'mp4',
+                      ep.info?.movie_image || ep.movie_image || ep.cover || '',
+                      ep.added || ''
+                    );
                     ep.id = newId;
 
                     // Cache the episode name for the active streams dashboard
                     const seriesName = data.info ? data.info.name : 'Unknown Series';
                     const epTitle = ep.title ? ep.title : `Episode ${originalId}`;
                     episodeNameCache.set(newId, `${seriesName} - ${epTitle}`);
-                 });
-              }
-           }
+                    return true;
+                });
+             }
+           })();
         }
 
         return res.json(data);
@@ -724,8 +750,6 @@ export const getPlaylist = async (req, res) => {
     const sourceKeyByProviderId = new Map(
       db.prepare('SELECT id, url FROM providers').all().map(p => [p.id, providerSourceKey(p.url)])
     );
-    const EPISODE_ID_OFFSET = 1000000000; // must match proxySeries decoding
-
     // ⚡ Bolt: Replace .all() with .iterate() to stream rows directly from SQLite.
     // 🎯 Why: Loading 50,000+ channel objects into V8 memory at once can cause memory spikes and block the event loop.
     // 📊 Impact: Drastically reduces peak memory usage and improves response time for massive playlists.
@@ -754,7 +778,9 @@ export const getPlaylist = async (req, res) => {
             const epCode = `S${String(ep.season || 0).padStart(2, '0')} E${String(ep.episode_num || 0).padStart(2, '0')}`;
             const epName = `${finalName} ${epCode}`;
             const epLogo = ep.logo ? sanitizeM3uTag(ep.logo) : safeLogo;
-            let episodeUrl = seriesPrefix + (ch.provider_id * EPISODE_ID_OFFSET + ep.remote_episode_id) + '.' + (ep.container_extension || 'mp4');
+            const episodeId = encodeSeriesEpisodeId(ch.user_channel_id, ep.remote_episode_id);
+            if (!episodeId) continue;
+            let episodeUrl = seriesPrefix + episodeId + '.' + (ep.container_extension || 'mp4');
             if (useTokenAuth) {
               episodeUrl += tokenParam;
             }

--- a/src/controllers/xtreamController.js
+++ b/src/controllers/xtreamController.js
@@ -1,5 +1,5 @@
 import zlib from 'zlib';
-import db from '../database/db.js';
+import db, { openDbConnection } from '../database/db.js';
 import { getXtreamUser } from '../services/authService.js';
 import { getEpgPrograms, getEpgProgramsForChannels, getEpgXmlForChannels } from '../services/epgService.js';
 import { channelsJsonCache } from '../services/cacheService.js';
@@ -9,7 +9,7 @@ import { fetchSafe } from '../utils/network.js';
 import { PORT } from '../config/constants.js';
 import { episodeNameCache } from '../services/episodeCache.js';
 import { getEpgLogo, loadEpgLogosCache } from '../services/logoResolver.js';
-import { encodeSeriesEpisodeId } from '../utils/seriesEpisodeId.js';
+import { SERIES_EPISODE_ALIAS_MIN, SERIES_EPISODE_OFFSET } from '../utils/seriesEpisodeId.js';
 
 const sanitizeM3uTag = (val) => {
   if (val === null || val === undefined) return '';
@@ -40,6 +40,33 @@ const sanitizeMetadata = (val) => {
 };
 
 const encodeXtreamEpgText = (val) => val ? Buffer.from(String(val)).toString('base64') : '';
+
+const prepareSeriesEpisodeAliases = (database = db) => ({
+  insert: database.prepare(`
+    INSERT OR IGNORE INTO series_episode_aliases
+      (user_channel_id, source_key, series_remote_id, remote_episode_id)
+    VALUES (?, ?, ?, ?)
+  `),
+  select: database.prepare(`
+    SELECT id FROM series_episode_aliases
+    WHERE user_channel_id = ? AND source_key = ? AND series_remote_id = ? AND remote_episode_id = ?
+  `),
+});
+
+const getOrCreateSeriesEpisodeAlias = (statements, userChannelId, sourceKey, seriesRemoteId, remoteEpisodeId) => {
+  const values = [Number(userChannelId), String(sourceKey || ''), Number(seriesRemoteId), Number(remoteEpisodeId)];
+  if (!values[1] || !values.every((value, index) => index === 1 || (Number.isSafeInteger(value) && value > 0))) return null;
+
+  let row = statements.select.get(...values);
+  if (!row) {
+    statements.insert.run(...values);
+    row = statements.select.get(...values);
+  }
+  return row && Number.isSafeInteger(Number(row.id)) &&
+    row.id >= SERIES_EPISODE_ALIAS_MIN && row.id < SERIES_EPISODE_OFFSET
+    ? String(row.id)
+    : null;
+};
 
 const formatXtreamEpgListing = (program, epgId) => ({
   id: String(program.start),
@@ -455,12 +482,12 @@ export const playerApi = async (req, res) => {
 
         if (data.episodes) {
            const sourceKey = providerSourceKey(channel.url);
+           const episodeAliases = prepareSeriesEpisodeAliases();
            const upsertEpisode = db.prepare(`
              INSERT INTO provider_series_episodes
                (source_key, series_remote_id, remote_episode_id, season, episode_num, title, container_extension, logo, added)
              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-             ON CONFLICT(source_key, remote_episode_id) DO UPDATE SET
-               series_remote_id = excluded.series_remote_id,
+             ON CONFLICT(source_key, series_remote_id, remote_episode_id) DO UPDATE SET
                season = excluded.season,
                episode_num = excluded.episode_num,
                title = excluded.title,
@@ -474,7 +501,13 @@ export const playerApi = async (req, res) => {
                 if (!Array.isArray(episodes)) continue;
                 data.episodes[seasonKey] = episodes.filter(ep => {
                     const originalId = Number(ep.id);
-                    const newId = encodeSeriesEpisodeId(channel.user_channel_id, originalId);
+                    const newId = getOrCreateSeriesEpisodeAlias(
+                      episodeAliases,
+                      channel.user_channel_id,
+                      sourceKey,
+                      remoteSeriesId,
+                      originalId
+                    );
                     if (!newId) return false;
                     upsertEpisode.run(
                       sourceKey,
@@ -747,12 +780,15 @@ export const getPlaylist = async (req, res) => {
       WHERE source_key = ? AND series_remote_id = ?
       ORDER BY season ASC, episode_num ASC, remote_episode_id ASC
     `);
+    const episodeAliasDb = openDbConnection();
+    const episodeAliases = prepareSeriesEpisodeAliases(episodeAliasDb);
     const sourceKeyByProviderId = new Map(
       db.prepare('SELECT id, url FROM providers').all().map(p => [p.id, providerSourceKey(p.url)])
     );
     // ⚡ Bolt: Replace .all() with .iterate() to stream rows directly from SQLite.
     // 🎯 Why: Loading 50,000+ channel objects into V8 memory at once can cause memory spikes and block the event loop.
     // 📊 Impact: Drastically reduces peak memory usage and improves response time for massive playlists.
+    try {
     for (const ch of stmt.iterate(...params)) {
       const epgId = ch.manual_epg_id || ch.epg_channel_id || '';
       const logo = ch.logo || '';
@@ -772,13 +808,20 @@ export const getPlaylist = async (req, res) => {
       finalName = finalName.trim();
 
       if (ch.stream_type === 'series') {
-        const episodes = episodesStmt.all(sourceKeyByProviderId.get(ch.provider_id) || '', ch.remote_stream_id);
+        const sourceKey = sourceKeyByProviderId.get(ch.provider_id) || '';
+        const episodes = episodesStmt.all(sourceKey, ch.remote_stream_id);
         if (episodes.length > 0) {
           for (const ep of episodes) {
             const epCode = `S${String(ep.season || 0).padStart(2, '0')} E${String(ep.episode_num || 0).padStart(2, '0')}`;
             const epName = `${finalName} ${epCode}`;
             const epLogo = ep.logo ? sanitizeM3uTag(ep.logo) : safeLogo;
-            const episodeId = encodeSeriesEpisodeId(ch.user_channel_id, ep.remote_episode_id);
+            const episodeId = getOrCreateSeriesEpisodeAlias(
+              episodeAliases,
+              ch.user_channel_id,
+              sourceKey,
+              ch.remote_stream_id,
+              ep.remote_episode_id
+            );
             if (!episodeId) continue;
             let episodeUrl = seriesPrefix + episodeId + '.' + (ep.container_extension || 'mp4');
             if (useTokenAuth) {
@@ -825,6 +868,9 @@ export const getPlaylist = async (req, res) => {
           res.write(buffer);
           buffer = '';
       }
+    }
+    } finally {
+      episodeAliasDb.close();
     }
 
     if (buffer.length > 0) {

--- a/src/controllers/xtreamController.js
+++ b/src/controllers/xtreamController.js
@@ -5,6 +5,7 @@ import { getEpgPrograms, getEpgProgramsForChannels, getEpgXmlForChannels } from 
 import { channelsJsonCache } from '../services/cacheService.js';
 import { decrypt } from '../utils/crypto.js';
 import { getBaseUrl, providerSourceKey } from '../utils/helpers.js';
+import { normalizeContainerExtension } from '../utils/containerExtension.js';
 import { fetchSafe } from '../utils/network.js';
 import { PORT } from '../config/constants.js';
 import { episodeNameCache } from '../services/episodeCache.js';
@@ -384,7 +385,7 @@ export const playerApi = async (req, res) => {
           rating_5based: ch.rating_5based || 0,
           added: ch.added || nowStr,
           category_id: String(ch.user_category_id),
-          container_extension: ch.mime_type || 'mp4',
+          container_extension: normalizeContainerExtension(ch.mime_type),
           custom_sid: null,
           direct_source: ''
         };
@@ -516,11 +517,12 @@ export const playerApi = async (req, res) => {
                       Number(ep.season ?? seasonKey) || 0,
                       Number(ep.episode_num) || 0,
                       ep.title || '',
-                      ep.container_extension || 'mp4',
+                      normalizeContainerExtension(ep.container_extension),
                       ep.info?.movie_image || ep.movie_image || ep.cover || '',
                       ep.added || ''
                     );
                     ep.id = newId;
+                    ep.container_extension = normalizeContainerExtension(ep.container_extension);
 
                     // Cache the episode name for the active streams dashboard
                     const seriesName = data.info ? data.info.name : 'Unknown Series';
@@ -823,7 +825,7 @@ export const getPlaylist = async (req, res) => {
               ep.remote_episode_id
             );
             if (!episodeId) continue;
-            let episodeUrl = seriesPrefix + episodeId + '.' + (ep.container_extension || 'mp4');
+            let episodeUrl = seriesPrefix + episodeId + '.' + normalizeContainerExtension(ep.container_extension);
             if (useTokenAuth) {
               episodeUrl += tokenParam;
             }
@@ -842,14 +844,13 @@ export const getPlaylist = async (req, res) => {
           }
           continue;
         }
-        // Episodes not synced (yet): fall through to the legacy series entry.
+        // Unsynchronized series have no playable episode identifier yet.
+        continue;
       }
 
       let streamUrl;
       if (ch.stream_type === 'movie') {
-         streamUrl = moviePrefix + streamId + '.' + (ch.mime_type || 'mp4');
-      } else if (ch.stream_type === 'series') {
-         streamUrl = seriesPrefix + streamId + '.' + (ch.mime_type || 'mp4');
+         streamUrl = moviePrefix + streamId + '.' + normalizeContainerExtension(ch.mime_type);
       } else {
          streamUrl = livePrefix + streamId + '.' + (output === 'hls' ? 'm3u8' : 'ts');
       }
@@ -967,6 +968,7 @@ export const playerChannelsJson = async (req, res) => {
         pc.logo,
         pc.epg_channel_id,
         pc.remote_stream_id,
+        pc.provider_id,
         pc.stream_type,
         pc.tv_archive,
         pc.tv_archive_duration,
@@ -976,7 +978,8 @@ export const playerChannelsJson = async (req, res) => {
         pc.plot, pc."cast", pc.director, pc.genre, pc.releaseDate, pc.rating, pc.episode_run_time,
         cat.name as category_name,
         map.epg_channel_id as manual_epg_id,
-        p.use_mapped_epg_icon
+        p.use_mapped_epg_icon,
+        p.url as provider_url
       FROM user_categories cat
       JOIN authorized_user_channels uc ON cat.id = uc.user_category_id
       JOIN provider_channels pc ON pc.id = uc.provider_channel_id
@@ -1003,6 +1006,27 @@ export const playerChannelsJson = async (req, res) => {
     // 📊 Impact: Significantly lowers RAM usage and speeds up response generation for player JSON payload.
     let jsonOutput = '[';
     let isFirst = true;
+    const appendItem = (item, ch) => {
+      if (ch.stream_type === 'movie' || ch.stream_type === 'series') {
+        if (ch.plot) item.plot = ch.plot;
+        if (ch.cast) item.cast = ch.cast;
+        if (ch.director) item.director = ch.director;
+        if (ch.genre) item.genre = ch.genre;
+        if (ch.releaseDate) item.releaseDate = ch.releaseDate;
+        if (ch.rating) item.rating = ch.rating;
+        if (ch.episode_run_time) item.duration = ch.episode_run_time;
+      }
+
+      if (ch.drm_license_type || ch.drm_license_key) {
+        item.drm = {};
+        if (ch.drm_license_type) item.drm.license_type = ch.drm_license_type;
+        if (ch.drm_license_key) item.drm.license_key = ch.drm_license_key;
+      }
+
+      if (!isFirst) jsonOutput += ',';
+      jsonOutput += JSON.stringify(item);
+      isFirst = false;
+    };
 
     if (!isExpired) {
         // ⚡ Bolt: Pre-construct URL prefixes outside of the tight loop.
@@ -1010,7 +1034,16 @@ export const playerChannelsJson = async (req, res) => {
         const liveMpdPrefix = `${host}/live/mpd/token/auth/`;
         const moviePrefix = `${host}/movie/token/auth/`;
         const seriesPrefix = `${host}/series/token/auth/`;
+        const episodesStmt = db.prepare(`
+          SELECT remote_episode_id, season, episode_num, container_extension, logo
+          FROM provider_series_episodes
+          WHERE source_key = ? AND series_remote_id = ?
+          ORDER BY season ASC, episode_num ASC, remote_episode_id ASC
+        `);
+        const episodeAliasDb = openDbConnection();
+        const episodeAliases = prepareSeriesEpisodeAliases(episodeAliasDb);
 
+        try {
         for (const ch of stmt.iterate(user.id)) {
           if (allowedSet && !allowedSet.has(ch.user_channel_id)) continue;
 
@@ -1027,17 +1060,43 @@ export const playerChannelsJson = async (req, res) => {
           }
           name = name.trim();
 
-          const containerExtension = String(ch.mime_type || '').trim().toLowerCase();
-          const isDashStream = containerExtension === 'mpd' || containerExtension === 'dash' || containerExtension === 'application/dash+xml';
+          const containerExtension = normalizeContainerExtension(
+            ch.mime_type,
+            ch.stream_type === 'live' ? 'ts' : 'mp4'
+          );
+          const isDashStream = containerExtension === 'mpd';
           let streamUrl;
           let type = 'live';
 
           if (ch.stream_type === 'movie') {
              type = 'movie';
-             streamUrl = moviePrefix + ch.user_channel_id + '.' + (containerExtension || 'mp4') + tokenParam;
+             streamUrl = moviePrefix + ch.user_channel_id + '.' + containerExtension + tokenParam;
           } else if (ch.stream_type === 'series') {
-             type = 'series';
-             streamUrl = seriesPrefix + ch.user_channel_id + '.' + (containerExtension || 'mp4') + tokenParam;
+             const sourceKey = providerSourceKey(ch.provider_url);
+             for (const ep of episodesStmt.all(sourceKey, ch.remote_stream_id)) {
+               const episodeId = getOrCreateSeriesEpisodeAlias(
+                 episodeAliases,
+                 ch.user_channel_id,
+                 sourceKey,
+                 ch.remote_stream_id,
+                 ep.remote_episode_id
+               );
+               if (!episodeId) continue;
+               const extension = normalizeContainerExtension(ep.container_extension);
+               const episodeCode = `S${String(ep.season || 0).padStart(2, '0')} E${String(ep.episode_num || 0).padStart(2, '0')}`;
+               appendItem({
+                 name: `${name} ${episodeCode}`,
+                 group,
+                 logo: ep.logo || logo,
+                 epg_id: epgId,
+                 url: seriesPrefix + episodeId + '.' + extension + tokenParam,
+                 type: 'series',
+                 container_extension: extension,
+                 tv_archive: 0,
+                 tv_archive_duration: 0
+               }, ch);
+             }
+             continue;
           } else {
              if (isDashStream) {
                  streamUrl = liveMpdPrefix + ch.user_channel_id + '/manifest.mpd' + tokenParam;
@@ -1058,27 +1117,10 @@ export const playerChannelsJson = async (req, res) => {
             tv_archive_duration: ch.tv_archive_duration || 0
           };
 
-          if (ch.stream_type === 'movie' || ch.stream_type === 'series') {
-            if (ch.plot) item.plot = ch.plot;
-            if (ch.cast) item.cast = ch.cast;
-            if (ch.director) item.director = ch.director;
-            if (ch.genre) item.genre = ch.genre;
-            if (ch.releaseDate) item.releaseDate = ch.releaseDate;
-            if (ch.rating) item.rating = ch.rating;
-            if (ch.episode_run_time) item.duration = ch.episode_run_time;
-          }
-
-          if (ch.drm_license_type || ch.drm_license_key) {
-              item.drm = {};
-              if (ch.drm_license_type) item.drm.license_type = ch.drm_license_type;
-              if (ch.drm_license_key) item.drm.license_key = ch.drm_license_key;
-          }
-
-          if (!isFirst) {
-            jsonOutput += ',';
-          }
-          jsonOutput += JSON.stringify(item);
-          isFirst = false;
+          appendItem(item, ch);
+        }
+        } finally {
+          episodeAliasDb.close();
         }
     }
     jsonOutput += ']';
@@ -1155,7 +1197,6 @@ export const playerPlaylist = async (req, res) => {
         const livePrefix = `${host}/live/token/auth/`;
         const liveMpdPrefix = `${host}/live/mpd/token/auth/`;
         const moviePrefix = `${host}/movie/token/auth/`;
-        const seriesPrefix = `${host}/series/token/auth/`;
 
         // ⚡ Bolt: Replace .all() with .iterate() to stream rows directly from SQLite.
         // 🎯 Why: Loading 50,000+ channel objects into V8 memory at once can cause memory spikes and block the event loop.
@@ -1168,12 +1209,14 @@ export const playerPlaylist = async (req, res) => {
       const name = ch.name || 'Unknown';
 
       let streamUrl;
+      const containerExtension = normalizeContainerExtension(
+        ch.mime_type,
+        ch.stream_type === 'live' ? 'ts' : 'mp4'
+      );
       if (ch.stream_type === 'movie') {
-         streamUrl = moviePrefix + ch.user_channel_id + '.' + (ch.mime_type || 'mp4') + tokenParam;
-      } else if (ch.stream_type === 'series') {
-         streamUrl = seriesPrefix + ch.user_channel_id + '.' + (ch.mime_type || 'mp4') + tokenParam;
+         streamUrl = moviePrefix + ch.user_channel_id + '.' + containerExtension + tokenParam;
       } else {
-         if (ch.mime_type === 'mpd') {
+         if (containerExtension === 'mpd') {
              streamUrl = liveMpdPrefix + ch.user_channel_id + '/manifest.mpd' + tokenParam;
          } else {
              streamUrl = livePrefix + ch.user_channel_id + '.ts' + tokenParam;

--- a/src/database/db.js
+++ b/src/database/db.js
@@ -111,7 +111,8 @@ export function initDb(isPrimary) {
       provider_channel_id INTEGER NOT NULL,
       sort_order INTEGER DEFAULT 0,
       custom_name TEXT DEFAULT '',
-      is_hidden INTEGER DEFAULT 0
+      is_hidden INTEGER DEFAULT 0,
+      granted_by_admin INTEGER NOT NULL DEFAULT 0
     );
 
     CREATE TABLE IF NOT EXISTS user_backups (
@@ -298,6 +299,7 @@ export function initDb(isPrimary) {
             migrations.migrateUserAllowedCountries(db);
             migrations.migrateUserChannelsCustomName(db);
             migrations.migrateUserChannelsIsHidden(db);
+            migrations.migrateUserChannelAdminGrants(db);
             migrations.migrateUserNotes(db);
             if (typeof migrations.migrateProviderUseMappedEpgIcon === 'function') {
                 migrations.migrateProviderUseMappedEpgIcon(db);

--- a/src/database/db.js
+++ b/src/database/db.js
@@ -136,6 +136,7 @@ export function initDb(isPrimary) {
       next_sync INTEGER DEFAULT 0,
       auto_add_categories INTEGER DEFAULT 1,
       auto_add_channels INTEGER DEFAULT 1,
+      granted_by_admin INTEGER NOT NULL DEFAULT 0,
       FOREIGN KEY (provider_id) REFERENCES providers(id),
       FOREIGN KEY (user_id) REFERENCES users(id)
     );
@@ -300,6 +301,7 @@ export function initDb(isPrimary) {
             migrations.migrateUserChannelsCustomName(db);
             migrations.migrateUserChannelsIsHidden(db);
             migrations.migrateUserChannelAdminGrants(db);
+            migrations.migrateSyncConfigAdminGrants(db);
             migrations.migrateUserNotes(db);
             if (typeof migrations.migrateProviderUseMappedEpgIcon === 'function') {
                 migrations.migrateProviderUseMappedEpgIcon(db);

--- a/src/database/db.js
+++ b/src/database/db.js
@@ -7,13 +7,19 @@ import * as migrations from './migrations.js';
 // Ensure Data Directory exists
 if (!fs.existsSync(DATA_DIR)) fs.mkdirSync(DATA_DIR, { recursive: true });
 
-const db = new Database(path.join(DATA_DIR, 'db.sqlite'), { timeout: 5000 });
-// Enable foreign keys
-db.pragma('foreign_keys = ON');
-db.pragma('busy_timeout = 5000');
+const DB_PATH = path.join(DATA_DIR, 'db.sqlite');
+
+export function openDbConnection() {
+    const connection = new Database(DB_PATH, { timeout: 5000 });
+    connection.pragma('foreign_keys = ON');
+    connection.pragma('busy_timeout = 5000');
+    connection.pragma('synchronous = NORMAL');
+    return connection;
+}
+
+const db = openDbConnection();
 // Performance tuning
 db.pragma('journal_mode = WAL');
-db.pragma('synchronous = NORMAL');
 
 export function initDb(isPrimary) {
     if (isPrimary) {

--- a/src/database/db.js
+++ b/src/database/db.js
@@ -118,7 +118,8 @@ export function initDb(isPrimary) {
       sort_order INTEGER DEFAULT 0,
       custom_name TEXT DEFAULT '',
       is_hidden INTEGER DEFAULT 0,
-      granted_by_admin INTEGER NOT NULL DEFAULT 0
+      granted_by_admin INTEGER NOT NULL DEFAULT 0,
+      authorization_revoked INTEGER NOT NULL DEFAULT 0
     );
 
     CREATE TABLE IF NOT EXISTS user_backups (

--- a/src/database/migrations.js
+++ b/src/database/migrations.js
@@ -815,6 +815,32 @@ export function migrateUserChannelAdminGrants(db) {
   }
 }
 
+export function migrateSyncConfigAdminGrants(db) {
+  const migrate = db.transaction(() => {
+    const columns = db.prepare('PRAGMA table_info(sync_configs)').all().map(column => column.name);
+    if (columns.includes('granted_by_admin')) return 0;
+
+    db.exec('ALTER TABLE sync_configs ADD COLUMN granted_by_admin INTEGER NOT NULL DEFAULT 0');
+    return db.prepare(`
+      UPDATE sync_configs
+      SET enabled = 0
+      WHERE enabled = 1
+        AND NOT EXISTS (
+          SELECT 1
+          FROM providers p
+          WHERE p.id = sync_configs.provider_id
+            AND p.user_id IS sync_configs.user_id
+        )
+    `).run().changes;
+  });
+
+  const disabled = migrate();
+  if (disabled > 0) {
+    console.info(`Sync grant migration disabled ${disabled} unapproved cross-owner config(s)`);
+  }
+  return disabled;
+}
+
 export function migrateUserNotes(db) {
   try {
     const tableInfo = db.prepare("PRAGMA table_info(users)").all();

--- a/src/database/migrations.js
+++ b/src/database/migrations.js
@@ -768,6 +768,53 @@ export function migrateUserChannelsIsHidden(db) {
   }
 }
 
+export function migrateUserChannelAdminGrants(db) {
+  const migrate = db.transaction(() => {
+    const columns = db.prepare('PRAGMA table_info(user_channels)').all().map(column => column.name);
+    const needsLegacyRevocation = !columns.includes('granted_by_admin');
+    if (needsLegacyRevocation) {
+      db.exec('ALTER TABLE user_channels ADD COLUMN granted_by_admin INTEGER NOT NULL DEFAULT 0');
+    }
+
+    db.exec(`
+      CREATE VIEW IF NOT EXISTS authorized_user_channels AS
+      SELECT uc.*
+      FROM user_channels uc
+      JOIN user_categories cat ON cat.id = uc.user_category_id
+      JOIN provider_channels pc ON pc.id = uc.provider_channel_id
+      JOIN providers p ON p.id = pc.provider_id
+      WHERE uc.is_hidden = 0
+        AND (p.user_id = cat.user_id OR uc.granted_by_admin = 1)
+    `);
+
+    if (!needsLegacyRevocation) return 0;
+
+    return db.prepare(`
+      UPDATE user_channels
+      SET is_hidden = 1
+      WHERE is_hidden = 0
+        AND granted_by_admin = 0
+        AND NOT EXISTS (
+          SELECT 1
+          FROM user_categories cat
+          JOIN provider_channels pc ON pc.id = user_channels.provider_channel_id
+          JOIN providers p ON p.id = pc.provider_id
+          WHERE cat.id = user_channels.user_category_id
+            AND p.user_id = cat.user_id
+        )
+    `).run().changes;
+  });
+
+  try {
+    const revoked = migrate();
+    console.info(`✅ DB Migration: user channel grants ready; revoked ${revoked} unauthorized assignment(s)`);
+    return revoked;
+  } catch (e) {
+    console.error('User channel admin grants migration error:', e.message);
+    throw e;
+  }
+}
+
 export function migrateUserNotes(db) {
   try {
     const tableInfo = db.prepare("PRAGMA table_info(users)").all();

--- a/src/database/migrations.js
+++ b/src/database/migrations.js
@@ -771,29 +771,39 @@ export function migrateUserChannelsIsHidden(db) {
 export function migrateUserChannelAdminGrants(db) {
   const migrate = db.transaction(() => {
     const columns = db.prepare('PRAGMA table_info(user_channels)').all().map(column => column.name);
-    const needsLegacyRevocation = !columns.includes('granted_by_admin');
-    if (needsLegacyRevocation) {
+    if (!columns.includes('granted_by_admin')) {
       db.exec('ALTER TABLE user_channels ADD COLUMN granted_by_admin INTEGER NOT NULL DEFAULT 0');
     }
+    if (!columns.includes('authorization_revoked')) {
+      db.exec('ALTER TABLE user_channels ADD COLUMN authorization_revoked INTEGER NOT NULL DEFAULT 0');
+    }
 
-    db.exec(`
-      DROP VIEW IF EXISTS authorized_user_channels;
-      CREATE VIEW authorized_user_channels AS
-      SELECT uc.*
-      FROM user_channels uc
-      JOIN user_categories cat ON cat.id = uc.user_category_id
-      JOIN provider_channels pc ON pc.id = uc.provider_channel_id
-      JOIN providers p ON p.id = pc.provider_id
-      WHERE uc.is_hidden = 0
-        AND (p.user_id = cat.user_id OR uc.granted_by_admin = 1)
-    `);
-
-    if (!needsLegacyRevocation) return 0;
-
-    return db.prepare(`
+    db.prepare(`
       UPDATE user_channels
-      SET is_hidden = 1
-      WHERE is_hidden = 0
+      SET granted_by_admin = 0,
+          authorization_revoked = 0
+      WHERE (granted_by_admin != 0 OR authorization_revoked != 0)
+        AND EXISTS (
+        SELECT 1
+        FROM user_categories cat
+        JOIN provider_channels pc ON pc.id = user_channels.provider_channel_id
+        JOIN providers p ON p.id = pc.provider_id
+        WHERE cat.id = user_channels.user_category_id
+          AND p.user_id = cat.user_id
+      )
+    `).run();
+
+    db.prepare(`
+      UPDATE user_channels
+      SET authorization_revoked = 0
+      WHERE granted_by_admin = 1
+        AND authorization_revoked != 0
+    `).run();
+
+    const revoked = db.prepare(`
+      UPDATE user_channels
+      SET authorization_revoked = 1
+      WHERE authorization_revoked = 0
         AND granted_by_admin = 0
         AND NOT EXISTS (
           SELECT 1
@@ -804,11 +814,26 @@ export function migrateUserChannelAdminGrants(db) {
             AND p.user_id = cat.user_id
         )
     `).run().changes;
+
+    db.exec(`
+      DROP VIEW IF EXISTS authorized_user_channels;
+      CREATE VIEW authorized_user_channels AS
+      SELECT uc.*
+      FROM user_channels uc
+      JOIN user_categories cat ON cat.id = uc.user_category_id
+      JOIN provider_channels pc ON pc.id = uc.provider_channel_id
+      JOIN providers p ON p.id = pc.provider_id
+      WHERE uc.is_hidden = 0
+        AND uc.authorization_revoked = 0
+        AND (p.user_id = cat.user_id OR uc.granted_by_admin = 1)
+    `);
+
+    return revoked;
   });
 
   try {
     const revoked = migrate();
-    console.info(`✅ DB Migration: user channel grants ready; revoked ${revoked} unauthorized assignment(s)`);
+    console.info(`✅ DB Migration: user channel authorization ready; revoked ${revoked} unauthorized assignment(s)`);
     return revoked;
   } catch (e) {
     console.error('User channel admin grants migration error:', e.message);

--- a/src/database/migrations.js
+++ b/src/database/migrations.js
@@ -1003,15 +1003,53 @@ export function migrateSeriesEpisodes(db) {
         source_key TEXT NOT NULL,
         series_remote_id INTEGER NOT NULL,
         remote_episode_id INTEGER NOT NULL,
-        UNIQUE(user_channel_id, source_key, series_remote_id, remote_episode_id)
+        UNIQUE(user_channel_id, source_key, series_remote_id, remote_episode_id),
+        FOREIGN KEY (user_channel_id) REFERENCES user_channels(id) ON DELETE CASCADE
       );
-
-      INSERT OR IGNORE INTO series_episode_aliases
-        (id, user_channel_id, source_key, series_remote_id, remote_episode_id)
-      VALUES (900000000, 0, '', 0, 0);
-      DELETE FROM series_episode_aliases
-      WHERE id = 900000000 AND user_channel_id = 0;
     `);
+
+    const aliasForeignKeys = db.prepare("PRAGMA foreign_key_list('series_episode_aliases')").all();
+    const hasAliasCascade = aliasForeignKeys.some(key =>
+      key.table === 'user_channels' &&
+      key.from === 'user_channel_id' &&
+      key.to === 'id' &&
+      String(key.on_delete).toUpperCase() === 'CASCADE'
+    );
+
+    if (!hasAliasCascade) {
+      db.exec(`
+        DROP TABLE IF EXISTS series_episode_aliases_new;
+        CREATE TABLE series_episode_aliases_new (
+          id INTEGER PRIMARY KEY AUTOINCREMENT CHECK(id >= 900000000 AND id < 1000000000),
+          user_channel_id INTEGER NOT NULL,
+          source_key TEXT NOT NULL,
+          series_remote_id INTEGER NOT NULL,
+          remote_episode_id INTEGER NOT NULL,
+          UNIQUE(user_channel_id, source_key, series_remote_id, remote_episode_id),
+          FOREIGN KEY (user_channel_id) REFERENCES user_channels(id) ON DELETE CASCADE
+        );
+        INSERT INTO series_episode_aliases_new
+          (id, user_channel_id, source_key, series_remote_id, remote_episode_id)
+        SELECT a.id, a.user_channel_id, a.source_key, a.series_remote_id, a.remote_episode_id
+        FROM series_episode_aliases a
+        JOIN user_channels uc ON uc.id = a.user_channel_id;
+        DROP TABLE series_episode_aliases;
+        ALTER TABLE series_episode_aliases_new RENAME TO series_episode_aliases;
+      `);
+      console.info('✅ DB Migration: series episode aliases rebuilt with cascading assignment cleanup');
+    }
+
+    db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_series_episode_aliases_user_channel
+        ON series_episode_aliases(user_channel_id);
+    `);
+
+    const aliasSequence = db.prepare("SELECT seq FROM sqlite_sequence WHERE name = 'series_episode_aliases'").get();
+    if (!aliasSequence) {
+      db.prepare("INSERT INTO sqlite_sequence(name, seq) VALUES ('series_episode_aliases', 900000000)").run();
+    } else if (Number(aliasSequence.seq) < 900000000) {
+      db.prepare("UPDATE sqlite_sequence SET seq = 900000000 WHERE name = 'series_episode_aliases'").run();
+    }
 
     const columns = db.prepare('PRAGMA table_info(sync_configs)').all().map(column => column.name);
     if (!columns.includes('sync_series_episodes')) {

--- a/src/database/migrations.js
+++ b/src/database/migrations.js
@@ -777,7 +777,8 @@ export function migrateUserChannelAdminGrants(db) {
     }
 
     db.exec(`
-      CREATE VIEW IF NOT EXISTS authorized_user_channels AS
+      DROP VIEW IF EXISTS authorized_user_channels;
+      CREATE VIEW authorized_user_channels AS
       SELECT uc.*
       FROM user_channels uc
       JOIN user_categories cat ON cat.id = uc.user_category_id
@@ -920,22 +921,32 @@ export function migrateEpgMappingJobs(db) {
 }
 
 export function migrateSeriesEpisodes(db) {
-  try {
-    // Episode data is keyed by the upstream panel (source_key = normalized
-    // provider URL), not by provider row: users sharing the same panel with
-    // their own credentials share one copy of the episode catalog.
-    // An early uncommitted schema keyed these tables by provider_id; since the
-    // tables are a rebuildable cache, drop and recreate them in that case.
-    for (const table of ['provider_series_episodes', 'provider_series_state']) {
-      const cols = db.prepare(`PRAGMA table_info(${table})`).all().map(c => c.name);
-      if (cols.length > 0 && !cols.includes('source_key')) {
-        db.exec(`DROP TABLE ${table}`);
-        console.log(`✅ DB Migration: ${table} rebuilt with source_key schema`);
-      }
+  const migrate = db.transaction(() => {
+    const expectedEpisodeKey = 'source_key,series_remote_id,remote_episode_id';
+    const episodeColumns = db.prepare('PRAGMA table_info(provider_series_episodes)').all().map(column => column.name);
+    const stateColumns = db.prepare('PRAGMA table_info(provider_series_state)').all().map(column => column.name);
+    let rebuildCache = (episodeColumns.length > 0 && !episodeColumns.includes('source_key')) ||
+      (stateColumns.length > 0 && !stateColumns.includes('source_key'));
+
+    if (episodeColumns.length > 0 && !rebuildCache) {
+      const uniqueKeys = db.prepare(`
+        SELECT name
+        FROM pragma_index_list('provider_series_episodes')
+        WHERE "unique" = 1
+      `).all().map(index => db.prepare(
+        'SELECT name FROM pragma_index_info(?) ORDER BY seqno'
+      ).all(index.name).map(column => column.name).join(','));
+      rebuildCache = uniqueKeys.length !== 1 || uniqueKeys[0] !== expectedEpisodeKey;
     }
 
-    // Episodes per upstream series, populated by the episode sync so that
-    // get.php can expand series into playable per-episode entries.
+    if (rebuildCache) {
+      db.exec(`
+        DROP TABLE IF EXISTS provider_series_episodes;
+        DROP TABLE IF EXISTS provider_series_state;
+      `);
+      console.info('✅ DB Migration: series episode cache rebuilt with series-scoped keys');
+    }
+
     db.exec(`
       CREATE TABLE IF NOT EXISTS provider_series_episodes (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -948,30 +959,46 @@ export function migrateSeriesEpisodes(db) {
         container_extension TEXT DEFAULT 'mp4',
         logo TEXT DEFAULT '',
         added TEXT DEFAULT '',
-        UNIQUE(source_key, remote_episode_id)
-      )
-    `);
-    db.exec('CREATE INDEX IF NOT EXISTS idx_pse_series ON provider_series_episodes(source_key, series_remote_id, season, episode_num)');
+        UNIQUE(source_key, series_remote_id, remote_episode_id)
+      );
+      CREATE INDEX IF NOT EXISTS idx_pse_series
+        ON provider_series_episodes(source_key, series_remote_id, season, episode_num);
 
-    // Per-series sync state (last_modified from get_series) so unchanged
-    // series are skipped on subsequent episode syncs.
-    db.exec(`
       CREATE TABLE IF NOT EXISTS provider_series_state (
         source_key TEXT NOT NULL,
         series_remote_id INTEGER NOT NULL,
         last_modified TEXT DEFAULT '',
         synced_at INTEGER DEFAULT 0,
         PRIMARY KEY (source_key, series_remote_id)
-      )
+      );
+
+      CREATE TABLE IF NOT EXISTS series_episode_aliases (
+        id INTEGER PRIMARY KEY AUTOINCREMENT CHECK(id >= 900000000 AND id < 1000000000),
+        user_channel_id INTEGER NOT NULL,
+        source_key TEXT NOT NULL,
+        series_remote_id INTEGER NOT NULL,
+        remote_episode_id INTEGER NOT NULL,
+        UNIQUE(user_channel_id, source_key, series_remote_id, remote_episode_id)
+      );
+
+      INSERT OR IGNORE INTO series_episode_aliases
+        (id, user_channel_id, source_key, series_remote_id, remote_episode_id)
+      VALUES (900000000, 0, '', 0, 0);
+      DELETE FROM series_episode_aliases
+      WHERE id = 900000000 AND user_channel_id = 0;
     `);
 
-    const tableInfo = db.prepare("PRAGMA table_info(sync_configs)").all();
-    const columns = tableInfo.map(c => c.name);
+    const columns = db.prepare('PRAGMA table_info(sync_configs)').all().map(column => column.name);
     if (!columns.includes('sync_series_episodes')) {
       db.exec('ALTER TABLE sync_configs ADD COLUMN sync_series_episodes INTEGER DEFAULT 1');
-      console.log('✅ DB Migration: sync_series_episodes column added to sync_configs');
+      console.info('✅ DB Migration: sync_series_episodes column added to sync_configs');
     }
+  });
+
+  try {
+    migrate();
   } catch (e) {
     console.error('Series episodes migration error:', e);
+    throw e;
   }
 }

--- a/src/database/migrations.js
+++ b/src/database/migrations.js
@@ -771,6 +771,17 @@ export function migrateUserChannelsIsHidden(db) {
 export function migrateUserChannelAdminGrants(db) {
   const migrate = db.transaction(() => {
     const columns = db.prepare('PRAGMA table_info(user_channels)').all().map(column => column.name);
+    const markerKey = 'user_channel_authorization_v1';
+    const completed = db.prepare('SELECT value FROM settings WHERE key = ?').get(markerKey);
+    const authorizationView = db.prepare(`
+      SELECT name FROM sqlite_master
+      WHERE type = 'view' AND name = 'authorized_user_channels'
+    `).get();
+    if (completed?.value === 'true' && authorizationView &&
+        columns.includes('granted_by_admin') && columns.includes('authorization_revoked')) {
+      return 0;
+    }
+
     if (!columns.includes('granted_by_admin')) {
       db.exec('ALTER TABLE user_channels ADD COLUMN granted_by_admin INTEGER NOT NULL DEFAULT 0');
     }
@@ -827,6 +838,11 @@ export function migrateUserChannelAdminGrants(db) {
         AND uc.authorization_revoked = 0
         AND (p.user_id = cat.user_id OR uc.granted_by_admin = 1)
     `);
+
+    db.prepare(`
+      INSERT INTO settings (key, value) VALUES (?, 'true')
+      ON CONFLICT(key) DO UPDATE SET value = excluded.value
+    `).run(markerKey);
 
     return revoked;
   });

--- a/src/services/schedulerService.js
+++ b/src/services/schedulerService.js
@@ -20,7 +20,7 @@ export function startSyncScheduler() {
         if (runningSyncs.has(config.id)) continue;
         runningSyncs.add(config.id);
 
-        performSync(config.provider_id, config.user_id, false)
+        performSync(config.provider_id, config.user_id, { mode: 'scheduled' })
           .catch(e => console.error(`Scheduled sync error for provider ${config.provider_id}:`, e))
           .finally(() => runningSyncs.delete(config.id));
       }

--- a/src/services/streamManager.js
+++ b/src/services/streamManager.js
@@ -318,7 +318,7 @@ class StreamManager {
   }
 
   async getUserConnectionCount(userId) {
-    await this.cleanupStaleStreams();
+    if (!this.redis) await this.cleanupStaleStreams();
 
     if (this.redis) {
       try {
@@ -354,7 +354,7 @@ class StreamManager {
 
   async getProviderConnectionCount(providerId) {
     if (!providerId) return 0;
-    await this.cleanupStaleStreams();
+    if (!this.redis) await this.cleanupStaleStreams();
 
     if (this.redis) {
       try {
@@ -383,7 +383,7 @@ class StreamManager {
   }
 
   async isSessionActive(userId, ip, channelName, providerId) {
-    await this.cleanupStaleStreams();
+    if (!this.redis) await this.cleanupStaleStreams();
 
     if (this.redis) {
       try {

--- a/src/services/syncService.js
+++ b/src/services/syncService.js
@@ -324,7 +324,7 @@ export async function performSync(providerId, userId, isManual = false) {
     db.transaction(() => {
       // Pre-calculate max sort order for optimization
       const maxSortRow = db.prepare('SELECT COALESCE(MAX(sort_order), -1) as max_sort FROM user_categories WHERE user_id = ?').get(userId);
-      let currentSortOrder = maxSortRow?.max_sort || -1;
+      let currentSortOrder = maxSortRow?.max_sort ?? -1;
 
       // 1. Process Categories
       for (const provCat of allCategories) {

--- a/src/services/syncService.js
+++ b/src/services/syncService.js
@@ -73,6 +73,7 @@ export async function performSync(providerId, userId, isManual = false) {
 
     const provider = db.prepare('SELECT * FROM providers WHERE id = ?').get(providerId);
     if (!provider) throw new Error('Provider not found');
+    const assignmentGrant = provider.user_id === Number(userId) ? 0 : 1;
 
     // Check expiry (non-blocking or blocking? blocking is safer to ensure updated data)
     await checkProviderExpiry(providerId);
@@ -287,7 +288,7 @@ export async function performSync(providerId, userId, isManual = false) {
     const maxSortMap = new Map();
 
     // Prepare statement unconditionally to avoid potential undefined issues
-    const insertUserChannel = db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, sort_order) VALUES (?, ?, ?)');
+    const insertUserChannel = db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, sort_order, granted_by_admin) VALUES (?, ?, ?, ?)');
     const deleteUserChannel = db.prepare('DELETE FROM user_channels WHERE user_category_id = ? AND provider_channel_id = ?');
 
     if (config && config.auto_add_channels) {
@@ -587,7 +588,7 @@ export async function performSync(providerId, userId, isManual = false) {
                 if (currentMax === undefined) currentMax = -1;
                 const newSortOrder = currentMax + 1;
 
-                insertUserChannel.run(userCatId, provChannelId, newSortOrder);
+                insertUserChannel.run(userCatId, provChannelId, newSortOrder, assignmentGrant);
 
                 // Update in-memory state
                 existingAssignments.add(assignmentKey);

--- a/src/services/syncService.js
+++ b/src/services/syncService.js
@@ -59,7 +59,7 @@ export function calculateNextSync(interval) {
   }
 }
 
-export async function performSync(providerId, userId, isManual = false) {
+export async function performSync(providerId, userId, options = {}) {
   const startTime = Math.floor(Date.now() / 1000);
   let channelsAdded = 0;
   let channelsUpdated = 0;
@@ -69,11 +69,33 @@ export async function performSync(providerId, userId, isManual = false) {
 
   try {
     config = db.prepare('SELECT * FROM sync_configs WHERE provider_id = ? AND user_id = ?').get(providerId, userId);
-    if (!config && !isManual) return;
+    const isManual = options?.mode === 'manual';
+    if ((!config || Number(config.enabled) !== 1) && !isManual) {
+      return { channelsAdded, channelsUpdated, categoriesAdded, errorMessage };
+    }
 
     const provider = db.prepare('SELECT * FROM providers WHERE id = ?').get(providerId);
     if (!provider) throw new Error('Provider not found');
-    const assignmentGrant = provider.user_id === Number(userId) ? 0 : 1;
+    const crossOwner = Number(provider.user_id) !== Number(userId);
+    const hasPersistedGrant = Number(config?.granted_by_admin) === 1;
+    const hasManualGrant = isManual && options?.allowCrossOwner === true;
+
+    if (crossOwner && !hasPersistedGrant && !hasManualGrant) {
+      const disabled = config
+        ? db.prepare('UPDATE sync_configs SET enabled = 0 WHERE id = ? AND enabled = 1').run(config.id).changes
+        : 0;
+      db.prepare('INSERT INTO security_logs (ip, action, details, timestamp) VALUES (?, ?, ?, ?)').run(
+        'scheduler',
+        'cross_owner_sync_blocked',
+        `Blocked unapproved cross-owner sync for provider ${providerId}; disabled ${disabled} config(s)`,
+        startTime
+      );
+      console.warn(`Blocked unapproved cross-owner sync for provider ${providerId}; disabled ${disabled} config(s)`);
+      errorMessage = 'Cross-owner sync requires explicit administrator approval';
+      return { channelsAdded, channelsUpdated, categoriesAdded, errorMessage };
+    }
+
+    const assignmentGrant = crossOwner ? 1 : 0;
 
     // Check expiry (non-blocking or blocking? blocking is safer to ensure updated data)
     await checkProviderExpiry(providerId);

--- a/src/services/syncService.js
+++ b/src/services/syncService.js
@@ -4,6 +4,7 @@ import db from '../database/db.js';
 import { fetchSafe } from '../utils/network.js';
 import { decrypt } from '../utils/crypto.js';
 import { isAdultCategory, providerSourceKey } from '../utils/helpers.js';
+import { normalizeContainerExtension } from '../utils/containerExtension.js';
 import { parseM3uStream } from '../utils/playlistParser.js';
 import { prePopulateProviderIconCache } from './logoResolver.js';
 
@@ -96,6 +97,10 @@ export async function performSync(providerId, userId, options = {}) {
     }
 
     const assignmentGrant = crossOwner ? 1 : 0;
+    const restoreRevokedAssignments = crossOwner && (
+      options?.restoreRevokedAssignments === true ||
+      (!isManual && hasPersistedGrant)
+    );
 
     // Check expiry (non-blocking or blocking? blocking is safer to ensure updated data)
     await checkProviderExpiry(providerId);
@@ -306,23 +311,33 @@ export async function performSync(providerId, userId, options = {}) {
     }
 
     // Optimization: Pre-fetch user channel assignments and sort orders to avoid N+1 queries
-    const existingAssignments = new Set();
+    const existingAssignments = new Map();
     const maxSortMap = new Map();
 
     // Prepare statement unconditionally to avoid potential undefined issues
-    const insertUserChannel = db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, sort_order, granted_by_admin) VALUES (?, ?, ?, ?)');
+    const insertUserChannel = db.prepare(`
+      INSERT INTO user_channels
+        (user_category_id, provider_channel_id, sort_order, granted_by_admin, authorization_revoked)
+      VALUES (?, ?, ?, ?, 0)
+    `);
+    const authorizeExistingAssignment = db.prepare(`
+      UPDATE user_channels
+      SET granted_by_admin = ?, authorization_revoked = 0
+      WHERE id = ?
+    `);
     const deleteUserChannel = db.prepare('DELETE FROM user_channels WHERE user_category_id = ? AND provider_channel_id = ?');
 
     if (config && config.auto_add_channels) {
       const existingAssignmentsRows = db.prepare(`
-        SELECT uc.user_category_id, uc.provider_channel_id
+        SELECT uc.id, uc.user_category_id, uc.provider_channel_id,
+               uc.granted_by_admin, uc.authorization_revoked
         FROM user_channels uc
         JOIN provider_channels pc ON pc.id = uc.provider_channel_id
         WHERE pc.provider_id = ?
       `).all(providerId);
 
       for (const r of existingAssignmentsRows) {
-        existingAssignments.add(`${r.user_category_id}_${r.provider_channel_id}`);
+        existingAssignments.set(`${r.user_category_id}_${r.provider_channel_id}`, r);
       }
 
       const sortRows = db.prepare(`
@@ -425,7 +440,10 @@ export async function performSync(providerId, userId, options = {}) {
           const tvArchive = Number(ch.tv_archive) === 1 ? 1 : 0;
           const tvArchiveDuration = Number(ch.tv_archive_duration) || 0;
           const streamType = ch.stream_type || 'live';
-          const mimeType = ch.container_extension || '';
+          const mimeType = normalizeContainerExtension(
+            ch.container_extension,
+            streamType === 'live' ? 'ts' : 'mp4'
+          );
 
           // Construct metadata
           let meta = {};
@@ -604,17 +622,26 @@ export async function performSync(providerId, userId, options = {}) {
               // Check if already added (Optimized in-memory check)
               const assignmentKey = `${userCatId}_${provChannelId}`;
 
-              if (!existingAssignments.has(assignmentKey)) {
+              const existingAssignment = existingAssignments.get(assignmentKey);
+              if (!existingAssignment) {
                 // Optimized sort order calculation
                 let currentMax = maxSortMap.get(userCatId);
                 if (currentMax === undefined) currentMax = -1;
                 const newSortOrder = currentMax + 1;
 
-                insertUserChannel.run(userCatId, provChannelId, newSortOrder, assignmentGrant);
+                const assignmentInfo = insertUserChannel.run(userCatId, provChannelId, newSortOrder, assignmentGrant);
 
                 // Update in-memory state
-                existingAssignments.add(assignmentKey);
+                existingAssignments.set(assignmentKey, {
+                  id: Number(assignmentInfo.lastInsertRowid),
+                  granted_by_admin: assignmentGrant,
+                  authorization_revoked: 0
+                });
                 maxSortMap.set(userCatId, newSortOrder);
+              } else if (!crossOwner) {
+                authorizeExistingAssignment.run(0, existingAssignment.id);
+              } else if (Number(existingAssignment.granted_by_admin) === 1 || restoreRevokedAssignments) {
+                authorizeExistingAssignment.run(1, existingAssignment.id);
               }
             }
           }
@@ -676,11 +703,10 @@ export async function performSync(providerId, userId, options = {}) {
 // value from get_series (stored in provider_channels.metadata) gates
 // refetching, so after the initial run only changed series are re-fetched.
 //
-// Episode data is stored per upstream panel (source_key = normalized provider
-// URL), not per provider row: users pointing at the same panel with their own
-// credentials share one episode catalog, so nothing is fetched or stored
-// twice. Remote episode IDs are panel-global, which is what makes the shared
-// catalog (and the providerId*OFFSET+episodeId playback encoding) valid.
+// Episode data is stored per upstream panel and series. Playable URLs use a
+// persistent compact alias bound to the exact authorized series assignment;
+// a raw series assignment ID is never treated as an episode ID. Legacy IDs
+// remain usable only when they resolve to one authorized cached episode.
 
 const EPISODE_SYNC_CONCURRENCY = 3;
 const EPISODE_SYNC_RETRY_AGE = 7 * 86400; // re-check series lacking last_modified weekly
@@ -701,7 +727,7 @@ export function parseSeriesInfoEpisodes(data) {
         season: Number(ep.season) || 0,
         episode_num: Number(ep.episode_num) || 0,
         title: ep.title ? String(ep.title) : '',
-        container_extension: ep.container_extension ? String(ep.container_extension) : 'mp4',
+        container_extension: normalizeContainerExtension(ep.container_extension),
         logo: (ep.info && (ep.info.movie_image || ep.info.cover_big)) || '',
         added: ep.added ? String(ep.added) : ''
       });
@@ -850,6 +876,7 @@ export async function syncSeriesEpisodes(providerId) {
     };
     await Promise.all(Array.from({ length: Math.min(EPISODE_SYNC_CONCURRENCY, queue.length) }, () => worker()));
 
+    if (processed > 0) clearChannelsCache();
     console.info(`✅ Episode sync completed for provider ${provider.name}: ${processed} series updated (${episodeCount} episodes), ${failed} failed`);
     return { synced: processed, failed, total: queue.length };
   } finally {

--- a/src/services/syncService.js
+++ b/src/services/syncService.js
@@ -266,8 +266,16 @@ export async function performSync(providerId, userId, options = {}) {
 
     // Performance Optimization: Pre-fetch all mappings to avoid N+1 queries
     const allMappings = db.prepare(`
-      SELECT * FROM category_mappings
-      WHERE provider_id = ? AND user_id = ?
+      SELECT cm.*,
+             CASE
+               WHEN uc.user_id = cm.user_id
+                AND COALESCE(uc.type, 'live') = COALESCE(cm.category_type, 'live')
+               THEN cm.user_category_id
+               ELSE NULL
+             END AS user_category_id
+      FROM category_mappings cm
+      LEFT JOIN user_categories uc ON uc.id = cm.user_category_id
+      WHERE cm.provider_id = ? AND cm.user_id = ?
     `).all(providerId, userId);
 
     const isFirstSync = allMappings.length === 0;

--- a/src/services/syncService.js
+++ b/src/services/syncService.js
@@ -790,8 +790,7 @@ export async function syncSeriesEpisodes(providerId) {
       INSERT INTO provider_series_episodes
         (source_key, series_remote_id, remote_episode_id, season, episode_num, title, container_extension, logo, added)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-      ON CONFLICT(source_key, remote_episode_id) DO UPDATE SET
-        series_remote_id = excluded.series_remote_id,
+      ON CONFLICT(source_key, series_remote_id, remote_episode_id) DO UPDATE SET
         season = excluded.season,
         episode_num = excluded.episode_num,
         title = excluded.title,
@@ -800,7 +799,7 @@ export async function syncSeriesEpisodes(providerId) {
         added = excluded.added
     `);
     const selectExistingEpisodes = db.prepare('SELECT remote_episode_id FROM provider_series_episodes WHERE source_key = ? AND series_remote_id = ?');
-    const deleteEpisode = db.prepare('DELETE FROM provider_series_episodes WHERE source_key = ? AND remote_episode_id = ?');
+    const deleteEpisode = db.prepare('DELETE FROM provider_series_episodes WHERE source_key = ? AND series_remote_id = ? AND remote_episode_id = ?');
     const upsertState = db.prepare(`
       INSERT INTO provider_series_state (source_key, series_remote_id, last_modified, synced_at)
       VALUES (?, ?, ?, ?)
@@ -816,7 +815,7 @@ export async function syncSeriesEpisodes(providerId) {
         keep.add(ep.remote_episode_id);
       }
       for (const row of selectExistingEpisodes.all(sourceKey, sid)) {
-        if (!keep.has(Number(row.remote_episode_id))) deleteEpisode.run(sourceKey, row.remote_episode_id);
+        if (!keep.has(Number(row.remote_episode_id))) deleteEpisode.run(sourceKey, sid, row.remote_episode_id);
       }
       upsertState.run(sourceKey, sid, lastModified, Math.floor(Date.now() / 1000));
     });

--- a/src/utils/containerExtension.js
+++ b/src/utils/containerExtension.js
@@ -1,0 +1,20 @@
+const MIME_EXTENSIONS = new Map([
+  ['video/mp4', 'mp4'],
+  ['video/x-matroska', 'mkv'],
+  ['video/mp2t', 'ts'],
+  ['application/vnd.apple.mpegurl', 'm3u8'],
+  ['application/x-mpegurl', 'm3u8'],
+  ['application/dash+xml', 'mpd'],
+  ['dash', 'mpd'],
+]);
+
+function normalize(value) {
+  if (value === null || value === undefined) return '';
+  const raw = String(value).trim().toLowerCase();
+  const extension = MIME_EXTENSIONS.get(raw) || raw.replace(/^\.+/, '');
+  return /^[a-z0-9]{1,10}$/.test(extension) ? extension : '';
+}
+
+export function normalizeContainerExtension(value, fallback = 'mp4') {
+  return normalize(value) || normalize(fallback) || 'mp4';
+}

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -225,6 +225,9 @@ export function redactUrl(url) {
     // 2. Redact share-management tokens while preserving any query string.
     redacted = redacted.replace(/(\/api\/shares\/)[^/?#]+/gi, '$1********');
 
+    // Public share slugs are bearer credentials too.
+    redacted = redacted.replace(/^((?:https?:\/\/[^/?#]+)?\/share\/)[^/?#]+/i, '$1********');
+
     // 3. Redact HDHomeRun token: /hdhr/TOKEN/...
     redacted = redacted.replace(/\/hdhr\/([^/]+)/, '/hdhr/********');
 
@@ -235,4 +238,17 @@ export function redactUrl(url) {
   } catch (e) {
     return '[redacted]';
   }
+}
+
+export function resolveAssignmentGrant({
+  categoryOwnerId,
+  providerOwnerId,
+  isAdmin = false,
+  allowExplicitAdminGrant = false
+}) {
+  if (categoryOwnerId !== null && categoryOwnerId !== undefined &&
+      providerOwnerId !== null && providerOwnerId !== undefined &&
+      Number(categoryOwnerId) === Number(providerOwnerId)) return 0;
+
+  return isAdmin && allowExplicitAdminGrant ? 1 : null;
 }

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -203,7 +203,7 @@ export function getCookie(req, name) {
 /**
  * Redacts sensitive information from URLs for logging purposes.
  * This includes Xtream passwords in path segments, HDHomeRun tokens,
- * and password query parameters.
+ * and sensitive query parameters.
  * @param {string} url The URL to redact
  * @returns {string} The redacted URL
  */
@@ -225,9 +225,8 @@ export function redactUrl(url) {
     // 2. Redact HDHomeRun token: /hdhr/TOKEN/...
     redacted = redacted.replace(/\/hdhr\/([^/]+)/, '/hdhr/********');
 
-    // 3. Redact password in query strings: ?password=... or &password=...
-    // Preserves the case of the 'password' key
-    redacted = redacted.replace(/([?&])(password)=[^&]*/gi, '$1$2=********');
+    // 3. Redact credentials in query strings while preserving key casing
+    redacted = redacted.replace(/([?&])(password|token)=[^&]*/gi, '$1$2=********');
 
     return redacted;
   } catch (e) {

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -222,10 +222,13 @@ export function redactUrl(url) {
       }
     );
 
-    // 2. Redact HDHomeRun token: /hdhr/TOKEN/...
+    // 2. Redact share-management tokens while preserving any query string.
+    redacted = redacted.replace(/(\/api\/shares\/)[^/?#]+/gi, '$1********');
+
+    // 3. Redact HDHomeRun token: /hdhr/TOKEN/...
     redacted = redacted.replace(/\/hdhr\/([^/]+)/, '/hdhr/********');
 
-    // 3. Redact credentials in query strings while preserving key casing
+    // 4. Redact credentials in query strings while preserving key casing
     redacted = redacted.replace(/([?&])(password|token)=[^&]*/gi, '$1$2=********');
 
     return redacted;

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -232,7 +232,7 @@ export function redactUrl(url) {
     redacted = redacted.replace(/\/hdhr\/([^/]+)/, '/hdhr/********');
 
     // 4. Redact credentials in query strings while preserving key casing
-    redacted = redacted.replace(/([?&])(password|token)=[^&]*/gi, '$1$2=********');
+    redacted = redacted.replace(/([?&])(password|token|access_token|mac)=[^&]*/gi, '$1$2=********');
 
     return redacted;
   } catch (e) {

--- a/src/utils/network.js
+++ b/src/utils/network.js
@@ -53,6 +53,7 @@ export async function fetchSafe(url, options = {}, redirectCount = 0) {
     if (response.status >= 300 && response.status < 400 && response.headers.get('location')) {
       const location = response.headers.get('location');
       const nextUrl = new URL(location, url).toString(); // Handle relative URLs
+      response.body?.destroy?.();
       return await fetchSafe(nextUrl, options, redirectCount + 1);
     }
 

--- a/src/utils/network.js
+++ b/src/utils/network.js
@@ -52,8 +52,12 @@ export async function fetchSafe(url, options = {}, redirectCount = 0) {
 
     if (response.status >= 300 && response.status < 400 && response.headers.get('location')) {
       const location = response.headers.get('location');
-      const nextUrl = new URL(location, url).toString(); // Handle relative URLs
-      response.body?.destroy?.();
+      let nextUrl;
+      try {
+        nextUrl = new URL(location, url).toString(); // Handle relative URLs
+      } finally {
+        response.body?.destroy?.();
+      }
       return await fetchSafe(nextUrl, options, redirectCount + 1);
     }
 

--- a/src/utils/seriesEpisodeId.js
+++ b/src/utils/seriesEpisodeId.js
@@ -1,0 +1,24 @@
+export const SERIES_EPISODE_OFFSET = 1_000_000_000;
+
+export function encodeSeriesEpisodeId(userChannelId, remoteEpisodeId) {
+  const assignmentId = Number(userChannelId);
+  const episodeId = Number(remoteEpisodeId);
+  const encoded = assignmentId * SERIES_EPISODE_OFFSET + episodeId;
+
+  if (!Number.isSafeInteger(assignmentId) || assignmentId <= 0 ||
+      !Number.isSafeInteger(episodeId) || episodeId <= 0 || episodeId >= SERIES_EPISODE_OFFSET ||
+      !Number.isSafeInteger(encoded)) return null;
+
+  return String(encoded);
+}
+
+export function decodeSeriesEpisodeId(value) {
+  const encoded = Number(value);
+  if (!Number.isSafeInteger(encoded) || encoded <= 0) return null;
+
+  const assignmentId = Math.floor(encoded / SERIES_EPISODE_OFFSET);
+  const remoteEpisodeId = encoded % SERIES_EPISODE_OFFSET;
+  if (!assignmentId || !remoteEpisodeId) return null;
+
+  return { assignmentId, remoteEpisodeId };
+}

--- a/src/utils/seriesEpisodeId.js
+++ b/src/utils/seriesEpisodeId.js
@@ -1,16 +1,5 @@
+export const SERIES_EPISODE_ALIAS_MIN = 900_000_000;
 export const SERIES_EPISODE_OFFSET = 1_000_000_000;
-
-export function encodeSeriesEpisodeId(userChannelId, remoteEpisodeId) {
-  const assignmentId = Number(userChannelId);
-  const episodeId = Number(remoteEpisodeId);
-  const encoded = assignmentId * SERIES_EPISODE_OFFSET + episodeId;
-
-  if (!Number.isSafeInteger(assignmentId) || assignmentId <= 0 ||
-      !Number.isSafeInteger(episodeId) || episodeId <= 0 || episodeId >= SERIES_EPISODE_OFFSET ||
-      !Number.isSafeInteger(encoded)) return null;
-
-  return String(encoded);
-}
 
 export function decodeSeriesEpisodeId(value) {
   const encoded = Number(value);

--- a/tests/app_smoke.test.js
+++ b/tests/app_smoke.test.js
@@ -57,4 +57,20 @@ describe('application wiring smoke checks', () => {
     expect(hdhrRoutes).toContain("router.get(['/:token/discover.json'");
     expect(hdhrRoutes).toContain("router.get('/:token/auto/v:channelId'");
   });
+
+  it('ships the identified Web UI vendor assets in the Docker image', () => {
+    const bootstrapPath = path.join(root, 'public/vendor/bootstrap.bundle.min.js');
+    const sortablePath = path.join(root, 'public/vendor/sortable.min.js');
+    const indexHtml = readRepoFile('public/index.html');
+    const playerHtml = readRepoFile('public/player.html');
+
+    expect(fs.existsSync(bootstrapPath)).toBe(true);
+    expect(fs.existsSync(sortablePath)).toBe(true);
+    expect(fs.readFileSync(bootstrapPath, 'utf8')).toContain('Bootstrap v5.3.8');
+    expect(fs.readFileSync(sortablePath, 'utf8')).toContain('Sortable 1.15.6');
+    expect(indexHtml).toContain('vendor/bootstrap.bundle.min.js');
+    expect(indexHtml).toContain('vendor/sortable.min.js');
+    expect(playerHtml).toContain('vendor/bootstrap.bundle.min.js');
+    expect(readRepoFile('Dockerfile')).toContain('COPY public ./public');
+  });
 });

--- a/tests/app_smoke.test.js
+++ b/tests/app_smoke.test.js
@@ -35,7 +35,7 @@ describe('application wiring smoke checks', () => {
     const appSource = readRepoFile('src/app.js');
 
     expect(appSource).toContain('app.use(securityHeaders)');
-    expect(appSource).toContain("bodyParser.json({ limit: '1mb' })");
+    expect(appSource).toContain("express.json({ limit: '1mb' })");
     expect(appSource).toContain('process.env.ALLOWED_ORIGINS');
     expect(appSource).toContain('redactUrl(req.originalUrl || req.url)');
     expect(appSource).toContain("app.use('/api', apiLimiter)");

--- a/tests/app_smoke.test.js
+++ b/tests/app_smoke.test.js
@@ -73,4 +73,12 @@ describe('application wiring smoke checks', () => {
     expect(playerHtml).toContain('vendor/bootstrap.bundle.min.js');
     expect(readRepoFile('Dockerfile')).toContain('COPY public ./public');
   });
+
+  it('blocks Docker and release jobs until validation succeeds', () => {
+    const workflow = readRepoFile('.github/workflows/package.yml');
+
+    expect(workflow).toMatch(/build-docker:\n\s+needs: validate/);
+    expect(workflow).toMatch(/release-package:\n\s+needs:\n\s+- validate\n\s+- build-docker/);
+    expect(workflow).toContain("push: ${{ github.event_name != 'pull_request' }}");
+  });
 });

--- a/tests/container_extension.test.js
+++ b/tests/container_extension.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeContainerExtension } from '../src/utils/containerExtension.js';
+
+describe('normalizeContainerExtension', () => {
+  it.each([
+    ['mkv', 'mkv'],
+    ['.MKV', 'mkv'],
+    [' mp4 ', 'mp4'],
+    ['video/mp4', 'mp4'],
+    ['video/x-matroska', 'mkv'],
+    ['video/mp2t', 'ts'],
+    ['application/vnd.apple.mpegurl', 'm3u8'],
+    ['application/x-mpegurl', 'm3u8'],
+    ['application/dash+xml', 'mpd'],
+  ])('normalizes %j to %j', (value, expected) => {
+    expect(normalizeContainerExtension(value)).toBe(expected);
+  });
+
+  it.each([
+    'mp4\r\n#EXTINF:-1,Injected',
+    'mkv?token=secret',
+    'mkv#fragment',
+    '../mkv',
+    'mkv/segment',
+    'mkv\\segment',
+    'percent%2fencoded',
+    '',
+    null,
+    undefined,
+    'thisextensionistoolong',
+  ])('uses a safe fallback for %j', (value) => {
+    expect(normalizeContainerExtension(value)).toBe('mp4');
+  });
+
+  it('normalizes the fallback and cannot return an unsafe fallback', () => {
+    expect(normalizeContainerExtension('', '.TS')).toBe('ts');
+    expect(normalizeContainerExtension('', '../bad')).toBe('mp4');
+  });
+});

--- a/tests/controllers/backup_restore_authorization.test.js
+++ b/tests/controllers/backup_restore_authorization.test.js
@@ -1,0 +1,184 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'fs';
+
+const { TEST_DB_DIR } = vi.hoisted(() => {
+  const fsModule = require('fs');
+  const osModule = require('os');
+  const pathModule = require('path');
+  return { TEST_DB_DIR: fsModule.mkdtempSync(pathModule.join(osModule.tmpdir(), 'iptv-backup-restore-')) };
+});
+
+vi.mock('../../src/config/constants.js', () => ({
+  DATA_DIR: TEST_DB_DIR,
+  EPG_DB_PATH: `${TEST_DB_DIR}/epg.db`,
+  BCRYPT_ROUNDS: 1,
+  DEFAULT_USER_AGENT: 'TestAgent',
+}));
+
+vi.mock('../../src/services/cacheService.js', () => ({
+  clearChannelsCache: vi.fn(),
+}));
+
+import db, { initDb } from '../../src/database/db.js';
+import { createBackup, restoreBackup } from '../../src/controllers/backupController.js';
+import { clearChannelsCache } from '../../src/services/cacheService.js';
+
+const response = () => ({
+  json: vi.fn(),
+  status: vi.fn().mockReturnThis(),
+});
+
+const backupData = (userId, channel) => ({
+  userCategories: [{ id: 100, user_id: userId, name: 'Series', sort_order: 0, is_adult: 0, type: 'series' }],
+  userChannels: channel ? [{ id: 200, user_category_id: 100, sort_order: 0, custom_name: '', is_hidden: 0, ...channel }] : [],
+  categoryMappings: [],
+});
+
+describe('user backup restore authorization', () => {
+  beforeAll(() => initDb(true));
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db.pragma('foreign_keys = OFF');
+    for (const table of ['user_backups', 'user_channels', 'user_categories', 'provider_channels', 'providers', 'users']) {
+      db.prepare(`DELETE FROM ${table}`).run();
+    }
+    db.pragma('foreign_keys = ON');
+    db.prepare("INSERT INTO users (id, username, password) VALUES (1, 'user', 'p'), (2, 'owner', 'p'), (9, 'admin', 'p')").run();
+  });
+
+  afterAll(() => {
+    db.close();
+    fs.rmSync(TEST_DB_DIR, { recursive: true, force: true });
+  });
+
+  const addProviderChannel = (ownerId) => {
+    const providerId = db.prepare("INSERT INTO providers (name, url, username, password, user_id) VALUES ('P', 'http://provider.example', 'u', 'p', ?)").run(ownerId).lastInsertRowid;
+    return db.prepare("INSERT INTO provider_channels (provider_id, remote_stream_id, name, stream_type) VALUES (?, 10, 'Show', 'series')").run(providerId).lastInsertRowid;
+  };
+
+  const addBackup = (data) => db.prepare(`
+    INSERT INTO user_backups (user_id, name, timestamp, category_count, channel_count, data)
+    VALUES (1, 'snapshot', 1, ?, ?, ?)
+  `).run(data.userCategories?.length || 0, data.userChannels?.length || 0, JSON.stringify(data)).lastInsertRowid;
+
+  const restore = (backupId, user = { id: 1, is_admin: false }) => {
+    const req = { params: { userId: '1', id: String(backupId) }, user };
+    const res = response();
+    restoreBackup(req, res);
+    return res;
+  };
+
+  it('restores same-owner assignments with IDs preserved and no admin grant', () => {
+    const providerChannelId = addProviderChannel(1);
+    const backupId = addBackup(backupData(1, { provider_channel_id: providerChannelId, granted_by_admin: 1 }));
+
+    const res = restore(backupId);
+
+    expect(db.prepare('SELECT id, is_hidden, granted_by_admin FROM user_channels').get()).toEqual({ id: 200, is_hidden: 0, granted_by_admin: 0 });
+    expect(res.json).toHaveBeenCalledWith({ success: true, channels_restored: 1, channels_hidden: 0, channels_skipped: 0 });
+    expect(clearChannelsCache).toHaveBeenCalledWith(1);
+  });
+
+  it('does not resurrect a revoked historical admin grant for a normal user', () => {
+    const providerChannelId = addProviderChannel(2);
+    db.prepare("INSERT INTO user_categories (id, user_id, name, type) VALUES (100, 1, 'Series', 'series')").run();
+    db.prepare(`
+      INSERT INTO user_channels (id, user_category_id, provider_channel_id, is_hidden, granted_by_admin)
+      VALUES (200, 100, ?, 0, 1)
+    `).run(providerChannelId);
+    const createRes = response();
+    createBackup(
+      { params: { userId: '1' }, user: { id: 1, is_admin: false }, body: { name: 'active grant' } },
+      createRes
+    );
+    const backupId = createRes.json.mock.calls[0][0].id;
+
+    // Administrator revokes the grant after the snapshot was created.
+    db.prepare('UPDATE user_channels SET is_hidden = 1, granted_by_admin = 0 WHERE id = 200').run();
+
+    const res = restore(backupId);
+
+    expect(db.prepare('SELECT is_hidden, granted_by_admin FROM user_channels WHERE id = 200').get()).toEqual({ is_hidden: 1, granted_by_admin: 0 });
+    expect(db.prepare('SELECT id FROM authorized_user_channels WHERE id = 200').get()).toBeUndefined();
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ channels_hidden: 1 }));
+  });
+
+  it('cannot turn crafted cross-owner backup data into an admin grant', () => {
+    const providerChannelId = addProviderChannel(2);
+    const backupId = addBackup(backupData(1, {
+      provider_channel_id: providerChannelId,
+      granted_by_admin: 1,
+      is_hidden: 0,
+    }));
+
+    restore(backupId);
+
+    expect(db.prepare('SELECT is_hidden, granted_by_admin FROM user_channels WHERE id = 200').get()).toEqual({
+      is_hidden: 1,
+      granted_by_admin: 0,
+    });
+    expect(db.prepare('SELECT id FROM authorized_user_channels WHERE id = 200').get()).toBeUndefined();
+  });
+
+  it('allows an admin to deliberately restore a valid cross-owner assignment', () => {
+    const providerChannelId = addProviderChannel(2);
+    const backupId = addBackup(backupData(1, { provider_channel_id: providerChannelId, granted_by_admin: 0 }));
+
+    restore(backupId, { id: 9, is_admin: true });
+
+    expect(db.prepare('SELECT is_hidden, granted_by_admin FROM user_channels WHERE id = 200').get()).toEqual({ is_hidden: 0, granted_by_admin: 1 });
+    expect(db.prepare('SELECT id FROM authorized_user_channels WHERE id = 200').get()).toEqual({ id: 200 });
+  });
+
+  it('normalizes same-owner assignments restored by an admin to grant zero', () => {
+    const providerChannelId = addProviderChannel(1);
+    const backupId = addBackup(backupData(1, { provider_channel_id: providerChannelId, granted_by_admin: 1 }));
+
+    restore(backupId, { id: 9, is_admin: true });
+
+    expect(db.prepare('SELECT is_hidden, granted_by_admin FROM user_channels WHERE id = 200').get()).toEqual({
+      is_hidden: 0,
+      granted_by_admin: 0,
+    });
+  });
+
+  it('uses current ownership and skips missing provider channels', () => {
+    const providerChannelId = addProviderChannel(1);
+    const data = backupData(1, { provider_channel_id: providerChannelId, granted_by_admin: 0 });
+    data.userChannels.push({ ...data.userChannels[0], id: 201, provider_channel_id: 9999 });
+    const backupId = addBackup(data);
+    db.prepare('UPDATE providers SET user_id = 2').run();
+
+    const res = restore(backupId);
+
+    expect(db.prepare('SELECT is_hidden, granted_by_admin FROM user_channels WHERE id = 200').get()).toEqual({ is_hidden: 1, granted_by_admin: 0 });
+    expect(db.prepare('SELECT id FROM user_channels WHERE id = 201').get()).toBeUndefined();
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ channels_hidden: 1, channels_skipped: 1 }));
+  });
+
+  it('leaves current data untouched when backup data is malformed', () => {
+    db.prepare("INSERT INTO user_categories (id, user_id, name) VALUES (500, 1, 'Current')").run();
+    const backupId = addBackup({ userCategories: null, userChannels: [], categoryMappings: [] });
+
+    const res = restore(backupId);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(db.prepare('SELECT id, name FROM user_categories WHERE id = 500').get()).toEqual({ id: 500, name: 'Current' });
+    expect(clearChannelsCache).not.toHaveBeenCalled();
+  });
+
+  it('rolls back all restore changes when malformed rows fail inside the transaction', () => {
+    db.prepare("INSERT INTO user_categories (id, user_id, name) VALUES (500, 1, 'Current')").run();
+    const data = backupData(1);
+    data.userCategories.push({ ...data.userCategories[0], name: 'Duplicate ID' });
+    const backupId = addBackup(data);
+
+    const res = restore(backupId);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Restore failed' });
+    expect(db.prepare('SELECT id, name FROM user_categories WHERE user_id = 1').all()).toEqual([{ id: 500, name: 'Current' }]);
+    expect(clearChannelsCache).not.toHaveBeenCalled();
+  });
+});

--- a/tests/controllers/backup_restore_authorization.test.js
+++ b/tests/controllers/backup_restore_authorization.test.js
@@ -62,8 +62,8 @@ describe('user backup restore authorization', () => {
     VALUES (1, 'snapshot', 1, ?, ?, ?)
   `).run(data.userCategories?.length || 0, data.userChannels?.length || 0, JSON.stringify(data)).lastInsertRowid;
 
-  const restore = (backupId, user = { id: 1, is_admin: false }) => {
-    const req = { params: { userId: '1', id: String(backupId) }, user };
+  const restore = (backupId, user = { id: 1, is_admin: false }, body = {}) => {
+    const req = { params: { userId: '1', id: String(backupId) }, user, body };
     const res = response();
     restoreBackup(req, res);
     return res;
@@ -121,11 +121,24 @@ describe('user backup restore authorization', () => {
     expect(db.prepare('SELECT id FROM authorized_user_channels WHERE id = 200').get()).toBeUndefined();
   });
 
+  it.each([undefined, false])('keeps an admin-restored cross-owner assignment hidden without explicit approval (%s)', (allowCrossOwner) => {
+    const providerChannelId = addProviderChannel(2);
+    const backupId = addBackup(backupData(1, { provider_channel_id: providerChannelId, granted_by_admin: 1 }));
+    const body = allowCrossOwner === undefined ? {} : { allow_cross_owner: allowCrossOwner };
+
+    restore(backupId, { id: 9, is_admin: true }, body);
+
+    expect(db.prepare('SELECT is_hidden, granted_by_admin FROM user_channels WHERE id = 200').get()).toEqual({
+      is_hidden: 1,
+      granted_by_admin: 0,
+    });
+  });
+
   it('allows an admin to deliberately restore a valid cross-owner assignment', () => {
     const providerChannelId = addProviderChannel(2);
     const backupId = addBackup(backupData(1, { provider_channel_id: providerChannelId, granted_by_admin: 0 }));
 
-    restore(backupId, { id: 9, is_admin: true });
+    restore(backupId, { id: 9, is_admin: true }, { allow_cross_owner: true });
 
     expect(db.prepare('SELECT is_hidden, granted_by_admin FROM user_channels WHERE id = 200').get()).toEqual({ is_hidden: 0, granted_by_admin: 1 });
     expect(db.prepare('SELECT id FROM authorized_user_channels WHERE id = 200').get()).toEqual({ id: 200 });

--- a/tests/controllers/backup_restore_authorization.test.js
+++ b/tests/controllers/backup_restore_authorization.test.js
@@ -75,7 +75,9 @@ describe('user backup restore authorization', () => {
 
     const res = restore(backupId);
 
-    expect(db.prepare('SELECT id, is_hidden, granted_by_admin FROM user_channels').get()).toEqual({ id: 200, is_hidden: 0, granted_by_admin: 0 });
+    expect(db.prepare('SELECT id, is_hidden, granted_by_admin, authorization_revoked FROM user_channels').get()).toEqual({
+      id: 200, is_hidden: 0, granted_by_admin: 0, authorization_revoked: 0
+    });
     expect(res.json).toHaveBeenCalledWith({ success: true, channels_restored: 1, channels_hidden: 0, channels_skipped: 0 });
     expect(clearChannelsCache).toHaveBeenCalledWith(1);
   });
@@ -95,11 +97,13 @@ describe('user backup restore authorization', () => {
     const backupId = createRes.json.mock.calls[0][0].id;
 
     // Administrator revokes the grant after the snapshot was created.
-    db.prepare('UPDATE user_channels SET is_hidden = 1, granted_by_admin = 0 WHERE id = 200').run();
+    db.prepare('UPDATE user_channels SET granted_by_admin = 0, authorization_revoked = 1 WHERE id = 200').run();
 
     const res = restore(backupId);
 
-    expect(db.prepare('SELECT is_hidden, granted_by_admin FROM user_channels WHERE id = 200').get()).toEqual({ is_hidden: 1, granted_by_admin: 0 });
+    expect(db.prepare('SELECT is_hidden, granted_by_admin, authorization_revoked FROM user_channels WHERE id = 200').get()).toEqual({
+      is_hidden: 0, granted_by_admin: 0, authorization_revoked: 1
+    });
     expect(db.prepare('SELECT id FROM authorized_user_channels WHERE id = 200').get()).toBeUndefined();
     expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ channels_hidden: 1 }));
   });
@@ -114,9 +118,10 @@ describe('user backup restore authorization', () => {
 
     restore(backupId);
 
-    expect(db.prepare('SELECT is_hidden, granted_by_admin FROM user_channels WHERE id = 200').get()).toEqual({
-      is_hidden: 1,
+    expect(db.prepare('SELECT is_hidden, granted_by_admin, authorization_revoked FROM user_channels WHERE id = 200').get()).toEqual({
+      is_hidden: 0,
       granted_by_admin: 0,
+      authorization_revoked: 1,
     });
     expect(db.prepare('SELECT id FROM authorized_user_channels WHERE id = 200').get()).toBeUndefined();
   });
@@ -128,9 +133,10 @@ describe('user backup restore authorization', () => {
 
     restore(backupId, { id: 9, is_admin: true }, body);
 
-    expect(db.prepare('SELECT is_hidden, granted_by_admin FROM user_channels WHERE id = 200').get()).toEqual({
-      is_hidden: 1,
+    expect(db.prepare('SELECT is_hidden, granted_by_admin, authorization_revoked FROM user_channels WHERE id = 200').get()).toEqual({
+      is_hidden: 0,
       granted_by_admin: 0,
+      authorization_revoked: 1,
     });
   });
 
@@ -140,7 +146,9 @@ describe('user backup restore authorization', () => {
 
     restore(backupId, { id: 9, is_admin: true }, { allow_cross_owner: true });
 
-    expect(db.prepare('SELECT is_hidden, granted_by_admin FROM user_channels WHERE id = 200').get()).toEqual({ is_hidden: 0, granted_by_admin: 1 });
+    expect(db.prepare('SELECT is_hidden, granted_by_admin, authorization_revoked FROM user_channels WHERE id = 200').get()).toEqual({
+      is_hidden: 0, granted_by_admin: 1, authorization_revoked: 0
+    });
     expect(db.prepare('SELECT id FROM authorized_user_channels WHERE id = 200').get()).toEqual({ id: 200 });
   });
 
@@ -150,9 +158,10 @@ describe('user backup restore authorization', () => {
 
     restore(backupId, { id: 9, is_admin: true });
 
-    expect(db.prepare('SELECT is_hidden, granted_by_admin FROM user_channels WHERE id = 200').get()).toEqual({
+    expect(db.prepare('SELECT is_hidden, granted_by_admin, authorization_revoked FROM user_channels WHERE id = 200').get()).toEqual({
       is_hidden: 0,
       granted_by_admin: 0,
+      authorization_revoked: 0,
     });
   });
 
@@ -165,7 +174,9 @@ describe('user backup restore authorization', () => {
 
     const res = restore(backupId);
 
-    expect(db.prepare('SELECT is_hidden, granted_by_admin FROM user_channels WHERE id = 200').get()).toEqual({ is_hidden: 1, granted_by_admin: 0 });
+    expect(db.prepare('SELECT is_hidden, granted_by_admin, authorization_revoked FROM user_channels WHERE id = 200').get()).toEqual({
+      is_hidden: 0, granted_by_admin: 0, authorization_revoked: 1
+    });
     expect(db.prepare('SELECT id FROM user_channels WHERE id = 201').get()).toBeUndefined();
     expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ channels_hidden: 1, channels_skipped: 1 }));
   });

--- a/tests/controllers/channelController.test.js
+++ b/tests/controllers/channelController.test.js
@@ -1,19 +1,19 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest';
 import fs from 'fs';
-import path from 'path';
 
-// Ensure directory exists BEFORE imports
-if (!fs.existsSync(path.join(process.cwd(), 'tests/temp_db_channel'))) fs.mkdirSync(path.join(process.cwd(), 'tests/temp_db_channel'), { recursive: true });
-
-const TEST_DB_DIR = path.join(process.cwd(), 'tests/temp_db_channel');
+const { TEST_DB_DIR } = vi.hoisted(() => {
+    const fsModule = require('fs');
+    const osModule = require('os');
+    const pathModule = require('path');
+    return { TEST_DB_DIR: fsModule.mkdtempSync(pathModule.join(osModule.tmpdir(), 'iptv-channel-controller-')) };
+});
 
 // Mock Constants
 vi.mock('../../src/config/constants.js', async () => {
     const path = require('path');
-    const testDir = path.join(process.cwd(), 'tests/temp_db_channel');
     return {
-        DATA_DIR: testDir,
-        EPG_DB_PATH: path.join(testDir, 'epg.db'),
+        DATA_DIR: TEST_DB_DIR,
+        EPG_DB_PATH: path.join(TEST_DB_DIR, 'epg.db'),
         PORT: 3000,
         BCRYPT_ROUNDS: 1,
         JWT_EXPIRES_IN: '1h',
@@ -37,6 +37,11 @@ import db, { initDb } from '../../src/database/db.js';
 import * as channelController from '../../src/controllers/channelController.js';
 
 describe('Channel Controller - createUserCategory', () => {
+    afterAll(() => {
+        db.close();
+        fs.rmSync(TEST_DB_DIR, { recursive: true, force: true });
+    });
+
     beforeEach(() => {
         // Clear DB
         initDb(true);

--- a/tests/controllers/channelController.test.js
+++ b/tests/controllers/channelController.test.js
@@ -237,7 +237,73 @@ describe('Channel Controller - createUserCategory', () => {
         channelController.addUserChannel(req, res);
 
         expect(res.status).not.toHaveBeenCalled();
-        expect(db.prepare('SELECT provider_channel_id FROM user_channels WHERE id = ?').get(res.json.mock.calls[0][0].id).provider_channel_id).toBe(channelId);
+        const created = db.prepare('SELECT * FROM user_channels WHERE id = ?').get(res.json.mock.calls[0][0].id);
+        expect(created.provider_channel_id).toBe(channelId);
+        expect(created.granted_by_admin).toBe(1);
+        expect(db.prepare('SELECT id FROM authorized_user_channels WHERE id = ?').get(created.id).id).toBe(created.id);
+    });
+
+    it('should mark same-owner assignments as normal and playable', () => {
+        const categoryId = db.prepare("INSERT INTO user_categories (user_id, name) VALUES (2, 'My Category')").run().lastInsertRowid;
+        const providerId = db.prepare("INSERT INTO providers (name, url, username, password, user_id) VALUES ('My Provider', 'http://provider.test', 'u', 'p', 2)").run().lastInsertRowid;
+        const channelId = db.prepare("INSERT INTO provider_channels (provider_id, remote_stream_id, name) VALUES (?, 100, 'My Channel')").run(providerId).lastInsertRowid;
+        const req = {
+            params: { catId: String(categoryId) },
+            body: { provider_channel_id: channelId },
+            user: { id: 2, is_admin: false }
+        };
+        const res = { json: vi.fn(), status: vi.fn().mockReturnThis() };
+
+        channelController.addUserChannel(req, res);
+
+        const created = db.prepare('SELECT * FROM user_channels WHERE id = ?').get(res.json.mock.calls[0][0].id);
+        expect(created.granted_by_admin).toBe(0);
+        expect(db.prepare('SELECT id FROM authorized_user_channels WHERE id = ?').get(created.id).id).toBe(created.id);
+    });
+
+    it('should return 404 for an unknown provider channel', () => {
+        const categoryId = db.prepare("INSERT INTO user_categories (user_id, name) VALUES (2, 'My Category')").run().lastInsertRowid;
+        const req = {
+            params: { catId: String(categoryId) },
+            body: { provider_channel_id: 999999 },
+            user: { id: 2, is_admin: false }
+        };
+        const res = { json: vi.fn(), status: vi.fn().mockReturnThis() };
+
+        channelController.addUserChannel(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(404);
+        expect(res.json).toHaveBeenCalledWith({ error: 'Channel not found' });
+    });
+
+    it('should only restore a hidden cross-owner row as an explicit admin grant', () => {
+        const categoryId = db.prepare("INSERT INTO user_categories (user_id, name) VALUES (2, 'Managed Category')").run().lastInsertRowid;
+        const providerId = db.prepare("INSERT INTO providers (name, url, username, password, user_id) VALUES ('Foreign Provider', 'http://provider.test', 'u', 'p', 1)").run().lastInsertRowid;
+        const channelId = db.prepare("INSERT INTO provider_channels (provider_id, remote_stream_id, name) VALUES (?, 100, 'Foreign Channel')").run(providerId).lastInsertRowid;
+        const assignmentId = db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, sort_order, is_hidden) VALUES (?, ?, 0, 1)').run(categoryId, channelId).lastInsertRowid;
+        const body = { provider_channel_id: channelId };
+
+        const userRes = { json: vi.fn(), status: vi.fn().mockReturnThis() };
+        channelController.addUserChannel({ params: { catId: String(categoryId) }, body, user: { id: 2, is_admin: false } }, userRes);
+        expect(userRes.status).toHaveBeenCalledWith(403);
+        expect(db.prepare('SELECT is_hidden, granted_by_admin FROM user_channels WHERE id = ?').get(assignmentId)).toEqual({ is_hidden: 1, granted_by_admin: 0 });
+
+        const adminRes = { json: vi.fn(), status: vi.fn().mockReturnThis() };
+        channelController.addUserChannel({ params: { catId: String(categoryId) }, body, user: { id: 1, is_admin: true } }, adminRes);
+        expect(adminRes.json).toHaveBeenCalledWith({ id: assignmentId });
+        expect(db.prepare('SELECT is_hidden, granted_by_admin FROM user_channels WHERE id = ?').get(assignmentId)).toEqual({ is_hidden: 0, granted_by_admin: 1 });
+    });
+
+    it('should exclude an ungranted legacy mismatch from category lists', () => {
+        const categoryId = db.prepare("INSERT INTO user_categories (user_id, name) VALUES (2, 'My Category')").run().lastInsertRowid;
+        const providerId = db.prepare("INSERT INTO providers (name, url, username, password, user_id) VALUES ('Foreign Provider', 'http://provider.test', 'u', 'p', 1)").run().lastInsertRowid;
+        const channelId = db.prepare("INSERT INTO provider_channels (provider_id, remote_stream_id, name) VALUES (?, 100, 'Foreign Channel')").run(providerId).lastInsertRowid;
+        db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, sort_order) VALUES (?, ?, 0)').run(categoryId, channelId);
+        const res = { json: vi.fn(), status: vi.fn().mockReturnThis() };
+
+        channelController.getCategoryChannels({ params: { catId: String(categoryId) }, user: { id: 1, is_admin: true } }, res);
+
+        expect(res.json).toHaveBeenCalledWith([]);
     });
 
     it('should add an owned channel after an existing zero sort order', () => {
@@ -258,6 +324,7 @@ describe('Channel Controller - createUserCategory', () => {
         expect(res.status).not.toHaveBeenCalled();
         const created = db.prepare('SELECT * FROM user_channels WHERE id = ?').get(res.json.mock.calls[0][0].id);
         expect(created.sort_order).toBe(1);
+        expect(created.granted_by_admin).toBe(0);
     });
 
     it('should handle database errors', async () => {

--- a/tests/controllers/channelController.test.js
+++ b/tests/controllers/channelController.test.js
@@ -40,7 +40,7 @@ describe('Channel Controller - createUserCategory', () => {
     beforeEach(() => {
         // Clear DB
         initDb(true);
-        const tables = ['user_channels', 'user_categories', 'users', 'admin_users'];
+        const tables = ['user_channels', 'user_categories', 'provider_channels', 'providers', 'users', 'admin_users'];
         db.pragma('foreign_keys = OFF');
         tables.forEach(t => db.prepare(`DELETE FROM ${t}`).run());
         db.pragma('foreign_keys = ON');
@@ -185,7 +185,7 @@ describe('Channel Controller - createUserCategory', () => {
 
     it('should calculate correct sort_order', async () => {
         // Insert existing category
-        db.prepare("INSERT INTO user_categories (user_id, name, sort_order) VALUES (1, 'Cat 1', 5)").run();
+        db.prepare("INSERT INTO user_categories (user_id, name, sort_order) VALUES (1, 'Cat 1', 0)").run();
 
         const req = {
             params: { userId: '1' },
@@ -202,7 +202,62 @@ describe('Channel Controller - createUserCategory', () => {
 
         const response = res.json.mock.calls[0][0];
         const cat = db.prepare('SELECT * FROM user_categories WHERE id = ?').get(response.id);
-        expect(cat.sort_order).toBe(6);
+        expect(cat.sort_order).toBe(1);
+    });
+
+    it('should reject channels owned by another user', () => {
+        const categoryId = db.prepare("INSERT INTO user_categories (user_id, name) VALUES (2, 'My Category')").run().lastInsertRowid;
+        const providerId = db.prepare("INSERT INTO providers (name, url, username, password, user_id) VALUES ('Admin Provider', 'http://provider.test', 'u', 'p', 1)").run().lastInsertRowid;
+        const channelId = db.prepare("INSERT INTO provider_channels (provider_id, remote_stream_id, name) VALUES (?, 100, 'Foreign Channel')").run(providerId).lastInsertRowid;
+        const req = {
+            params: { catId: String(categoryId) },
+            body: { provider_channel_id: channelId },
+            user: { id: 2, is_admin: false }
+        };
+        const res = { json: vi.fn(), status: vi.fn().mockReturnThis() };
+
+        channelController.addUserChannel(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(403);
+        expect(res.json).toHaveBeenCalledWith({ error: 'Access denied' });
+        expect(db.prepare('SELECT COUNT(*) AS count FROM user_channels').get().count).toBe(0);
+    });
+
+    it('should allow admins to assign channels across users', () => {
+        const categoryId = db.prepare("INSERT INTO user_categories (user_id, name) VALUES (2, 'Managed Category')").run().lastInsertRowid;
+        const providerId = db.prepare("INSERT INTO providers (name, url, username, password, user_id) VALUES ('Admin Provider', 'http://provider.test', 'u', 'p', 1)").run().lastInsertRowid;
+        const channelId = db.prepare("INSERT INTO provider_channels (provider_id, remote_stream_id, name) VALUES (?, 100, 'Managed Channel')").run(providerId).lastInsertRowid;
+        const req = {
+            params: { catId: String(categoryId) },
+            body: { provider_channel_id: channelId },
+            user: { id: 1, is_admin: true }
+        };
+        const res = { json: vi.fn(), status: vi.fn().mockReturnThis() };
+
+        channelController.addUserChannel(req, res);
+
+        expect(res.status).not.toHaveBeenCalled();
+        expect(db.prepare('SELECT provider_channel_id FROM user_channels WHERE id = ?').get(res.json.mock.calls[0][0].id).provider_channel_id).toBe(channelId);
+    });
+
+    it('should add an owned channel after an existing zero sort order', () => {
+        const categoryId = db.prepare("INSERT INTO user_categories (user_id, name) VALUES (2, 'My Category')").run().lastInsertRowid;
+        const providerId = db.prepare("INSERT INTO providers (name, url, username, password, user_id) VALUES ('My Provider', 'http://provider.test', 'u', 'p', 2)").run().lastInsertRowid;
+        const firstChannelId = db.prepare("INSERT INTO provider_channels (provider_id, remote_stream_id, name) VALUES (?, 100, 'First Channel')").run(providerId).lastInsertRowid;
+        const secondChannelId = db.prepare("INSERT INTO provider_channels (provider_id, remote_stream_id, name) VALUES (?, 101, 'Second Channel')").run(providerId).lastInsertRowid;
+        db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, sort_order) VALUES (?, ?, 0)').run(categoryId, firstChannelId);
+        const req = {
+            params: { catId: String(categoryId) },
+            body: { provider_channel_id: secondChannelId },
+            user: { id: 2, is_admin: false }
+        };
+        const res = { json: vi.fn(), status: vi.fn().mockReturnThis() };
+
+        channelController.addUserChannel(req, res);
+
+        expect(res.status).not.toHaveBeenCalled();
+        const created = db.prepare('SELECT * FROM user_channels WHERE id = ?').get(res.json.mock.calls[0][0].id);
+        expect(created.sort_order).toBe(1);
     });
 
     it('should handle database errors', async () => {

--- a/tests/controllers/channelController.test.js
+++ b/tests/controllers/channelController.test.js
@@ -35,6 +35,7 @@ vi.mock('../../src/utils/crypto.js', () => {
 // Import modules AFTER mocking
 import db, { initDb } from '../../src/database/db.js';
 import * as channelController from '../../src/controllers/channelController.js';
+import { channelsJsonCache } from '../../src/services/cacheService.js';
 
 describe('Channel Controller - createUserCategory', () => {
     afterAll(() => {
@@ -542,5 +543,126 @@ describe('Channel Controller - createUserCategory', () => {
 
         expect(res.status).toHaveBeenCalledWith(500);
         expect(res.json).toHaveBeenCalledWith({ error: 'DB Error' });
+    });
+
+    const addAssignment = (userId, isHidden = 0) => {
+        const categoryId = db.prepare('INSERT INTO user_categories (user_id, name) VALUES (?, ?)')
+            .run(userId, `Category ${userId}-${Date.now()}-${Math.random()}`).lastInsertRowid;
+        const providerId = db.prepare("INSERT INTO providers (name, url, username, password, user_id) VALUES (?, 'http://provider.test', 'u', 'p', ?)")
+            .run(`Provider ${userId}-${Date.now()}-${Math.random()}`, userId).lastInsertRowid;
+        const providerChannelId = db.prepare('INSERT INTO provider_channels (provider_id, remote_stream_id, name) VALUES (?, ?, ?)')
+            .run(providerId, Number(`${userId}${Date.now()}`.slice(-8)), `Channel ${userId}`).lastInsertRowid;
+        const assignmentId = db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, is_hidden) VALUES (?, ?, ?)')
+            .run(categoryId, providerChannelId, isHidden).lastInsertRowid;
+        return { assignmentId, categoryId, userId };
+    };
+
+    const response = () => ({ json: vi.fn(), status: vi.fn().mockReturnThis() });
+
+    it('atomically hides valid own assignments and reports the changed count', () => {
+        const first = addAssignment(2);
+        const second = addAssignment(2);
+        const res = response();
+
+        channelController.bulkDeleteUserChannels({
+            body: { ids: [first.assignmentId, String(second.assignmentId)] },
+            user: { id: 2, is_admin: false, username: 'user' }, ip: '127.0.0.1'
+        }, res);
+
+        expect(res.json).toHaveBeenCalledWith({ success: true, deleted: 2 });
+        expect(db.prepare('SELECT is_hidden FROM user_channels WHERE id IN (?, ?) ORDER BY id').all(first.assignmentId, second.assignmentId))
+            .toEqual([{ is_hidden: 1 }, { is_hidden: 1 }]);
+    });
+
+    it.each([
+        ['an unknown ID', ({ own }) => [own.assignmentId, 999999]],
+        ['a malformed ID', ({ own }) => [own.assignmentId, 'not-an-id']],
+        ['duplicate IDs', ({ own }) => [own.assignmentId, String(own.assignmentId)]]
+    ])('rejects %s without writing or clearing caches', (_label, idsFor) => {
+        const own = addAssignment(2);
+        const before = db.prepare('SELECT is_hidden FROM user_channels WHERE id = ?').get(own.assignmentId);
+        const cacheKey = 'user_2_live';
+        channelsJsonCache.set(cacheKey, ['cached']);
+        const res = response();
+
+        channelController.bulkDeleteUserChannels({
+            body: { ids: idsFor({ own }) },
+            user: { id: 2, is_admin: false, username: 'user' }, ip: '127.0.0.1'
+        }, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(db.prepare('SELECT is_hidden FROM user_channels WHERE id = ?').get(own.assignmentId)).toEqual(before);
+        expect(channelsJsonCache.has(cacheKey)).toBe(true);
+    });
+
+    it('rejects mixed own and foreign assignments without partial writes', () => {
+        const own = addAssignment(2);
+        const foreign = addAssignment(3);
+        const res = response();
+
+        channelController.bulkDeleteUserChannels({
+            body: { ids: [own.assignmentId, foreign.assignmentId] },
+            user: { id: 2, is_admin: false, username: 'user' }, ip: '127.0.0.1'
+        }, res);
+
+        expect(res.status).toHaveBeenCalledWith(403);
+        expect(db.prepare('SELECT is_hidden FROM user_channels WHERE id IN (?, ?) ORDER BY id').all(own.assignmentId, foreign.assignmentId))
+            .toEqual([{ is_hidden: 0 }, { is_hidden: 0 }]);
+    });
+
+    it('allows administrators to hide valid assignments across users and clears each cache', () => {
+        const first = addAssignment(2);
+        const second = addAssignment(3);
+        channelsJsonCache.set('user_2_live', ['cached']);
+        channelsJsonCache.set('user_3_live', ['cached']);
+        const res = response();
+
+        channelController.bulkDeleteUserChannels({
+            body: { ids: [first.assignmentId, second.assignmentId] },
+            user: { id: 1, is_admin: true, username: 'admin' }, ip: '127.0.0.1'
+        }, res);
+
+        expect(res.json).toHaveBeenCalledWith({ success: true, deleted: 2 });
+        expect(channelsJsonCache.has('user_2_live')).toBe(false);
+        expect(channelsJsonCache.has('user_3_live')).toBe(false);
+    });
+
+    it('rejects an administrator request containing an unknown assignment', () => {
+        const own = addAssignment(2);
+        const res = response();
+
+        channelController.bulkDeleteUserChannels({
+            body: { ids: [own.assignmentId, 999999] },
+            user: { id: 1, is_admin: true, username: 'admin' }, ip: '127.0.0.1'
+        }, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(db.prepare('SELECT is_hidden FROM user_channels WHERE id = ?').get(own.assignmentId)).toEqual({ is_hidden: 0 });
+    });
+
+    it('reports only assignments whose visibility changed', () => {
+        const visible = addAssignment(2, 0);
+        const alreadyHidden = addAssignment(2, 1);
+        const res = response();
+
+        channelController.bulkDeleteUserChannels({
+            body: { ids: [visible.assignmentId, alreadyHidden.assignmentId] },
+            user: { id: 2, is_admin: false, username: 'user' }, ip: '127.0.0.1'
+        }, res);
+
+        expect(res.json).toHaveBeenCalledWith({ success: true, deleted: 1 });
+    });
+
+    it('rejects unknown bulk category IDs without deleting a valid category', () => {
+        const category = addAssignment(2).categoryId;
+        const res = response();
+
+        channelController.bulkDeleteUserCategories({
+            body: { ids: [category, 999999] },
+            user: { id: 2, is_admin: false, username: 'user' }, ip: '127.0.0.1'
+        }, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(db.prepare('SELECT id FROM user_categories WHERE id = ?').get(category)).toEqual({ id: category });
     });
 });

--- a/tests/controllers/channelController.test.js
+++ b/tests/controllers/channelController.test.js
@@ -45,7 +45,7 @@ describe('Channel Controller - createUserCategory', () => {
     beforeEach(() => {
         // Clear DB
         initDb(true);
-        const tables = ['user_channels', 'user_categories', 'provider_channels', 'providers', 'users', 'admin_users'];
+        const tables = ['user_channels', 'category_mappings', 'user_categories', 'provider_channels', 'providers', 'users', 'admin_users'];
         db.pragma('foreign_keys = OFF');
         tables.forEach(t => db.prepare(`DELETE FROM ${t}`).run());
         db.pragma('foreign_keys = ON');
@@ -54,6 +54,7 @@ describe('Channel Controller - createUserCategory', () => {
         // Note: is_admin is not in users table, it's separate admin_users or managed by webui_access
         db.prepare("INSERT INTO admin_users (id, username, password, is_active) VALUES (1, 'admin', 'admin', 1)").run();
         db.prepare("INSERT INTO users (id, username, password, is_active) VALUES (2, 'user', 'user', 1)").run();
+        db.prepare("INSERT INTO users (id, username, password, is_active) VALUES (3, 'other', 'other', 1)").run();
     });
 
     afterEach(() => {
@@ -340,6 +341,185 @@ describe('Channel Controller - createUserCategory', () => {
         const created = db.prepare('SELECT * FROM user_channels WHERE id = ?').get(res.json.mock.calls[0][0].id);
         expect(created.sort_order).toBe(1);
         expect(created.granted_by_admin).toBe(0);
+    });
+
+    it('reorders only categories owned by the route user', () => {
+        const first = db.prepare("INSERT INTO user_categories (user_id, name, sort_order) VALUES (2, 'First', 10)").run().lastInsertRowid;
+        const second = db.prepare("INSERT INTO user_categories (user_id, name, sort_order) VALUES (2, 'Second', 20)").run().lastInsertRowid;
+        const foreign = db.prepare("INSERT INTO user_categories (user_id, name, sort_order) VALUES (3, 'Foreign', 30)").run().lastInsertRowid;
+        const res = { json: vi.fn(), status: vi.fn().mockReturnThis() };
+
+        channelController.reorderUserCategories({
+            params: { userId: '2' },
+            body: { category_ids: [String(second), first] },
+            user: { id: 2, is_admin: false }
+        }, res);
+
+        expect(res.json).toHaveBeenCalledWith({ success: true });
+        expect(db.prepare('SELECT id, sort_order FROM user_categories ORDER BY id').all()).toEqual([
+            { id: first, sort_order: 1 },
+            { id: second, sort_order: 0 },
+            { id: foreign, sort_order: 30 }
+        ]);
+    });
+
+    it.each([
+        ['a foreign ID', 'foreign', false],
+        ['mixed own and foreign IDs', 'mixed', false],
+        ['an unknown ID', 'unknown', false],
+        ['a malformed ID', 'malformed', false],
+        ['duplicate IDs', 'duplicate', false],
+        ['an admin request containing a foreign ID', 'mixed', true]
+    ])('rejects category reorder with %s without partial writes', (_label, kind, isAdmin) => {
+        const first = db.prepare("INSERT INTO user_categories (user_id, name, sort_order) VALUES (2, 'First', 10)").run().lastInsertRowid;
+        const second = db.prepare("INSERT INTO user_categories (user_id, name, sort_order) VALUES (2, 'Second', 20)").run().lastInsertRowid;
+        const foreign = db.prepare("INSERT INTO user_categories (user_id, name, sort_order) VALUES (3, 'Foreign', 30)").run().lastInsertRowid;
+        const submitted = {
+            foreign: [foreign],
+            mixed: [second, foreign],
+            unknown: [second, 999999],
+            malformed: [second, 'not-an-id'],
+            duplicate: [first, String(first)]
+        }[kind];
+        const before = db.prepare('SELECT id, sort_order FROM user_categories ORDER BY id').all();
+        const res = { json: vi.fn(), status: vi.fn().mockReturnThis() };
+
+        channelController.reorderUserCategories({
+            params: { userId: '2' },
+            body: { category_ids: submitted },
+            user: isAdmin ? { id: 1, is_admin: true } : { id: 2, is_admin: false }
+        }, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(db.prepare('SELECT id, sort_order FROM user_categories ORDER BY id').all()).toEqual(before);
+    });
+
+    it('reorders only assignments in the route category', () => {
+        const category = db.prepare("INSERT INTO user_categories (user_id, name) VALUES (2, 'Live')").run().lastInsertRowid;
+        const otherCategory = db.prepare("INSERT INTO user_categories (user_id, name) VALUES (2, 'Other')").run().lastInsertRowid;
+        const foreignCategory = db.prepare("INSERT INTO user_categories (user_id, name) VALUES (3, 'Foreign')").run().lastInsertRowid;
+        const provider = db.prepare("INSERT INTO providers (name, url, username, password, user_id) VALUES ('Provider', 'http://provider.test', 'u', 'p', 2)").run().lastInsertRowid;
+        const addAssignment = (catId, remoteId, sortOrder) => {
+            const providerChannel = db.prepare('INSERT INTO provider_channels (provider_id, remote_stream_id, name) VALUES (?, ?, ?)')
+                .run(provider, remoteId, `Channel ${remoteId}`).lastInsertRowid;
+            return db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, sort_order) VALUES (?, ?, ?)')
+                .run(catId, providerChannel, sortOrder).lastInsertRowid;
+        };
+        const first = addAssignment(category, 101, 10);
+        const second = addAssignment(category, 102, 20);
+        const other = addAssignment(otherCategory, 103, 30);
+        const foreign = addAssignment(foreignCategory, 104, 40);
+        const res = { json: vi.fn(), status: vi.fn().mockReturnThis() };
+
+        channelController.reorderUserChannels({
+            params: { catId: String(category) },
+            body: { channel_ids: [second, String(first)] },
+            user: { id: 2, is_admin: false }
+        }, res);
+
+        expect(res.json).toHaveBeenCalledWith({ success: true });
+        expect(db.prepare('SELECT id, sort_order FROM user_channels ORDER BY id').all()).toEqual([
+            { id: first, sort_order: 1 },
+            { id: second, sort_order: 0 },
+            { id: other, sort_order: 30 },
+            { id: foreign, sort_order: 40 }
+        ]);
+    });
+
+    it.each([
+        ['another category of the same user', 'other', false],
+        ['a foreign user assignment', 'foreign', false],
+        ['mixed valid and other-category IDs', 'mixed', false],
+        ['an unknown ID', 'unknown', false],
+        ['a malformed ID', 'malformed', false],
+        ['duplicate IDs', 'duplicate', false],
+        ['an admin request containing an out-of-category ID', 'mixed', true]
+    ])('rejects channel reorder with %s without partial writes', (_label, kind, isAdmin) => {
+        const category = db.prepare("INSERT INTO user_categories (user_id, name) VALUES (2, 'Live')").run().lastInsertRowid;
+        const otherCategory = db.prepare("INSERT INTO user_categories (user_id, name) VALUES (2, 'Other')").run().lastInsertRowid;
+        const foreignCategory = db.prepare("INSERT INTO user_categories (user_id, name) VALUES (3, 'Foreign')").run().lastInsertRowid;
+        const provider = db.prepare("INSERT INTO providers (name, url, username, password, user_id) VALUES ('Provider', 'http://provider.test', 'u', 'p', 2)").run().lastInsertRowid;
+        const addAssignment = (catId, remoteId, sortOrder) => {
+            const providerChannel = db.prepare('INSERT INTO provider_channels (provider_id, remote_stream_id, name) VALUES (?, ?, ?)')
+                .run(provider, remoteId, `Channel ${remoteId}`).lastInsertRowid;
+            return db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, sort_order) VALUES (?, ?, ?)')
+                .run(catId, providerChannel, sortOrder).lastInsertRowid;
+        };
+        const first = addAssignment(category, 101, 10);
+        const second = addAssignment(category, 102, 20);
+        const other = addAssignment(otherCategory, 103, 30);
+        const foreign = addAssignment(foreignCategory, 104, 40);
+        const submitted = {
+            other: [other],
+            foreign: [foreign],
+            mixed: [second, other],
+            unknown: [second, 999999],
+            malformed: [second, 'not-an-id'],
+            duplicate: [first, String(first)]
+        }[kind];
+        const before = db.prepare('SELECT id, sort_order FROM user_channels ORDER BY id').all();
+        const res = { json: vi.fn(), status: vi.fn().mockReturnThis() };
+
+        channelController.reorderUserChannels({
+            params: { catId: String(category) },
+            body: { channel_ids: submitted },
+            user: isAdmin ? { id: 1, is_admin: true } : { id: 2, is_admin: false }
+        }, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(db.prepare('SELECT id, sort_order FROM user_channels ORDER BY id').all()).toEqual(before);
+    });
+
+    it('maps only to a category with the same user and content type and allows explicit unmapping', () => {
+        const provider = db.prepare("INSERT INTO providers (name, url, username, password, user_id) VALUES ('Provider', 'http://provider.test', 'u', 'p', 2)").run().lastInsertRowid;
+        const target = db.prepare("INSERT INTO user_categories (user_id, name, type) VALUES (2, 'Live', 'live')").run().lastInsertRowid;
+        const mapping = db.prepare(`
+          INSERT INTO category_mappings
+            (provider_id, user_id, provider_category_id, provider_category_name, category_type)
+          VALUES (?, 2, 10, 'Provider Live', 'live')
+        `).run(provider).lastInsertRowid;
+        const res = { json: vi.fn(), status: vi.fn().mockReturnThis() };
+
+        channelController.updateCategoryMapping({
+            params: { id: String(mapping) }, body: { user_category_id: String(target) },
+            user: { id: 2, is_admin: false }
+        }, res);
+        expect(db.prepare('SELECT user_category_id FROM category_mappings WHERE id = ?').get(mapping))
+            .toEqual({ user_category_id: target });
+
+        channelController.updateCategoryMapping({
+            params: { id: String(mapping) }, body: { user_category_id: null },
+            user: { id: 2, is_admin: false }
+        }, res);
+        expect(db.prepare('SELECT user_category_id FROM category_mappings WHERE id = ?').get(mapping))
+            .toEqual({ user_category_id: null });
+    });
+
+    it.each([
+        ["another user's category", 'foreign'],
+        ['a category with the wrong type', 'wrong-type'],
+        ['an unknown category', 'unknown'],
+        ['a malformed category ID', 'malformed']
+    ])('rejects mapping to %s without changing the mapping', (_label, kind) => {
+        const provider = db.prepare("INSERT INTO providers (name, url, username, password, user_id) VALUES ('Provider', 'http://provider.test', 'u', 'p', 2)").run().lastInsertRowid;
+        const foreign = db.prepare("INSERT INTO user_categories (user_id, name, type) VALUES (3, 'Foreign', 'live')").run().lastInsertRowid;
+        const wrongType = db.prepare("INSERT INTO user_categories (user_id, name, type) VALUES (2, 'Movies', 'movie')").run().lastInsertRowid;
+        const mapping = db.prepare(`
+          INSERT INTO category_mappings
+            (provider_id, user_id, provider_category_id, provider_category_name, category_type)
+          VALUES (?, 2, 10, 'Provider Live', 'live')
+        `).run(provider).lastInsertRowid;
+        const target = { foreign, 'wrong-type': wrongType, unknown: 999999, malformed: 'not-an-id' }[kind];
+        const res = { json: vi.fn(), status: vi.fn().mockReturnThis() };
+
+        channelController.updateCategoryMapping({
+            params: { id: String(mapping) }, body: { user_category_id: target },
+            user: { id: 2, is_admin: false }
+        }, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(db.prepare('SELECT user_category_id FROM category_mappings WHERE id = ?').get(mapping))
+            .toEqual({ user_category_id: null });
     });
 
     it('should handle database errors', async () => {

--- a/tests/controllers/channelController.test.js
+++ b/tests/controllers/channelController.test.js
@@ -245,6 +245,7 @@ describe('Channel Controller - createUserCategory', () => {
         const created = db.prepare('SELECT * FROM user_channels WHERE id = ?').get(res.json.mock.calls[0][0].id);
         expect(created.provider_channel_id).toBe(channelId);
         expect(created.granted_by_admin).toBe(1);
+        expect(created.authorization_revoked).toBe(0);
         expect(db.prepare('SELECT id FROM authorized_user_channels WHERE id = ?').get(created.id).id).toBe(created.id);
     });
 
@@ -263,6 +264,7 @@ describe('Channel Controller - createUserCategory', () => {
 
         const created = db.prepare('SELECT * FROM user_channels WHERE id = ?').get(res.json.mock.calls[0][0].id);
         expect(created.granted_by_admin).toBe(0);
+        expect(created.authorization_revoked).toBe(0);
         expect(db.prepare('SELECT id FROM authorized_user_channels WHERE id = ?').get(created.id).id).toBe(created.id);
     });
 
@@ -285,18 +287,26 @@ describe('Channel Controller - createUserCategory', () => {
         const categoryId = db.prepare("INSERT INTO user_categories (user_id, name) VALUES (2, 'Managed Category')").run().lastInsertRowid;
         const providerId = db.prepare("INSERT INTO providers (name, url, username, password, user_id) VALUES ('Foreign Provider', 'http://provider.test', 'u', 'p', 1)").run().lastInsertRowid;
         const channelId = db.prepare("INSERT INTO provider_channels (provider_id, remote_stream_id, name) VALUES (?, 100, 'Foreign Channel')").run(providerId).lastInsertRowid;
-        const assignmentId = db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, sort_order, is_hidden) VALUES (?, ?, 0, 1)').run(categoryId, channelId).lastInsertRowid;
+        const assignmentId = db.prepare(`
+          INSERT INTO user_channels
+            (user_category_id, provider_channel_id, sort_order, is_hidden, authorization_revoked)
+          VALUES (?, ?, 0, 1, 1)
+        `).run(categoryId, channelId).lastInsertRowid;
         const body = { provider_channel_id: channelId };
 
         const userRes = { json: vi.fn(), status: vi.fn().mockReturnThis() };
         channelController.addUserChannel({ params: { catId: String(categoryId) }, body, user: { id: 2, is_admin: false } }, userRes);
         expect(userRes.status).toHaveBeenCalledWith(403);
-        expect(db.prepare('SELECT is_hidden, granted_by_admin FROM user_channels WHERE id = ?').get(assignmentId)).toEqual({ is_hidden: 1, granted_by_admin: 0 });
+        expect(db.prepare('SELECT is_hidden, granted_by_admin, authorization_revoked FROM user_channels WHERE id = ?').get(assignmentId)).toEqual({
+          is_hidden: 1, granted_by_admin: 0, authorization_revoked: 1
+        });
 
         const adminRes = { json: vi.fn(), status: vi.fn().mockReturnThis() };
         channelController.addUserChannel({ params: { catId: String(categoryId) }, body, user: { id: 1, is_admin: true } }, adminRes);
         expect(adminRes.json).toHaveBeenCalledWith({ id: assignmentId });
-        expect(db.prepare('SELECT is_hidden, granted_by_admin FROM user_channels WHERE id = ?').get(assignmentId)).toEqual({ is_hidden: 0, granted_by_admin: 1 });
+        expect(db.prepare('SELECT is_hidden, granted_by_admin, authorization_revoked FROM user_channels WHERE id = ?').get(assignmentId)).toEqual({
+          is_hidden: 0, granted_by_admin: 1, authorization_revoked: 0
+        });
     });
 
     it('should exclude an ungranted legacy mismatch from category lists', () => {

--- a/tests/controllers/delete_cleanup.test.js
+++ b/tests/controllers/delete_cleanup.test.js
@@ -40,7 +40,10 @@ vi.mock('../../src/utils/network.js', () => ({
 vi.mock('../../src/utils/helpers.js', () => ({
   isSafeUrl: vi.fn(),
   isAdultCategory: vi.fn(),
-  providerSourceKey: vi.fn((url) => String(url || ''))
+  redactUrl: vi.fn((url) => url),
+  providerSourceKey: vi.fn((url) => String(url || '')),
+  resolveAssignmentGrant: vi.fn(({ categoryOwnerId, providerOwnerId, isAdmin }) =>
+    Number(categoryOwnerId) === Number(providerOwnerId) ? 0 : (isAdmin ? 1 : null))
 }));
 
 vi.mock('../../src/services/syncService.js', () => ({

--- a/tests/controllers/epg_mapping_category.test.js
+++ b/tests/controllers/epg_mapping_category.test.js
@@ -61,8 +61,8 @@ describe('EPG Mapping Category Mode', () => {
         db.prepare("INSERT INTO users (id, username, password, is_active) VALUES (1, 'admin', 'admin', 1)").run();
         db.prepare("INSERT INTO users (id, username, password, is_active) VALUES (2, 'user', 'user', 1)").run();
 
-        db.prepare("INSERT INTO providers (id, name, url, username, password, epg_url) VALUES (1, 'TestProvider', 'http://test.com', 'user', 'pass', 'http://epg.com')").run();
-        db.prepare("INSERT INTO providers (id, name, url, username, password, epg_url) VALUES (2, 'SecondProvider', 'http://test2.com', 'user', 'pass', 'http://epg2.com')").run();
+        db.prepare("INSERT INTO providers (id, name, url, username, password, epg_url, user_id) VALUES (1, 'TestProvider', 'http://test.com', 'user', 'pass', 'http://epg.com', 2)").run();
+        db.prepare("INSERT INTO providers (id, name, url, username, password, epg_url, user_id) VALUES (2, 'SecondProvider', 'http://test2.com', 'user', 'pass', 'http://epg2.com', 1)").run();
 
         // Channel 1: Provider 1
         db.prepare("INSERT INTO provider_channels (id, provider_id, remote_stream_id, name, stream_type) VALUES (1, 1, 100, 'Test Channel 1', 'live')").run();

--- a/tests/controllers/provider_owner_change.test.js
+++ b/tests/controllers/provider_owner_change.test.js
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const TEST_DB_DIR = path.join(process.cwd(), 'tests/temp_db_provider_owner');
+fs.mkdirSync(TEST_DB_DIR, { recursive: true });
+
+vi.mock('../../src/config/constants.js', () => {
+  const pathModule = require('path');
+  return {
+    DATA_DIR: pathModule.join(process.cwd(), 'tests/temp_db_provider_owner'),
+    EPG_DB_PATH: pathModule.join(process.cwd(), 'tests/temp_db_provider_owner/epg.db'),
+    BCRYPT_ROUNDS: 1,
+    DEFAULT_USER_AGENT: 'TestAgent',
+  };
+});
+
+vi.mock('../../src/utils/crypto.js', () => ({
+  encrypt: vi.fn((value) => `enc:${value}`),
+  decrypt: vi.fn((value) => String(value || '').replace(/^enc:/, '')),
+}));
+
+vi.mock('../../src/utils/network.js', () => ({ fetchSafe: vi.fn() }));
+vi.mock('../../src/services/syncService.js', () => ({
+  performSync: vi.fn(),
+  checkProviderExpiry: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../../src/services/epgService.js', () => ({
+  updateProviderEpg: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../../src/services/cacheService.js', () => ({
+  clearChannelsCache: vi.fn(),
+}));
+
+import db, { initDb } from '../../src/database/db.js';
+import { updateProvider } from '../../src/controllers/providerController.js';
+import { clearChannelsCache } from '../../src/services/cacheService.js';
+
+describe('provider owner changes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    initDb(true);
+    db.pragma('foreign_keys = OFF');
+    for (const table of ['security_logs', 'user_channels', 'user_categories', 'provider_channels', 'providers', 'users']) {
+      db.prepare(`DELETE FROM ${table}`).run();
+    }
+    db.pragma('foreign_keys = ON');
+  });
+
+  it('hides newly invalid normal assignments but preserves explicit admin grants', async () => {
+    db.prepare("INSERT INTO users (id, username, password) VALUES (1, 'old-owner', 'p'), (2, 'new-owner', 'p'), (3, 'shared-user', 'p')").run();
+    const providerId = db.prepare(`
+      INSERT INTO providers (name, url, username, password, epg_url, user_id, epg_enabled, max_connections)
+      VALUES ('Provider', 'http://provider.example', 'upstream', 'enc:secret', 'http://epg.example/xmltv', 1, 0, 5)
+    `).run().lastInsertRowid;
+    const providerChannelId = db.prepare("INSERT INTO provider_channels (provider_id, remote_stream_id, name, stream_type) VALUES (?, 10, 'Channel', 'live')").run(providerId).lastInsertRowid;
+    const oldCategoryId = db.prepare("INSERT INTO user_categories (user_id, name) VALUES (1, 'Old')").run().lastInsertRowid;
+    const newCategoryId = db.prepare("INSERT INTO user_categories (user_id, name) VALUES (2, 'New')").run().lastInsertRowid;
+    const sharedCategoryId = db.prepare("INSERT INTO user_categories (user_id, name) VALUES (3, 'Shared')").run().lastInsertRowid;
+
+    const oldAssignmentId = db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, granted_by_admin) VALUES (?, ?, 0)').run(oldCategoryId, providerChannelId).lastInsertRowid;
+    const newAssignmentId = db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, granted_by_admin) VALUES (?, ?, 0)').run(newCategoryId, providerChannelId).lastInsertRowid;
+    const grantedAssignmentId = db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, granted_by_admin) VALUES (?, ?, 1)').run(sharedCategoryId, providerChannelId).lastInsertRowid;
+
+    const req = {
+      params: { id: String(providerId) },
+      body: {
+        name: 'Provider',
+        url: 'http://provider.example',
+        username: 'upstream',
+        password: '********',
+        epg_url: 'http://epg.example/xmltv',
+        user_id: 2,
+        epg_enabled: false,
+        max_connections: 5,
+      },
+      user: { id: 99, username: 'admin', is_admin: true },
+      ip: '127.0.0.1',
+    };
+    const res = { json: vi.fn(), status: vi.fn().mockReturnThis() };
+
+    await updateProvider(req, res);
+
+    expect(res.json).toHaveBeenCalledWith({ success: true });
+    expect(db.prepare('SELECT user_id FROM providers WHERE id = ?').get(providerId).user_id).toBe(2);
+    expect(db.prepare('SELECT is_hidden FROM user_channels WHERE id = ?').get(oldAssignmentId).is_hidden).toBe(1);
+    expect(db.prepare('SELECT is_hidden FROM user_channels WHERE id = ?').get(newAssignmentId).is_hidden).toBe(0);
+    expect(db.prepare('SELECT is_hidden, granted_by_admin FROM user_channels WHERE id = ?').get(grantedAssignmentId)).toEqual({ is_hidden: 0, granted_by_admin: 1 });
+    expect(db.prepare('SELECT id FROM authorized_user_channels ORDER BY id').all()).toEqual([
+      { id: newAssignmentId },
+      { id: grantedAssignmentId },
+    ]);
+    expect(db.prepare("SELECT details FROM security_logs WHERE action = 'provider_owner_changed'").get().details).toContain('revoked 1 ungranted assignment(s)');
+    expect(clearChannelsCache).toHaveBeenCalledWith();
+  });
+});

--- a/tests/controllers/provider_owner_change.test.js
+++ b/tests/controllers/provider_owner_change.test.js
@@ -1,15 +1,18 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import fs from 'fs';
-import path from 'path';
 
-const TEST_DB_DIR = path.join(process.cwd(), 'tests/temp_db_provider_owner');
-fs.mkdirSync(TEST_DB_DIR, { recursive: true });
+const { TEST_DB_DIR } = vi.hoisted(() => {
+  const fsModule = require('fs');
+  const osModule = require('os');
+  const pathModule = require('path');
+  return { TEST_DB_DIR: fsModule.mkdtempSync(pathModule.join(osModule.tmpdir(), 'iptv-provider-owner-')) };
+});
 
 vi.mock('../../src/config/constants.js', () => {
   const pathModule = require('path');
   return {
-    DATA_DIR: pathModule.join(process.cwd(), 'tests/temp_db_provider_owner'),
-    EPG_DB_PATH: pathModule.join(process.cwd(), 'tests/temp_db_provider_owner/epg.db'),
+    DATA_DIR: TEST_DB_DIR,
+    EPG_DB_PATH: pathModule.join(TEST_DB_DIR, 'epg.db'),
     BCRYPT_ROUNDS: 1,
     DEFAULT_USER_AGENT: 'TestAgent',
   };
@@ -37,11 +40,16 @@ import { updateProvider } from '../../src/controllers/providerController.js';
 import { clearChannelsCache } from '../../src/services/cacheService.js';
 
 describe('provider owner changes', () => {
+  afterAll(() => {
+    db.close();
+    fs.rmSync(TEST_DB_DIR, { recursive: true, force: true });
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     initDb(true);
     db.pragma('foreign_keys = OFF');
-    for (const table of ['security_logs', 'user_channels', 'user_categories', 'provider_channels', 'providers', 'users']) {
+    for (const table of ['security_logs', 'sync_configs', 'user_channels', 'user_categories', 'provider_channels', 'providers', 'users']) {
       db.prepare(`DELETE FROM ${table}`).run();
     }
     db.pragma('foreign_keys = ON');
@@ -61,6 +69,7 @@ describe('provider owner changes', () => {
     const oldAssignmentId = db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, granted_by_admin) VALUES (?, ?, 0)').run(oldCategoryId, providerChannelId).lastInsertRowid;
     const newAssignmentId = db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, granted_by_admin) VALUES (?, ?, 0)').run(newCategoryId, providerChannelId).lastInsertRowid;
     const grantedAssignmentId = db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, granted_by_admin) VALUES (?, ?, 1)').run(sharedCategoryId, providerChannelId).lastInsertRowid;
+    const syncConfigId = db.prepare("INSERT INTO sync_configs (provider_id, user_id, enabled, granted_by_admin) VALUES (?, 1, 1, 0)").run(providerId).lastInsertRowid;
 
     const req = {
       params: { id: String(providerId) },
@@ -90,7 +99,40 @@ describe('provider owner changes', () => {
       { id: newAssignmentId },
       { id: grantedAssignmentId },
     ]);
+    expect(db.prepare('SELECT enabled, granted_by_admin FROM sync_configs WHERE id = ?').get(syncConfigId)).toEqual({ enabled: 0, granted_by_admin: 0 });
     expect(db.prepare("SELECT details FROM security_logs WHERE action = 'provider_owner_changed'").get().details).toContain('revoked 1 ungranted assignment(s)');
+    expect(db.prepare("SELECT details FROM security_logs WHERE action = 'provider_owner_changed'").get().details).toContain('disabled 1 ungranted sync config(s)');
     expect(clearChannelsCache).toHaveBeenCalledWith();
+  });
+
+  it('preserves an explicitly granted cross-owner sync config', async () => {
+    db.prepare("INSERT INTO users (id, username, password) VALUES (1, 'old-owner', 'p'), (2, 'new-owner', 'p')").run();
+    const providerId = db.prepare(`
+      INSERT INTO providers (name, url, username, password, epg_url, user_id, epg_enabled, max_connections)
+      VALUES ('Provider', 'http://provider.example', 'upstream', 'enc:secret', 'http://epg.example/xmltv', 1, 0, 5)
+    `).run().lastInsertRowid;
+    const syncConfigId = db.prepare("INSERT INTO sync_configs (provider_id, user_id, enabled, granted_by_admin) VALUES (?, 1, 1, 1)").run(providerId).lastInsertRowid;
+
+    const req = {
+      params: { id: String(providerId) },
+      body: {
+        name: 'Provider',
+        url: 'http://provider.example',
+        username: 'upstream',
+        password: '********',
+        epg_url: 'http://epg.example/xmltv',
+        user_id: 2,
+        epg_enabled: false,
+        max_connections: 5,
+      },
+      user: { id: 99, username: 'admin', is_admin: true },
+      ip: '127.0.0.1',
+    };
+    const res = { json: vi.fn(), status: vi.fn().mockReturnThis() };
+
+    await updateProvider(req, res);
+
+    expect(db.prepare('SELECT enabled, granted_by_admin FROM sync_configs WHERE id = ?').get(syncConfigId)).toEqual({ enabled: 1, granted_by_admin: 1 });
+    expect(db.prepare("SELECT details FROM security_logs WHERE action = 'provider_owner_changed'").get().details).toContain('retained 1 explicit sync grant(s)');
   });
 });

--- a/tests/controllers/provider_owner_change.test.js
+++ b/tests/controllers/provider_owner_change.test.js
@@ -55,7 +55,7 @@ describe('provider owner changes', () => {
     db.pragma('foreign_keys = ON');
   });
 
-  it('hides newly invalid normal assignments but preserves explicit admin grants', async () => {
+  it('revokes newly invalid normal assignments without rewriting hidden state', async () => {
     db.prepare("INSERT INTO users (id, username, password) VALUES (1, 'old-owner', 'p'), (2, 'new-owner', 'p'), (3, 'shared-user', 'p')").run();
     const providerId = db.prepare(`
       INSERT INTO providers (name, url, username, password, epg_url, user_id, epg_enabled, max_connections)
@@ -92,9 +92,15 @@ describe('provider owner changes', () => {
 
     expect(res.json).toHaveBeenCalledWith({ success: true });
     expect(db.prepare('SELECT user_id FROM providers WHERE id = ?').get(providerId).user_id).toBe(2);
-    expect(db.prepare('SELECT is_hidden FROM user_channels WHERE id = ?').get(oldAssignmentId).is_hidden).toBe(1);
-    expect(db.prepare('SELECT is_hidden FROM user_channels WHERE id = ?').get(newAssignmentId).is_hidden).toBe(0);
-    expect(db.prepare('SELECT is_hidden, granted_by_admin FROM user_channels WHERE id = ?').get(grantedAssignmentId)).toEqual({ is_hidden: 0, granted_by_admin: 1 });
+    expect(db.prepare('SELECT is_hidden, granted_by_admin, authorization_revoked FROM user_channels WHERE id = ?').get(oldAssignmentId)).toEqual({
+      is_hidden: 0, granted_by_admin: 0, authorization_revoked: 1
+    });
+    expect(db.prepare('SELECT is_hidden, granted_by_admin, authorization_revoked FROM user_channels WHERE id = ?').get(newAssignmentId)).toEqual({
+      is_hidden: 0, granted_by_admin: 0, authorization_revoked: 0
+    });
+    expect(db.prepare('SELECT is_hidden, granted_by_admin, authorization_revoked FROM user_channels WHERE id = ?').get(grantedAssignmentId)).toEqual({
+      is_hidden: 0, granted_by_admin: 1, authorization_revoked: 0
+    });
     expect(db.prepare('SELECT id FROM authorized_user_channels ORDER BY id').all()).toEqual([
       { id: newAssignmentId },
       { id: grantedAssignmentId },

--- a/tests/controllers/series_alias_cleanup.test.js
+++ b/tests/controllers/series_alias_cleanup.test.js
@@ -1,0 +1,123 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'fs';
+
+const { TEST_DB_DIR } = vi.hoisted(() => {
+  const fsModule = require('fs');
+  const osModule = require('os');
+  const pathModule = require('path');
+  return { TEST_DB_DIR: fsModule.mkdtempSync(pathModule.join(osModule.tmpdir(), 'iptv-alias-cleanup-')) };
+});
+
+vi.mock('../../src/config/constants.js', async (importOriginal) => {
+  const path = require('path');
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    DATA_DIR: TEST_DB_DIR,
+    EPG_DB_PATH: path.join(TEST_DB_DIR, 'epg.db'),
+    PORT: 3000,
+    BCRYPT_ROUNDS: 1,
+    JWT_EXPIRES_IN: '1h',
+    AUTH_CACHE_TTL: 60000,
+    AUTH_CACHE_MAX_SIZE: 100
+  };
+});
+
+vi.mock('../../src/utils/crypto.js', () => ({
+  JWT_SECRET: 'test-secret',
+  ENCRYPTION_KEY: 'test-key-32-bytes-length-12345678',
+  encrypt: value => value,
+  decrypt: value => value,
+}));
+
+import db, { initDb } from '../../src/database/db.js';
+import { deleteUserCategory } from '../../src/controllers/channelController.js';
+import { deleteProvider } from '../../src/controllers/providerController.js';
+import { deleteUser } from '../../src/controllers/userController.js';
+
+const response = () => ({ status: vi.fn().mockReturnThis(), json: vi.fn() });
+
+describe('series episode alias cascading cleanup', () => {
+  beforeAll(() => initDb(true));
+
+  beforeEach(() => {
+    db.pragma('foreign_keys = OFF');
+    for (const table of [
+      'series_episode_aliases', 'provider_series_episodes', 'provider_series_state',
+      'user_channels', 'category_mappings', 'epg_channel_mappings', 'stream_stats',
+      'provider_channels', 'sync_configs', 'sync_logs', 'provider_icon_cache',
+      'providers', 'user_categories', 'temporary_tokens', 'shared_links',
+      'user_backups', 'security_logs', 'users'
+    ]) {
+      db.prepare(`DELETE FROM ${table}`).run();
+    }
+    db.pragma('foreign_keys = ON');
+  });
+
+  afterAll(() => {
+    db.close();
+    fs.rmSync(TEST_DB_DIR, { recursive: true, force: true });
+  });
+
+  const createFixture = () => {
+    const userId = db.prepare("INSERT INTO users (username, password) VALUES ('owner', 'password')").run().lastInsertRowid;
+    const providerId = db.prepare(`
+      INSERT INTO providers (name, url, username, password, user_id)
+      VALUES ('Provider', 'http://panel.test', 'provider-user', 'provider-pass', ?)
+    `).run(userId).lastInsertRowid;
+    const providerChannelId = db.prepare(`
+      INSERT INTO provider_channels (provider_id, remote_stream_id, name, stream_type)
+      VALUES (?, 55, 'Series', 'series')
+    `).run(providerId).lastInsertRowid;
+    const categoryId = db.prepare("INSERT INTO user_categories (user_id, name, type) VALUES (?, 'Series', 'series')")
+      .run(userId).lastInsertRowid;
+    const userChannelId = db.prepare(`
+      INSERT INTO user_channels (user_category_id, provider_channel_id)
+      VALUES (?, ?)
+    `).run(categoryId, providerChannelId).lastInsertRowid;
+    const aliasId = db.prepare(`
+      INSERT INTO series_episode_aliases
+        (user_channel_id, source_key, series_remote_id, remote_episode_id)
+      VALUES (?, 'http://panel.test:80', 55, 77)
+    `).run(userChannelId).lastInsertRowid;
+    return { userId, providerId, categoryId, userChannelId, aliasId };
+  };
+
+  const aliasCount = () => db.prepare('SELECT COUNT(*) AS count FROM series_episode_aliases').get().count;
+
+  it('removes aliases when an assignment is permanently deleted', () => {
+    const fixture = createFixture();
+
+    db.prepare('DELETE FROM user_channels WHERE id = ?').run(fixture.userChannelId);
+
+    expect(aliasCount()).toBe(0);
+  });
+
+  it('removes aliases for every assignment deleted with a category', () => {
+    const fixture = createFixture();
+
+    deleteUserCategory({
+      params: { id: String(fixture.categoryId) },
+      user: { id: 1, is_admin: true, username: 'admin' },
+      ip: '127.0.0.1'
+    }, response());
+
+    expect(aliasCount()).toBe(0);
+  });
+
+  it('removes aliases for assignments deleted with a provider', () => {
+    const fixture = createFixture();
+
+    deleteProvider({ user: { is_admin: true }, params: { id: String(fixture.providerId) } }, response());
+
+    expect(aliasCount()).toBe(0);
+  });
+
+  it('removes all aliases for a deleted user', () => {
+    const fixture = createFixture();
+
+    deleteUser({ user: { is_admin: true }, params: { id: String(fixture.userId) } }, response());
+
+    expect(aliasCount()).toBe(0);
+  });
+});

--- a/tests/controllers/streamController_perf.test.js
+++ b/tests/controllers/streamController_perf.test.js
@@ -30,7 +30,21 @@ vi.mock('../../src/database/db.js', () => {
   return {
     default: {
       prepare: vi.fn((query) => {
-        if (query.includes('FROM user_channels')) {
+        if (query.includes('FROM providers p') && query.includes('authorized_user_channels')) {
+            return {
+                get: vi.fn().mockReturnValue({
+                    id: 1,
+                    user_id: 1,
+                    url: 'http://upstream.com',
+                    username: 'puser',
+                    password: 'ppass',
+                    max_connections: 10,
+                    backup_urls: null,
+                    user_agent: 'TestAgent',
+                })
+            };
+        }
+        if (query.includes('FROM authorized_user_channels')) {
           return {
             get: vi.fn().mockReturnValue({
               user_channel_id: 1,
@@ -58,20 +72,6 @@ vi.mock('../../src/database/db.js', () => {
                 }])
             };
         }
-        if (query.includes('SELECT * FROM providers WHERE id = ?')) {
-            return {
-                get: vi.fn().mockReturnValue({
-                    id: 1,
-                    user_id: 1,
-                    url: 'http://upstream.com',
-                    username: 'puser',
-                    password: 'ppass',
-                    max_connections: 10,
-                    backup_urls: null,
-                    user_agent: 'TestAgent',
-                })
-            };
-        }
         if (query.includes('SELECT id FROM stream_stats')) {
            return { get: vi.fn().mockReturnValue({ id: 50 }), run: vi.fn() };
         }
@@ -95,6 +95,7 @@ vi.mock('../../src/utils/helpers.js', () => ({
   getBaseUrl: vi.fn(() => 'http://localhost'),
   isSafeUrl: vi.fn(() => Promise.resolve(true)),
   safeLookup: vi.fn((hostname, options, cb) => cb(null, '127.0.0.1', 4)),
+  providerSourceKey: vi.fn((url) => String(url || '')),
 }));
 
 // We don't mock ffmpeg here because it's not strictly needed for m3u8 logic test,
@@ -281,6 +282,8 @@ describe('Stream Controller Performance (proxyLive)', () => {
 
     await streamController.proxySeries(req, res);
 
+    expect(db.prepare).toHaveBeenCalledWith(expect.stringContaining('FROM providers p'));
+    expect(db.prepare).toHaveBeenCalledWith(expect.stringContaining('FROM authorized_user_channels uc'));
     expect(fetch).toHaveBeenCalledWith(
       expect.stringContaining('/series/puser/ppass/1.mkv'),
       expect.objectContaining({

--- a/tests/controllers/streamController_perf.test.js
+++ b/tests/controllers/streamController_perf.test.js
@@ -30,19 +30,30 @@ vi.mock('../../src/database/db.js', () => {
   return {
     default: {
       prepare: vi.fn((query) => {
-        if (query.includes('FROM providers p') && query.includes('authorized_user_channels')) {
-            return {
-                get: vi.fn().mockReturnValue({
-                    id: 1,
-                    user_id: 1,
-                    url: 'http://upstream.com',
-                    username: 'puser',
-                    password: 'ppass',
-                    max_connections: 10,
-                    backup_urls: null,
-                    user_agent: 'TestAgent',
-                })
-            };
+        if (query.includes("WHERE uc.id = ? AND cat.user_id = ? AND pc.stream_type = 'series'")) {
+          return {
+            get: vi.fn((assignmentId, userId) => assignmentId === 1 && userId === 1 ? {
+              id: 1,
+              user_id: 1,
+              url: 'http://upstream.com',
+              username: 'puser',
+              password: 'ppass',
+              max_connections: 10,
+              backup_urls: null,
+              user_agent: 'TestAgent',
+              user_channel_id: 1,
+              series_remote_id: 55,
+              series_name: 'Test Series',
+            } : undefined),
+          };
+        }
+        if (query.includes('FROM provider_series_episodes')) {
+          return {
+            get: vi.fn((sourceKey, seriesRemoteId, remoteEpisodeId) =>
+              sourceKey === 'http://upstream.com' && seriesRemoteId === 55 && remoteEpisodeId === 1
+                ? { season: 1, episode_num: 1, title: 'Pilot', container_extension: 'mkv', logo: '' }
+                : undefined),
+          };
         }
         if (query.includes('FROM authorized_user_channels')) {
           return {
@@ -282,8 +293,8 @@ describe('Stream Controller Performance (proxyLive)', () => {
 
     await streamController.proxySeries(req, res);
 
-    expect(db.prepare).toHaveBeenCalledWith(expect.stringContaining('FROM providers p'));
-    expect(db.prepare).toHaveBeenCalledWith(expect.stringContaining('FROM authorized_user_channels uc'));
+    expect(db.prepare).toHaveBeenCalledWith(expect.stringContaining("pc.stream_type = 'series'"));
+    expect(db.prepare).toHaveBeenCalledWith(expect.stringContaining('FROM provider_series_episodes'));
     expect(fetch).toHaveBeenCalledWith(
       expect.stringContaining('/series/puser/ppass/1.mkv'),
       expect.objectContaining({
@@ -293,6 +304,67 @@ describe('Stream Controller Performance (proxyLive)', () => {
     expect(res.status).toHaveBeenCalledWith(206);
     expect(res.setHeader).toHaveBeenCalledWith('Content-Range', 'bytes 300-400/1000');
     expect(res.setHeader).toHaveBeenCalledWith('Accept-Ranges', 'bytes');
+  });
+
+  it.each([
+    ['track probing', { tracks: 'true' }],
+    ['subtitle extraction', { subtitle_format: 'vtt', subtitle_track: '1' }],
+    ['transcoding', { transcode: 'true' }],
+  ])('rejects an unknown series episode before %s', async (_label, query) => {
+    req.params = { episode_id: '1000000002', ext: 'mkv' };
+    req.query = query;
+
+    await streamController.proxySeries(req, res);
+
+    expect(res.sendStatus).toHaveBeenCalledWith(404);
+    expect(fetch).not.toHaveBeenCalled();
+    expect(spawn).not.toHaveBeenCalled();
+    expect(streamManager.add).not.toHaveBeenCalled();
+  });
+
+  it('rejects an episode identifier for another user assignment', async () => {
+    req.params = { episode_id: '2000000001', ext: 'mkv' };
+
+    await streamController.proxySeries(req, res);
+
+    expect(res.sendStatus).toHaveBeenCalledWith(404);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('allows a share guest only for the explicitly shared series', async () => {
+    req.params = { episode_id: '1000000001', ext: 'mkv' };
+    req.headers = { range: 'bytes=0-10' };
+    res.headersSent = false;
+    authService.getXtreamUser.mockResolvedValue({
+      id: 1,
+      is_share_guest: true,
+      allowed_channels: [1],
+      share_start: 0,
+      share_end: 0,
+    });
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      status: 206,
+      headers: { get: vi.fn() },
+      body: { pipe: vi.fn(), on: vi.fn(), destroy: vi.fn() },
+    });
+
+    await streamController.proxySeries(req, res);
+
+    expect(fetch).toHaveBeenCalled();
+
+    vi.clearAllMocks();
+    authService.getXtreamUser.mockResolvedValue({
+      id: 1,
+      is_share_guest: true,
+      allowed_channels: [2],
+      share_start: 0,
+      share_end: 0,
+    });
+    await streamController.proxySeries(req, res);
+
+    expect(res.sendStatus).toHaveBeenCalledWith(403);
+    expect(fetch).not.toHaveBeenCalled();
   });
 
   it('should return probed VOD tracks without opening a stream session', async () => {

--- a/tests/controllers/streamController_perf.test.js
+++ b/tests/controllers/streamController_perf.test.js
@@ -27,31 +27,50 @@ vi.mock('../../src/services/streamManager.js', () => ({
 }));
 vi.mock('../../src/services/authService.js');
 vi.mock('../../src/database/db.js', () => {
+  const seriesAssignment = (overrides = {}) => ({
+    id: 1,
+    user_id: 1,
+    url: 'http://upstream.com',
+    username: 'puser',
+    password: 'ppass',
+    max_connections: 10,
+    backup_urls: null,
+    user_agent: 'TestAgent',
+    user_channel_id: 1,
+    series_remote_id: 55,
+    series_name: 'Test Series',
+    ...overrides,
+  });
   return {
     default: {
       prepare: vi.fn((query) => {
-        if (query.includes("WHERE uc.id = ? AND cat.user_id = ? AND pc.stream_type = 'series'")) {
+        if (query.includes('FROM series_episode_aliases a')) {
           return {
-            get: vi.fn((assignmentId, userId) => assignmentId === 1 && userId === 1 ? {
-              id: 1,
-              user_id: 1,
-              url: 'http://upstream.com',
-              username: 'puser',
-              password: 'ppass',
-              max_connections: 10,
-              backup_urls: null,
-              user_agent: 'TestAgent',
-              user_channel_id: 1,
-              series_remote_id: 55,
-              series_name: 'Test Series',
-            } : undefined),
+            get: vi.fn((aliasId, userId) => aliasId === 900000321 && userId === 1
+              ? seriesAssignment({ episode_source_key: 'http://upstream.com', remote_episode_id: 1 })
+              : undefined),
+          };
+        }
+        if (query.includes('(uc.id = ? OR p.id = ?)')) {
+          return {
+            all: vi.fn((assignmentId, _providerId, userId) => {
+              if (userId !== 1) return [];
+              if (assignmentId === 1) return [seriesAssignment()];
+              if (assignmentId === 7) {
+                return [
+                  seriesAssignment(),
+                  seriesAssignment({ id: 2, user_channel_id: 2, series_remote_id: 56 }),
+                ];
+              }
+              return [];
+            }),
           };
         }
         if (query.includes('FROM provider_series_episodes')) {
           return {
             get: vi.fn((sourceKey, seriesRemoteId, remoteEpisodeId) =>
-              sourceKey === 'http://upstream.com' && seriesRemoteId === 55 && remoteEpisodeId === 1
-                ? { season: 1, episode_num: 1, title: 'Pilot', container_extension: 'mkv', logo: '' }
+              sourceKey === 'http://upstream.com' && [55, 56].includes(seriesRemoteId) && remoteEpisodeId === 1
+                ? { season: 1, episode_num: 1, title: 'Pilot', container_extension: '.MKV', logo: '' }
                 : undefined),
           };
         }
@@ -264,9 +283,9 @@ describe('Stream Controller Performance (proxyLive)', () => {
     expect(res.setHeader).toHaveBeenCalledWith('Accept-Ranges', 'bytes');
   });
 
-  it('should proxy MKV series range requests without browser auto-transcode', async () => {
-    req.params = { episode_id: '1000000001', ext: 'mkv' };
-    req.path = '/series/user/pass/1000000001.mkv';
+  it('uses the stored MKV extension when the public series suffix differs', async () => {
+    req.params = { episode_id: '900000321', ext: 'mp4' };
+    req.path = '/series/user/pass/900000321.mp4';
     req.headers = {
       range: 'bytes=300-400',
       'user-agent': 'Mozilla/5.0 Firefox/140',
@@ -293,7 +312,7 @@ describe('Stream Controller Performance (proxyLive)', () => {
 
     await streamController.proxySeries(req, res);
 
-    expect(db.prepare).toHaveBeenCalledWith(expect.stringContaining("pc.stream_type = 'series'"));
+    expect(db.prepare).toHaveBeenCalledWith(expect.stringContaining('FROM series_episode_aliases a'));
     expect(db.prepare).toHaveBeenCalledWith(expect.stringContaining('FROM provider_series_episodes'));
     expect(fetch).toHaveBeenCalledWith(
       expect.stringContaining('/series/puser/ppass/1.mkv'),
@@ -304,6 +323,28 @@ describe('Stream Controller Performance (proxyLive)', () => {
     expect(res.status).toHaveBeenCalledWith(206);
     expect(res.setHeader).toHaveBeenCalledWith('Content-Range', 'bytes 300-400/1000');
     expect(res.setHeader).toHaveBeenCalledWith('Accept-Ranges', 'bytes');
+  });
+
+  it('resolves a stale provider-based episode ID only when it has one exact match', async () => {
+    req.params = { episode_id: '1000000001', ext: 'mp4' };
+    req.headers = { range: 'bytes=0-10' };
+    res.headersSent = false;
+
+    await streamController.proxySeries(req, res);
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/series/puser/ppass/1.mkv'),
+      expect.any(Object)
+    );
+  });
+
+  it('fails closed when a stale provider-based episode ID matches multiple series', async () => {
+    req.params = { episode_id: '7000000001', ext: 'mkv' };
+
+    await streamController.proxySeries(req, res);
+
+    expect(res.sendStatus).toHaveBeenCalledWith(404);
+    expect(fetch).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -332,7 +373,7 @@ describe('Stream Controller Performance (proxyLive)', () => {
   });
 
   it('allows a share guest only for the explicitly shared series', async () => {
-    req.params = { episode_id: '1000000001', ext: 'mkv' };
+    req.params = { episode_id: '900000321', ext: 'mkv' };
     req.headers = { range: 'bytes=0-10' };
     res.headersSent = false;
     authService.getXtreamUser.mockResolvedValue({

--- a/tests/controllers/streamController_perf.test.js
+++ b/tests/controllers/streamController_perf.test.js
@@ -8,6 +8,11 @@ import db from '../../src/database/db.js';
 import * as authService from '../../src/services/authService.js';
 import fetch from 'node-fetch';
 import { spawn } from 'child_process';
+import ffmpeg from 'fluent-ffmpeg';
+
+const { streamDbState } = vi.hoisted(() => ({
+  streamDbState: { channelOverrides: {}, providerPool: [] }
+}));
 
 // Mock dependencies
 vi.mock('node-fetch');
@@ -76,30 +81,30 @@ vi.mock('../../src/database/db.js', () => {
         }
         if (query.includes('FROM authorized_user_channels')) {
           return {
-            get: vi.fn().mockReturnValue({
+            get: vi.fn((streamId) => ({
               user_channel_id: 1,
               provider_channel_id: 100,
-              remote_stream_id: 'remote1',
+              remote_stream_id: `remote${streamId}`,
               name: 'Test Channel',
               metadata: '{}',
+              mime_type: 'mkv',
               provider_url: 'http://upstream.com',
               provider_user: 'puser',
               provider_pass: 'ppass',
               backup_urls: null,
               user_agent: 'TestAgent',
-            }),
+              provider_id: 100,
+              provider_max_connections: 10,
+              granted_by_admin: 0,
+              category_owner_id: 1,
+              provider_owner_id: 1,
+              ...(streamDbState.channelOverrides[streamId] || {}),
+            })),
           };
         }
         if (query.includes('FROM providers WHERE user_id = ? AND url LIKE ?')) {
             return {
-                all: vi.fn().mockReturnValue([{
-                    id: 100,
-                    user_id: 1,
-                    url: 'http://upstream.com',
-                    username: 'puser',
-                    password: 'ppass',
-                    max_connections: 10
-                }])
+                all: vi.fn(() => streamDbState.providerPool)
             };
         }
         if (query.includes('SELECT id FROM stream_stats')) {
@@ -125,7 +130,8 @@ vi.mock('../../src/utils/helpers.js', () => ({
   getBaseUrl: vi.fn(() => 'http://localhost'),
   isSafeUrl: vi.fn(() => Promise.resolve(true)),
   safeLookup: vi.fn((hostname, options, cb) => cb(null, '127.0.0.1', 4)),
-  providerSourceKey: vi.fn((url) => String(url || '')),
+  redactUrl: vi.fn((url) => url),
+  providerSourceKey: vi.fn((url) => String(url || '').replace(/\/+$/, '')),
 }));
 
 // We don't mock ffmpeg here because it's not strictly needed for m3u8 logic test,
@@ -159,6 +165,19 @@ describe('Stream Controller Performance (proxyLive)', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    streamDbState.channelOverrides = {};
+    streamDbState.providerPool = [{
+      id: 100,
+      user_id: 1,
+      url: 'http://upstream.com',
+      username: 'puser',
+      password: 'ppass',
+      backup_urls: null,
+      user_agent: 'TestAgent',
+      max_connections: 10,
+    }];
+    streamManager.isSessionActive.mockResolvedValue(false);
+    streamManager.getProviderConnectionCount.mockResolvedValue(0);
 
     req = {
       params: { stream_id: '1', username: 'user', password: 'pass' },
@@ -194,6 +213,85 @@ describe('Stream Controller Performance (proxyLive)', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  const sourceProvider = (overrides = {}) => ({
+    provider_id: 200,
+    provider_url: 'http://upstream.com',
+    provider_user: 'source-user',
+    provider_pass: 'source-pass',
+    backup_urls: null,
+    user_agent: 'SourceAgent',
+    provider_max_connections: 2,
+    granted_by_admin: 0,
+    category_owner_id: 1,
+    provider_owner_id: 1,
+    ...overrides,
+  });
+
+  it('keeps same-owner provider pooling behavior', async () => {
+    streamDbState.providerPool = [
+      { id: 101, url: 'http://upstream.com/', username: 'pool-user', password: 'pool-pass', max_connections: 3 },
+      { id: 200, url: 'http://upstream.com', username: 'source-user', password: 'source-pass', max_connections: 2 },
+    ];
+
+    const selected = await streamController.findAvailableProvider(1, sourceProvider(), req.ip, 'Live');
+
+    expect(selected.id).toBe(101);
+  });
+
+  it('uses an explicitly granted cross-owner source before an unrelated same-panel account', async () => {
+    streamDbState.providerPool = [
+      { id: 101, url: 'http://upstream.com', username: 'target-user', password: 'target-pass', max_connections: 3 },
+    ];
+    const source = sourceProvider({
+      granted_by_admin: 1,
+      category_owner_id: 1,
+      provider_owner_id: 2,
+      backup_urls: JSON.stringify(['http://configured-backup.example']),
+    });
+
+    const selected = await streamController.findAvailableProvider(1, source, req.ip, 'Live');
+
+    expect(selected.id).toBe(200);
+    expect(selected.backup_urls).toBe(source.backup_urls);
+  });
+
+  it('applies the cross-owner source connection limit without substituting a same-panel account', async () => {
+    streamDbState.providerPool = [
+      { id: 101, url: 'http://upstream.com', username: 'target-user', password: 'target-pass', max_connections: 3 },
+    ];
+    streamManager.getProviderConnectionCount.mockImplementation(async id => id === 200 ? 1 : 0);
+
+    const selected = await streamController.findAvailableProvider(1, sourceProvider({
+      granted_by_admin: 1,
+      category_owner_id: 1,
+      provider_owner_id: 2,
+      provider_max_connections: 1,
+    }), req.ip, 'Live');
+
+    expect(selected).toBeNull();
+    expect(streamManager.getProviderConnectionCount).toHaveBeenCalledWith(200);
+    expect(streamManager.getProviderConnectionCount).not.toHaveBeenCalledWith(101);
+  });
+
+  it('uses another account only when its URL is an explicit source backup', async () => {
+    streamDbState.providerPool = [
+      { id: 101, url: 'http://upstream.com', username: 'unrelated', password: 'unrelated', max_connections: 3 },
+      { id: 300, url: 'http://failover.example/', username: 'failover', password: 'failover-pass', max_connections: 2 },
+    ];
+    streamManager.getProviderConnectionCount.mockImplementation(async id => id === 200 ? 1 : 0);
+
+    const selected = await streamController.findAvailableProvider(1, sourceProvider({
+      granted_by_admin: 1,
+      category_owner_id: 1,
+      provider_owner_id: 2,
+      provider_max_connections: 1,
+      backup_urls: JSON.stringify(['http://failover.example']),
+    }), req.ip, 'Live');
+
+    expect(selected.id).toBe(300);
+    expect(streamManager.getProviderConnectionCount).not.toHaveBeenCalledWith(101);
   });
 
   it('should NOT call streamManager.add/cleanupUser/remove for standard .m3u8 requests', async () => {
@@ -243,9 +341,9 @@ describe('Stream Controller Performance (proxyLive)', () => {
     vi.useRealTimers();
   });
 
-  it('should proxy MKV VOD range requests without browser auto-transcode', async () => {
-    req.params.ext = 'mkv';
-    req.path = '/movie/user/pass/1.mkv';
+  it('uses the stored MKV extension when the public movie suffix differs', async () => {
+    req.params.ext = 'ts';
+    req.path = '/movie/user/pass/1.ts';
     req.headers = {
       range: 'bytes=100-200',
       'user-agent': 'Mozilla/5.0 Firefox/140',
@@ -281,6 +379,135 @@ describe('Stream Controller Performance (proxyLive)', () => {
     expect(res.status).toHaveBeenCalledWith(206);
     expect(res.setHeader).toHaveBeenCalledWith('Content-Range', 'bytes 100-200/1000');
     expect(res.setHeader).toHaveBeenCalledWith('Accept-Ranges', 'bytes');
+  });
+
+  it('falls back to MP4 when stored movie metadata has no extension', async () => {
+    streamDbState.channelOverrides[2] = { mime_type: '' };
+    req.params = { ...req.params, stream_id: '2', ext: 'ts' };
+    req.path = '/movie/user/pass/2.ts';
+    res.headersSent = false;
+
+    await streamController.proxyMovie(req, res);
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/movie/puser/ppass/remote2.mp4'),
+      expect.any(Object)
+    );
+  });
+
+  it('ignores a malformed public movie extension', async () => {
+    req.params.ext = 'ts%0a%23EXTINF';
+    req.path = '/movie/user/pass/1.ts%0a%23EXTINF';
+    res.headersSent = false;
+
+    await streamController.proxyMovie(req, res);
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/movie/puser/ppass/remote1.mkv'),
+      expect.any(Object)
+    );
+    expect(fetch.mock.calls[0][0]).not.toContain('EXTINF');
+  });
+
+  it('uses the stored extension for movie backup URLs', async () => {
+    const backupUrls = JSON.stringify(['http://backup.example']);
+    streamDbState.channelOverrides[3] = {
+      mime_type: 'mkv',
+      backup_urls: backupUrls
+    };
+    streamDbState.providerPool[0].backup_urls = backupUrls;
+    req.params = { ...req.params, stream_id: '3', ext: 'ts' };
+    req.path = '/movie/user/pass/3.ts';
+    res.headersSent = false;
+    fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      headers: { get: vi.fn() },
+      body: { destroy: vi.fn() },
+    }).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      headers: { get: vi.fn() },
+      body: { pipe: vi.fn(), on: vi.fn(), destroy: vi.fn() },
+    });
+
+    await streamController.proxyMovie(req, res);
+
+    expect(fetch.mock.calls.map(call => call[0])).toEqual([
+      'http://upstream.com/movie/puser/ppass/remote3.mkv',
+      'http://backup.example/movie/puser/ppass/remote3.mkv'
+    ]);
+  });
+
+  it('proxies a cross-owner movie through the exact granted source account', async () => {
+    streamDbState.channelOverrides[4] = {
+      mime_type: 'mp4',
+      provider_id: 200,
+      provider_url: 'http://source.example',
+      provider_user: 'source-user',
+      provider_pass: 'source-pass',
+      provider_max_connections: 2,
+      backup_urls: JSON.stringify(['http://source-backup.example']),
+      granted_by_admin: 1,
+      category_owner_id: 1,
+      provider_owner_id: 2,
+    };
+    streamDbState.providerPool = [{
+      id: 101,
+      url: 'http://source.example',
+      username: 'target-user',
+      password: 'target-pass',
+      max_connections: 5,
+    }];
+    req.params = { ...req.params, stream_id: '4', ext: 'ts' };
+    res.headersSent = false;
+
+    await streamController.proxyMovie(req, res);
+
+    expect(fetch).toHaveBeenCalledWith(
+      'http://source.example/movie/source-user/source-pass/remote4.mp4',
+      expect.any(Object)
+    );
+  });
+
+  it('proxies through an explicitly compatible cross-owner account failover', async () => {
+    streamDbState.channelOverrides[5] = {
+      mime_type: 'mp4',
+      provider_id: 200,
+      provider_url: 'http://source.example',
+      provider_user: 'source-user',
+      provider_pass: 'source-pass',
+      provider_max_connections: 1,
+      backup_urls: JSON.stringify(['http://failover.example']),
+      granted_by_admin: 1,
+      category_owner_id: 1,
+      provider_owner_id: 2,
+    };
+    streamDbState.providerPool = [
+      { id: 101, url: 'http://source.example', username: 'unrelated', password: 'unrelated', max_connections: 5 },
+      { id: 300, url: 'http://failover.example', username: 'failover-user', password: 'failover-pass', max_connections: 2, backup_urls: null },
+    ];
+    streamManager.getProviderConnectionCount.mockImplementation(async id => id === 200 ? 1 : 0);
+    req.params = { ...req.params, stream_id: '5', ext: 'ts' };
+    res.headersSent = false;
+
+    await streamController.proxyMovie(req, res);
+
+    expect(fetch).toHaveBeenCalledWith(
+      'http://failover.example/movie/failover-user/failover-pass/remote5.mp4',
+      expect.any(Object)
+    );
+  });
+
+  it('uses the stored extension for movie transcoding', async () => {
+    req.params.ext = 'ts';
+    req.query.transcode = 'true';
+    req.path = '/movie/user/pass/1.ts';
+    res.headersSent = false;
+
+    await streamController.proxyMovie(req, res);
+
+    expect(ffmpeg).toHaveBeenCalledWith('http://upstream.com/movie/puser/ppass/remote1.mkv');
   });
 
   it('uses the stored MKV extension when the public series suffix differs', async () => {
@@ -432,6 +659,7 @@ Input #0, matroska,webm, from 'movie.mkv':
 
     expect(streamManager.add).not.toHaveBeenCalled();
     expect(spawn).toHaveBeenCalled();
+    expect(spawn.mock.calls[0][1]).toContain('http://upstream.com/movie/puser/ppass/remote1.mkv');
     expect(res.json).toHaveBeenCalledWith({
       audio: [
         { index: 1, language: 'deu', codec: 'ac3', label: 'deu - ac3' },
@@ -473,6 +701,7 @@ Input #0, matroska,webm, from 'movie.mkv':
 
     expect(streamManager.add).not.toHaveBeenCalled();
     expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/vtt; charset=utf-8');
+    expect(spawn.mock.calls[0][1]).toContain('http://upstream.com/movie/puser/ppass/remote1.mkv');
     expect(spawn).toHaveBeenCalledWith(
       expect.any(String),
       expect.arrayContaining(['-map', '0:3', '-f', 'webvtt', '-']),

--- a/tests/controllers/sync_config_authorization.test.js
+++ b/tests/controllers/sync_config_authorization.test.js
@@ -1,0 +1,157 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+const { memDb } = vi.hoisted(() => {
+  const Database = require('better-sqlite3');
+  return { memDb: new Database(':memory:') };
+});
+memDb.exec(`
+  CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT);
+  CREATE TABLE providers (id INTEGER PRIMARY KEY, user_id INTEGER);
+  CREATE TABLE sync_configs (
+    id INTEGER PRIMARY KEY, provider_id INTEGER UNIQUE, user_id INTEGER,
+    enabled INTEGER, sync_interval TEXT, next_sync INTEGER,
+    auto_add_categories INTEGER, auto_add_channels INTEGER,
+    sync_series_episodes INTEGER, granted_by_admin INTEGER NOT NULL DEFAULT 0
+  );
+`);
+
+vi.mock('../../src/database/db.js', () => ({ default: memDb }));
+vi.mock('../../src/services/syncService.js', () => ({ calculateNextSync: vi.fn(() => 12345) }));
+vi.mock('../../src/services/streamManager.js', () => ({ default: {} }));
+vi.mock('../../src/utils/crypto.js', () => ({
+  encryptWithPassword: vi.fn(),
+  decryptWithPassword: vi.fn(),
+  decrypt: vi.fn(value => value),
+  encrypt: vi.fn(value => value),
+}));
+vi.mock('../../src/services/logoResolver.js', () => ({ getEpgLogo: vi.fn(), loadEpgLogosCache: vi.fn() }));
+vi.mock('../../src/services/geoIpUpdateService.js', () => ({
+  getGeoIpUpdatePlan: vi.fn(),
+  reloadGeoIpData: vi.fn(),
+  runGeoIpUpdateProcess: vi.fn(),
+}));
+vi.mock('systeminformation', () => ({
+  default: {
+    networkStats: vi.fn().mockResolvedValue([]),
+    currentLoad: vi.fn(), cpu: vi.fn(), mem: vi.fn(), fsSize: vi.fn(),
+  },
+}));
+
+import { createSyncConfig, updateSyncConfig } from '../../src/controllers/systemController.js';
+
+const response = () => ({
+  status: vi.fn().mockReturnThis(),
+  json: vi.fn(),
+});
+
+describe('sync config administrator authorization', () => {
+  beforeEach(() => {
+    memDb.prepare('DELETE FROM sync_configs').run();
+    memDb.prepare('DELETE FROM providers').run();
+    memDb.prepare('DELETE FROM users').run();
+    memDb.prepare("INSERT INTO users (id, username) VALUES (1, 'owner'), (2, 'target')").run();
+    memDb.prepare('INSERT INTO providers (id, user_id) VALUES (10, 1)').run();
+  });
+
+  it('normalizes a same-owner config to granted_by_admin = 0', () => {
+    const req = {
+      user: { is_admin: true },
+      body: { provider_id: 10, user_id: 1, enabled: true, allow_cross_owner: true },
+    };
+    const res = response();
+
+    createSyncConfig(req, res);
+
+    expect(res.json).toHaveBeenCalledWith({ id: expect.any(Number) });
+    expect(memDb.prepare('SELECT enabled, granted_by_admin FROM sync_configs').get()).toEqual({
+      enabled: 1,
+      granted_by_admin: 0,
+    });
+  });
+
+  it('persists an intentional cross-owner administrator grant', () => {
+    const req = {
+      user: { is_admin: true },
+      body: { provider_id: 10, user_id: 2, enabled: true, allow_cross_owner: true },
+    };
+    const res = response();
+
+    createSyncConfig(req, res);
+
+    expect(memDb.prepare('SELECT enabled, granted_by_admin FROM sync_configs').get()).toEqual({
+      enabled: 1,
+      granted_by_admin: 1,
+    });
+  });
+
+  it('stores a declined cross-owner config disabled and ungranted', () => {
+    const req = {
+      user: { is_admin: true },
+      body: { provider_id: 10, user_id: 2, enabled: true, allow_cross_owner: false },
+    };
+    const res = response();
+
+    createSyncConfig(req, res);
+
+    expect(memDb.prepare('SELECT enabled, granted_by_admin FROM sync_configs').get()).toEqual({
+      enabled: 0,
+      granted_by_admin: 0,
+    });
+  });
+
+  it('cannot enable an unapproved cross-owner config without explicit approval', () => {
+    memDb.prepare(`
+      INSERT INTO sync_configs
+        (id, provider_id, user_id, enabled, sync_interval, auto_add_categories,
+         auto_add_channels, sync_series_episodes, granted_by_admin)
+      VALUES (7, 10, 2, 0, 'daily', 1, 1, 1, 0)
+    `).run();
+    const res = response();
+
+    updateSyncConfig({ user: { is_admin: true }, params: { id: 7 }, body: { enabled: true } }, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(memDb.prepare('SELECT enabled, granted_by_admin FROM sync_configs WHERE id = 7').get()).toEqual({
+      enabled: 0,
+      granted_by_admin: 0,
+    });
+  });
+
+  it('can explicitly approve and later revoke a cross-owner config', () => {
+    memDb.prepare(`
+      INSERT INTO sync_configs
+        (id, provider_id, user_id, enabled, sync_interval, auto_add_categories,
+         auto_add_channels, sync_series_episodes, granted_by_admin)
+      VALUES (7, 10, 2, 0, 'daily', 1, 1, 1, 0)
+    `).run();
+
+    updateSyncConfig(
+      { user: { is_admin: true }, params: { id: 7 }, body: { enabled: true, allow_cross_owner: true } },
+      response()
+    );
+    expect(memDb.prepare('SELECT enabled, granted_by_admin FROM sync_configs WHERE id = 7').get()).toEqual({
+      enabled: 1,
+      granted_by_admin: 1,
+    });
+
+    updateSyncConfig(
+      { user: { is_admin: true }, params: { id: 7 }, body: { allow_cross_owner: false } },
+      response()
+    );
+    expect(memDb.prepare('SELECT enabled, granted_by_admin FROM sync_configs WHERE id = 7').get()).toEqual({
+      enabled: 0,
+      granted_by_admin: 0,
+    });
+  });
+
+  it('rejects normal users and missing references', () => {
+    const denied = response();
+    createSyncConfig({ user: { is_admin: false }, body: { provider_id: 10, user_id: 1 } }, denied);
+    expect(denied.status).toHaveBeenCalledWith(403);
+
+    const missing = response();
+    createSyncConfig({ user: { is_admin: true }, body: { provider_id: 99, user_id: 1 } }, missing);
+    expect(missing.status).toHaveBeenCalledWith(404);
+  });
+
+  afterAll(() => memDb.close());
+});

--- a/tests/controllers/sync_config_authorization.test.js
+++ b/tests/controllers/sync_config_authorization.test.js
@@ -83,19 +83,17 @@ describe('sync config administrator authorization', () => {
     });
   });
 
-  it('stores a declined cross-owner config disabled and ungranted', () => {
+  it.each([undefined, false])('rejects a cross-owner config unless approval is exactly true (%s)', (allowCrossOwner) => {
     const req = {
       user: { is_admin: true },
-      body: { provider_id: 10, user_id: 2, enabled: true, allow_cross_owner: false },
+      body: { provider_id: 10, user_id: 2, enabled: true, allow_cross_owner: allowCrossOwner },
     };
     const res = response();
 
     createSyncConfig(req, res);
 
-    expect(memDb.prepare('SELECT enabled, granted_by_admin FROM sync_configs').get()).toEqual({
-      enabled: 0,
-      granted_by_admin: 0,
-    });
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(memDb.prepare('SELECT id FROM sync_configs').get()).toBeUndefined();
   });
 
   it('cannot enable an unapproved cross-owner config without explicit approval', () => {

--- a/tests/controllers/xtream_channels_json.test.js
+++ b/tests/controllers/xtream_channels_json.test.js
@@ -11,6 +11,7 @@ const { mockDb } = vi.hoisted(() => {
 
 vi.mock('../../src/database/db.js', () => ({
   default: mockDb,
+  openDbConnection: vi.fn(() => ({ prepare: mockDb.prepare, close: vi.fn() })),
 }));
 
 vi.mock('node-fetch', () => ({

--- a/tests/controllers/xtream_channels_json.test.js
+++ b/tests/controllers/xtream_channels_json.test.js
@@ -22,6 +22,10 @@ vi.mock('../../src/services/authService.js', () => ({
   getXtreamUser: vi.fn(),
 }));
 
+vi.mock('../../src/services/cacheService.js', () => ({
+  channelsJsonCache: new Map(),
+}));
+
 vi.mock('../../src/services/epgService.js', () => ({
   getEpgPrograms: vi.fn(),
   getEpgProgramsForChannels: vi.fn(),
@@ -35,6 +39,7 @@ vi.mock('../../src/utils/crypto.js', () => ({
 vi.mock('../../src/utils/helpers.js', () => ({
   getBaseUrl: vi.fn().mockReturnValue('http://localhost'),
   safeLookup: vi.fn((hostname, options, callback) => callback(null, '127.0.0.1', 4)),
+  providerSourceKey: vi.fn(url => `source:${url}`),
 }));
 
 vi.mock('../../src/config/constants.js', () => ({
@@ -46,12 +51,14 @@ vi.mock('../../src/config/constants.js', () => ({
 // Import the controller after mocking
 import { playerChannelsJson } from '../../src/controllers/xtreamController.js';
 import { getXtreamUser } from '../../src/services/authService.js';
+import { channelsJsonCache } from '../../src/services/cacheService.js';
 
 describe('xtreamController - playerChannelsJson', () => {
   let req, res;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    channelsJsonCache.clear();
     req = {
       query: {},
       params: {},
@@ -131,6 +138,56 @@ describe('xtreamController - playerChannelsJson', () => {
     const output = JSON.parse(res.send.mock.calls[0][0]);
 
     expect(output[0].url).toBe('http://localhost/live/mpd/token/auth/101/manifest.mpd?token=dash-test');
-    expect(output[0].container_extension).toBe('dash');
+    expect(output[0].container_extension).toBe('mpd');
+  });
+
+  it('emits synchronized series episodes only through compact aliases', async () => {
+    getXtreamUser.mockResolvedValue({ id: 1, is_share_guest: false });
+    const channels = [
+      {
+        user_channel_id: 42,
+        remote_stream_id: 500,
+        provider_id: 7,
+        provider_url: 'http://panel.test',
+        name: 'Synced',
+        stream_type: 'series',
+        category_name: 'Series',
+      },
+      {
+        user_channel_id: 43,
+        remote_stream_id: 501,
+        provider_id: 7,
+        provider_url: 'http://panel.test',
+        name: 'Unsynced',
+        stream_type: 'series',
+        category_name: 'Series',
+      },
+    ];
+
+    mockDb.prepare.mockImplementation(sql => {
+      if (sql.includes('FROM provider_series_episodes')) {
+        return {
+          all: vi.fn((_sourceKey, seriesId) => seriesId === 500
+            ? [{ remote_episode_id: 9, season: 1, episode_num: 2, container_extension: '.MKV', logo: '' }]
+            : []),
+        };
+      }
+      if (sql.includes('INSERT OR IGNORE INTO series_episode_aliases')) return { run: vi.fn() };
+      if (sql.includes('SELECT id FROM series_episode_aliases')) return { get: vi.fn(() => ({ id: 900000009 })) };
+      return { iterate: vi.fn(() => channels) };
+    });
+
+    await playerChannelsJson(req, res);
+
+    const output = JSON.parse(res.send.mock.calls[0][0]);
+    expect(output).toHaveLength(1);
+    expect(output[0]).toMatchObject({
+      name: 'Synced S01 E02',
+      type: 'series',
+      container_extension: 'mkv',
+      url: 'http://localhost/series/token/auth/900000009.mkv',
+    });
+    expect(JSON.stringify(output)).not.toContain('/42.');
+    expect(JSON.stringify(output)).not.toContain('/43.');
   });
 });

--- a/tests/controllers/xtream_epg_batch.test.js
+++ b/tests/controllers/xtream_epg_batch.test.js
@@ -8,6 +8,7 @@ const { mockDb } = vi.hoisted(() => ({
 
 vi.mock('../../src/database/db.js', () => ({
   default: mockDb,
+  openDbConnection: vi.fn(() => ({ prepare: mockDb.prepare, close: vi.fn() })),
 }));
 
 vi.mock('../../src/services/authService.js', () => ({

--- a/tests/controllers/xtream_get_playlist.test.js
+++ b/tests/controllers/xtream_get_playlist.test.js
@@ -147,9 +147,9 @@ describe('xtreamController - getPlaylist (get.php)', () => {
     expect(output).toContain(',My Show S01 E01\n');
     expect(output).toContain('tvg-name="My Show S01 E02"');
 
-    // Encoded episode URL: providerId * 1e9 + remote_episode_id, episode container
-    expect(output).toContain('http://localhost/series/u/p/7000000123.mkv');
-    expect(output).toContain('http://localhost/series/u/p/7000000124.mkv');
+    // Encoded episode URL: userChannelId * 1e9 + remote_episode_id
+    expect(output).toContain('http://localhost/series/u/p/42000000123.mkv');
+    expect(output).toContain('http://localhost/series/u/p/42000000124.mkv');
 
     // No series-level URL for the expanded series
     expect(output).not.toContain('/series/u/p/42.');
@@ -184,7 +184,7 @@ describe('xtreamController - getPlaylist (get.php)', () => {
 
     const output = collectOutput();
     expect(output).toContain('#EXTINF:-1,My Show S01 E01\n');
-    expect(output).toContain('http://localhost/series/u/p/7000000123.mkv');
+    expect(output).toContain('http://localhost/series/u/p/42000000123.mkv');
     expect(output).not.toContain('tvg-name="My Show S01 E01"');
   });
 });

--- a/tests/controllers/xtream_get_playlist.test.js
+++ b/tests/controllers/xtream_get_playlist.test.js
@@ -140,6 +140,7 @@ describe('xtreamController - getPlaylist (get.php)', () => {
     await getPlaylist(req, res);
 
     const output = collectOutput();
+    expect(mockDb.prepare.mock.calls.some(([sql]) => sql.includes('JOIN authorized_user_channels uc'))).toBe(true);
 
     // Episode entries with SXX EXX naming
     expect(output).toContain('tvg-name="My Show S01 E01"');

--- a/tests/controllers/xtream_get_playlist.test.js
+++ b/tests/controllers/xtream_get_playlist.test.js
@@ -1,16 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock dependencies
-const { mockDb } = vi.hoisted(() => {
+const { mockDb, aliasDb } = vi.hoisted(() => {
   return {
     mockDb: {
       prepare: vi.fn(),
+    },
+    aliasDb: {
+      prepare: vi.fn(),
+      close: vi.fn(),
     },
   };
 });
 
 vi.mock('../../src/database/db.js', () => ({
   default: mockDb,
+  openDbConnection: vi.fn(() => aliasDb),
 }));
 
 vi.mock('node-fetch', () => ({
@@ -116,6 +121,20 @@ describe('xtreamController - getPlaylist (get.php)', () => {
 
     getXtreamUser.mockResolvedValue({ id: 1, is_share_guest: false });
 
+    aliasDb.prepare.mockImplementation((sql) => {
+      if (sql.includes('INSERT OR IGNORE INTO series_episode_aliases')) {
+        return { run: vi.fn() };
+      }
+      if (sql.includes('SELECT id FROM series_episode_aliases')) {
+        return {
+          get: vi.fn((_userChannelId, _sourceKey, _seriesRemoteId, remoteEpisodeId) => ({
+            id: remoteEpisodeId === 123 ? 900000501 : 900000502,
+          })),
+        };
+      }
+      throw new Error(`Unexpected alias SQL: ${sql}`);
+    });
+
     mockDb.prepare.mockImplementation((sql) => {
       if (sql.includes('provider_series_episodes')) {
         return {
@@ -136,7 +155,7 @@ describe('xtreamController - getPlaylist (get.php)', () => {
 
   const collectOutput = () => res.write.mock.calls.map((c) => c[0]).join('');
 
-  it('expands series into one entry per episode with encoded episode IDs', async () => {
+  it('expands series into one entry per episode with compact aliases', async () => {
     await getPlaylist(req, res);
 
     const output = collectOutput();
@@ -147,9 +166,9 @@ describe('xtreamController - getPlaylist (get.php)', () => {
     expect(output).toContain(',My Show S01 E01\n');
     expect(output).toContain('tvg-name="My Show S01 E02"');
 
-    // Encoded episode URL: userChannelId * 1e9 + remote_episode_id
-    expect(output).toContain('http://localhost/series/u/p/42000000123.mkv');
-    expect(output).toContain('http://localhost/series/u/p/42000000124.mkv');
+    expect(output).toContain('http://localhost/series/u/p/900000501.mkv');
+    expect(output).toContain('http://localhost/series/u/p/900000502.mkv');
+    expect(aliasDb.close).toHaveBeenCalledTimes(1);
 
     // No series-level URL for the expanded series
     expect(output).not.toContain('/series/u/p/42.');
@@ -184,7 +203,7 @@ describe('xtreamController - getPlaylist (get.php)', () => {
 
     const output = collectOutput();
     expect(output).toContain('#EXTINF:-1,My Show S01 E01\n');
-    expect(output).toContain('http://localhost/series/u/p/42000000123.mkv');
+    expect(output).toContain('http://localhost/series/u/p/900000501.mkv');
     expect(output).not.toContain('tvg-name="My Show S01 E01"');
   });
 });

--- a/tests/controllers/xtream_get_playlist.test.js
+++ b/tests/controllers/xtream_get_playlist.test.js
@@ -120,6 +120,9 @@ describe('xtreamController - getPlaylist (get.php)', () => {
     };
 
     getXtreamUser.mockResolvedValue({ id: 1, is_share_guest: false });
+    episodes[0].container_extension = 'mkv';
+    episodes[1].container_extension = 'mkv';
+    movieChannel.mime_type = 'mkv';
 
     aliasDb.prepare.mockImplementation((sql) => {
       if (sql.includes('INSERT OR IGNORE INTO series_episode_aliases')) {
@@ -181,12 +184,12 @@ describe('xtreamController - getPlaylist (get.php)', () => {
     expect(output).toContain('group-title="Serien DE",My Show S01 E01');
   });
 
-  it('falls back to the legacy series entry when no episodes are synced', async () => {
+  it('omits unsynchronized series instead of emitting a bare assignment URL', async () => {
     await getPlaylist(req, res);
 
     const output = collectOutput();
-    expect(output).toContain('tvg-name="Unsynced Show"');
-    expect(output).toContain('http://localhost/series/u/p/43.mp4');
+    expect(output).not.toContain('tvg-name="Unsynced Show"');
+    expect(output).not.toContain('/series/u/p/43.');
   });
 
   it('keeps movie entries unchanged', async () => {
@@ -205,5 +208,19 @@ describe('xtreamController - getPlaylist (get.php)', () => {
     expect(output).toContain('#EXTINF:-1,My Show S01 E01\n');
     expect(output).toContain('http://localhost/series/u/p/900000501.mkv');
     expect(output).not.toContain('tvg-name="My Show S01 E01"');
+  });
+
+  it('cannot inject an extra playlist line through provider extensions', async () => {
+    episodes[0].container_extension = 'mp4\r\n#EXTINF:-1,Injected';
+    movieChannel.mime_type = 'mkv?token=secret';
+
+    await getPlaylist(req, res);
+
+    const output = collectOutput();
+    expect(output).toContain('/series/u/p/900000501.mp4');
+    expect(output).toContain('/movie/u/p/100.mp4');
+    expect(output).not.toContain('Injected');
+    expect(output).not.toContain('token=secret');
+    expect(output.split('\n').filter(line => line.startsWith('#EXTINF')).length).toBe(3);
   });
 });

--- a/tests/controllers/xtream_playlist.test.js
+++ b/tests/controllers/xtream_playlist.test.js
@@ -11,6 +11,7 @@ const { mockDb } = vi.hoisted(() => {
 
 vi.mock('../../src/database/db.js', () => ({
   default: mockDb,
+  openDbConnection: vi.fn(() => ({ prepare: mockDb.prepare, close: vi.fn() })),
 }));
 
 vi.mock('node-fetch', () => ({

--- a/tests/controllers/xtream_series_info.test.js
+++ b/tests/controllers/xtream_series_info.test.js
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockDb, upsertEpisode } = vi.hoisted(() => ({
+  upsertEpisode: { run: vi.fn() },
+  mockDb: {
+    prepare: vi.fn(),
+    transaction: vi.fn(callback => (...args) => callback(...args)),
+  },
+}));
+
+vi.mock('../../src/database/db.js', () => ({ default: mockDb }));
+vi.mock('../../src/services/authService.js', () => ({ getXtreamUser: vi.fn() }));
+vi.mock('../../src/services/epgService.js', () => ({
+  getEpgPrograms: vi.fn(),
+  getEpgProgramsForChannels: vi.fn(),
+  getEpgXmlForChannels: vi.fn(),
+}));
+vi.mock('../../src/services/cacheService.js', () => ({ channelsJsonCache: new Map() }));
+vi.mock('../../src/services/episodeCache.js', () => ({ episodeNameCache: { set: vi.fn() } }));
+vi.mock('../../src/services/logoResolver.js', () => ({
+  getEpgLogo: vi.fn(),
+  loadEpgLogosCache: vi.fn(),
+}));
+vi.mock('../../src/utils/crypto.js', () => ({ decrypt: vi.fn(value => value) }));
+vi.mock('../../src/utils/helpers.js', () => ({
+  getBaseUrl: vi.fn(() => 'http://localhost'),
+  providerSourceKey: vi.fn(url => `source:${url}`),
+}));
+vi.mock('../../src/utils/network.js', () => ({ fetchSafe: vi.fn() }));
+vi.mock('../../src/config/constants.js', () => ({ PORT: 3000 }));
+
+import { playerApi } from '../../src/controllers/xtreamController.js';
+import { getXtreamUser } from '../../src/services/authService.js';
+import { fetchSafe } from '../../src/utils/network.js';
+
+describe('Xtream get_series_info episode authorization', () => {
+  const channel = {
+    user_channel_id: 42,
+    custom_name: 'Custom Series',
+    remote_stream_id: 555,
+    url: 'http://panel.test',
+    username: 'provider-user',
+    password: 'provider-pass',
+  };
+  let req;
+  let res;
+  let getChannel;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    req = {
+      query: { action: 'get_series_info', series_id: '42', username: 'user', password: 'pass' },
+      headers: {},
+      hostname: 'localhost',
+      secure: false,
+    };
+    res = { json: vi.fn() };
+    getXtreamUser.mockResolvedValue({ id: 1, is_share_guest: false });
+    getChannel = vi.fn((seriesId, userId) => seriesId === 42 && userId === 1 ? channel : undefined);
+    mockDb.prepare.mockImplementation(sql => {
+      if (sql.includes('FROM authorized_user_channels uc')) return { get: getChannel };
+      if (sql.includes('INSERT INTO provider_series_episodes')) return upsertEpisode;
+      throw new Error(`Unexpected SQL: ${sql}`);
+    });
+    fetchSafe.mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        info: { name: 'Provider Series' },
+        episodes: {
+          1: [
+            { id: 123, season: 1, episode_num: 1, title: 'Pilot', container_extension: 'mkv', added: '10' },
+            { id: 'invalid', title: 'Invalid' },
+          ],
+        },
+      }),
+    });
+  });
+
+  it('emits assignment-bound IDs and persists the exact episode relationship', async () => {
+    await playerApi(req, res);
+
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.info.name).toBe('Custom Series');
+    expect(payload.episodes[1]).toHaveLength(1);
+    expect(payload.episodes[1][0].id).toBe('42000000123');
+    expect(upsertEpisode.run).toHaveBeenCalledWith(
+      'source:http://panel.test', 555, 123, 1, 1, 'Pilot', 'mkv', '', '10'
+    );
+    expect(mockDb.transaction).toHaveBeenCalledTimes(1);
+    expect(mockDb.prepare.mock.calls[0][0]).toContain("pc.stream_type = 'series'");
+  });
+
+  it('rejects another user assignment before contacting the provider', async () => {
+    getXtreamUser.mockResolvedValue({ id: 2, is_share_guest: false });
+
+    await playerApi(req, res);
+
+    expect(res.json).toHaveBeenCalledWith({});
+    expect(fetchSafe).not.toHaveBeenCalled();
+  });
+
+  it('scopes share guests to the explicitly shared series', async () => {
+    getXtreamUser.mockResolvedValue({ id: 1, is_share_guest: true, allowed_channels: [42] });
+    await playerApi(req, res);
+    expect(fetchSafe).toHaveBeenCalledTimes(1);
+
+    vi.clearAllMocks();
+    getXtreamUser.mockResolvedValue({ id: 1, is_share_guest: true, allowed_channels: [43] });
+    await playerApi(req, res);
+
+    expect(res.json).toHaveBeenCalledWith({});
+    expect(fetchSafe).not.toHaveBeenCalled();
+  });
+});

--- a/tests/controllers/xtream_series_info.test.js
+++ b/tests/controllers/xtream_series_info.test.js
@@ -1,14 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockDb, upsertEpisode } = vi.hoisted(() => ({
+const { mockDb, upsertEpisode, insertAlias, selectAlias } = vi.hoisted(() => ({
   upsertEpisode: { run: vi.fn() },
+  insertAlias: { run: vi.fn() },
+  selectAlias: { get: vi.fn() },
   mockDb: {
     prepare: vi.fn(),
     transaction: vi.fn(callback => (...args) => callback(...args)),
   },
 }));
 
-vi.mock('../../src/database/db.js', () => ({ default: mockDb }));
+vi.mock('../../src/database/db.js', () => ({
+  default: mockDb,
+  openDbConnection: vi.fn(() => ({ prepare: mockDb.prepare, close: vi.fn() })),
+}));
 vi.mock('../../src/services/authService.js', () => ({ getXtreamUser: vi.fn() }));
 vi.mock('../../src/services/epgService.js', () => ({
   getEpgPrograms: vi.fn(),
@@ -56,9 +61,14 @@ describe('Xtream get_series_info episode authorization', () => {
     };
     res = { json: vi.fn() };
     getXtreamUser.mockResolvedValue({ id: 1, is_share_guest: false });
+    let aliasExists = false;
+    insertAlias.run.mockImplementation(() => { aliasExists = true; });
+    selectAlias.get.mockImplementation(() => aliasExists ? { id: 900000321 } : undefined);
     getChannel = vi.fn((seriesId, userId) => seriesId === 42 && userId === 1 ? channel : undefined);
     mockDb.prepare.mockImplementation(sql => {
       if (sql.includes('FROM authorized_user_channels uc')) return { get: getChannel };
+      if (sql.includes('INSERT OR IGNORE INTO series_episode_aliases')) return insertAlias;
+      if (sql.includes('SELECT id FROM series_episode_aliases')) return selectAlias;
       if (sql.includes('INSERT INTO provider_series_episodes')) return upsertEpisode;
       throw new Error(`Unexpected SQL: ${sql}`);
     });
@@ -76,16 +86,20 @@ describe('Xtream get_series_info episode authorization', () => {
     });
   });
 
-  it('emits assignment-bound IDs and persists the exact episode relationship', async () => {
+  it('emits compact persistent aliases and persists the exact episode relationship', async () => {
     await playerApi(req, res);
 
     const payload = res.json.mock.calls[0][0];
     expect(payload.info.name).toBe('Custom Series');
     expect(payload.episodes[1]).toHaveLength(1);
-    expect(payload.episodes[1][0].id).toBe('42000000123');
+    expect(payload.episodes[1][0].id).toBe('900000321');
+    expect(Number(payload.episodes[1][0].id)).toBeLessThan(2 ** 31);
+    expect(insertAlias.run).toHaveBeenCalledWith(42, 'source:http://panel.test', 555, 123);
     expect(upsertEpisode.run).toHaveBeenCalledWith(
       'source:http://panel.test', 555, 123, 1, 1, 'Pilot', 'mkv', '', '10'
     );
+    expect(mockDb.prepare.mock.calls.find(([sql]) => sql.includes('INSERT INTO provider_series_episodes'))[0])
+      .toContain('ON CONFLICT(source_key, series_remote_id, remote_episode_id)');
     expect(mockDb.transaction).toHaveBeenCalledTimes(1);
     expect(mockDb.prepare.mock.calls[0][0]).toContain("pc.stream_type = 'series'");
   });

--- a/tests/controllers/xtream_share_compat.test.js
+++ b/tests/controllers/xtream_share_compat.test.js
@@ -108,6 +108,7 @@ describe('xtreamController share compatibility', () => {
     await getPlaylist(req, res);
 
     const payload = res.write.mock.calls.map(call => call[0]).join('');
+    expect(mockDb.prepare).toHaveBeenCalledWith(expect.stringContaining('JOIN authorized_user_channels uc'));
     expect(payload).toContain('url-tvg="http://localhost/xmltv.php?token=share-token"');
     expect(payload).toContain('http://localhost/live/token/auth/100.ts?token=share-token');
   });
@@ -199,6 +200,7 @@ describe('xtreamController share compatibility', () => {
     await xmltv(req, res);
 
     expect(mockDb.prepare).toHaveBeenCalledWith(expect.stringContaining('uc.id IN (?,?)'));
+    expect(mockDb.prepare).toHaveBeenCalledWith(expect.stringContaining('FROM authorized_user_channels uc'));
     const xml = res.write.mock.calls.map(call => call[0]).join('');
     expect(xml).toContain('<channel id="news.epg">');
   });

--- a/tests/controllers/xtream_share_compat.test.js
+++ b/tests/controllers/xtream_share_compat.test.js
@@ -10,6 +10,7 @@ const { mockDb } = vi.hoisted(() => ({
 
 vi.mock('../../src/database/db.js', () => ({
   default: mockDb,
+  openDbConnection: vi.fn(() => ({ prepare: mockDb.prepare, close: vi.fn() })),
 }));
 
 vi.mock('../../src/services/authService.js', () => ({

--- a/tests/controllers/xtream_vod_info.test.js
+++ b/tests/controllers/xtream_vod_info.test.js
@@ -12,6 +12,7 @@ const { mockDb, mockFetch } = vi.hoisted(() => {
 
 vi.mock('../../src/database/db.js', () => ({
   default: mockDb,
+  openDbConnection: vi.fn(() => ({ prepare: mockDb.prepare, close: vi.fn() })),
 }));
 
 vi.mock('node-fetch', () => ({

--- a/tests/epg_streaming.test.js
+++ b/tests/epg_streaming.test.js
@@ -1,16 +1,20 @@
 import { describe, it, expect, beforeAll, afterAll, vi, beforeEach } from 'vitest';
-import path from 'path';
+import fs from 'fs';
 import { Readable } from 'stream';
+
+const { TEST_DATA_DIR } = vi.hoisted(() => {
+  const fsModule = require('fs');
+  const osModule = require('os');
+  const pathModule = require('path');
+  return { TEST_DATA_DIR: fsModule.mkdtempSync(pathModule.join(osModule.tmpdir(), 'iptv-epg-streaming-')) };
+});
 
 // Mock constants BEFORE imports
 vi.mock('../src/config/constants.js', async () => {
   const path = await import('path');
-  const fs = await import('fs');
-  const dir = path.resolve('temp_test_epg_data');
-  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
   return {
-    DATA_DIR: dir,
-    EPG_DB_PATH: path.resolve('temp_test_epg_data/epg.db')
+    DATA_DIR: TEST_DATA_DIR,
+    EPG_DB_PATH: path.join(TEST_DATA_DIR, 'epg.db')
   };
 });
 
@@ -21,7 +25,7 @@ vi.mock('../src/utils/network.js', () => ({
   httpsAgent: {}
 }));
 
-import { initDb } from '../src/database/db.js';
+import db, { initDb } from '../src/database/db.js';
 import { initEpgDb, default as epgDb } from '../src/database/epgDb.js';
 import { loadAllEpgChannels, importEpgFromUrl } from '../src/services/epgService.js';
 import { fetchSafe } from '../src/utils/network.js';
@@ -37,6 +41,12 @@ describe('EPG Streaming Optimization', () => {
     epgDb.prepare('DELETE FROM epg_channels').run();
     epgDb.prepare('DELETE FROM epg_programs').run();
     vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    epgDb.close();
+    db.close();
+    fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
   });
 
   it('should correctly parse pretty-printed channels from EPG stream', async () => {

--- a/tests/export_regression.test.js
+++ b/tests/export_regression.test.js
@@ -14,6 +14,7 @@ describe('Export/Import Regression Tests', () => {
     let encrypt;
     let decrypt;
     let decryptWithPassword;
+    let encryptWithPassword;
     let testDataDir;
     let tempFilePath;
 
@@ -30,6 +31,7 @@ describe('Export/Import Regression Tests', () => {
         encrypt = cryptoModule.encrypt;
         decrypt = cryptoModule.decrypt;
         decryptWithPassword = cryptoModule.decryptWithPassword;
+        encryptWithPassword = cryptoModule.encryptWithPassword;
 
         const { initDb } = dbModule;
         initDb(true);
@@ -168,5 +170,94 @@ describe('Export/Import Regression Tests', () => {
 
         // Should contain plaintext because decrypt(plaintext) returns null, so it falls back to original
         expect(exportedProvider.password).toBe(TEST_PROVIDER_PLAINTEXT);
+    });
+
+    it('normalizes imported grants against the rebuilt ownership relationships', async () => {
+        db.prepare('PRAGMA foreign_keys = OFF').run();
+        for (const table of ['user_channels', 'category_mappings', 'sync_configs', 'provider_channels', 'providers', 'user_categories', 'users']) {
+            db.prepare(`DELETE FROM ${table}`).run();
+        }
+        db.prepare('PRAGMA foreign_keys = ON').run();
+
+        const ownerId = db.prepare("INSERT INTO users (username, password) VALUES ('import_owner', 'pass')").run().lastInsertRowid;
+        const targetId = db.prepare("INSERT INTO users (username, password) VALUES ('import_target', 'pass')").run().lastInsertRowid;
+        const providerId = db.prepare(`
+            INSERT INTO providers (name, url, username, password, user_id)
+            VALUES ('Shared Provider', 'http://shared.example', 'u', ?, ?)
+        `).run(encrypt('provider-pass'), ownerId).lastInsertRowid;
+        const sameOwnerProviderId = db.prepare(`
+            INSERT INTO providers (name, url, username, password, user_id)
+            VALUES ('Owner Provider', 'http://owner.example', 'u', ?, ?)
+        `).run(encrypt('provider-pass'), ownerId).lastInsertRowid;
+        const channelA = db.prepare(`
+            INSERT INTO provider_channels (provider_id, remote_stream_id, name, stream_type)
+            VALUES (?, 101, 'Series A', 'series')
+        `).run(providerId).lastInsertRowid;
+        const channelB = db.prepare(`
+            INSERT INTO provider_channels (provider_id, remote_stream_id, name, stream_type)
+            VALUES (?, 102, 'Series B', 'series')
+        `).run(providerId).lastInsertRowid;
+        const sameCategory = db.prepare("INSERT INTO user_categories (user_id, name, type) VALUES (?, 'Same owner', 'series')").run(ownerId).lastInsertRowid;
+        const grantedCategory = db.prepare("INSERT INTO user_categories (user_id, name, type) VALUES (?, 'Cross granted', 'series')").run(targetId).lastInsertRowid;
+        const ungrantedCategory = db.prepare("INSERT INTO user_categories (user_id, name, type) VALUES (?, 'Cross ungranted', 'series')").run(targetId).lastInsertRowid;
+
+        db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, granted_by_admin) VALUES (?, ?, 1)').run(sameCategory, channelA);
+        db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, granted_by_admin) VALUES (?, ?, 1)').run(grantedCategory, channelA);
+        db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, granted_by_admin) VALUES (?, ?, 0)').run(ungrantedCategory, channelB);
+        db.prepare("INSERT INTO sync_configs (provider_id, user_id, enabled, granted_by_admin) VALUES (?, ?, 1, 1)").run(providerId, targetId);
+        db.prepare("INSERT INTO sync_configs (provider_id, user_id, enabled, granted_by_admin) VALUES (?, ?, 1, 1)").run(sameOwnerProviderId, ownerId);
+
+        let exportedBuffer;
+        systemController.exportData(
+            { user: { is_admin: true }, body: { password: TEST_EXPORT_PASSWORD, user_id: 'all' }, query: {} },
+            { setHeader: vi.fn(), status: vi.fn().mockReturnThis(), json: vi.fn(), send: vi.fn(buffer => { exportedBuffer = buffer; }) }
+        );
+
+        const exportedData = JSON.parse(zlib.gunzipSync(decryptWithPassword(exportedBuffer, TEST_EXPORT_PASSWORD)).toString('utf8'));
+        exportedData.channels.push({
+            id: 999999,
+            type: 'user_assignment',
+            user_category_id: grantedCategory,
+            provider_channel_id: 999999,
+            granted_by_admin: 1,
+            is_hidden: 0,
+        });
+        exportedBuffer = encryptWithPassword(zlib.gzipSync(JSON.stringify(exportedData)), TEST_EXPORT_PASSWORD);
+        fs.writeFileSync(tempFilePath, exportedBuffer);
+
+        db.prepare('PRAGMA foreign_keys = OFF').run();
+        for (const table of ['user_channels', 'category_mappings', 'sync_configs', 'provider_channels', 'providers', 'user_categories', 'users']) {
+            db.prepare(`DELETE FROM ${table}`).run();
+        }
+        db.prepare('PRAGMA foreign_keys = ON').run();
+
+        const resImport = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+        await systemController.importData(
+            { user: { is_admin: true }, body: { password: TEST_EXPORT_PASSWORD }, file: { path: tempFilePath } },
+            resImport
+        );
+
+        expect(resImport.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+        const assignments = db.prepare(`
+            SELECT cat.name, uc.is_hidden, uc.granted_by_admin
+            FROM user_channels uc
+            JOIN user_categories cat ON cat.id = uc.user_category_id
+            ORDER BY cat.name
+        `).all();
+        expect(assignments).toEqual([
+            { name: 'Cross granted', is_hidden: 0, granted_by_admin: 1 },
+            { name: 'Cross ungranted', is_hidden: 1, granted_by_admin: 0 },
+            { name: 'Same owner', is_hidden: 0, granted_by_admin: 0 },
+        ]);
+
+        const configs = db.prepare(`
+            SELECT p.name, sc.enabled, sc.granted_by_admin
+            FROM sync_configs sc JOIN providers p ON p.id = sc.provider_id
+            ORDER BY p.name
+        `).all();
+        expect(configs).toEqual([
+            { name: 'Owner Provider', enabled: 1, granted_by_admin: 0 },
+            { name: 'Shared Provider', enabled: 1, granted_by_admin: 1 },
+        ]);
     });
 });

--- a/tests/export_regression.test.js
+++ b/tests/export_regression.test.js
@@ -231,23 +231,53 @@ describe('Export/Import Regression Tests', () => {
         }
         db.prepare('PRAGMA foreign_keys = ON').run();
 
-        const resImport = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+        const failClosedImport = { status: vi.fn().mockReturnThis(), json: vi.fn() };
         await systemController.importData(
             { user: { is_admin: true }, body: { password: TEST_EXPORT_PASSWORD }, file: { path: tempFilePath } },
+            failClosedImport
+        );
+        expect(failClosedImport.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+        expect(db.prepare(`
+          SELECT uc.granted_by_admin, uc.authorization_revoked
+          FROM user_channels uc
+          JOIN user_categories cat ON cat.id = uc.user_category_id
+          WHERE cat.name = 'Cross granted'
+        `).get()).toEqual({ granted_by_admin: 0, authorization_revoked: 1 });
+        expect(db.prepare(`
+          SELECT sc.enabled, sc.granted_by_admin
+          FROM sync_configs sc
+          JOIN providers p ON p.id = sc.provider_id
+          WHERE p.name = 'Shared Provider'
+        `).get()).toEqual({ enabled: 0, granted_by_admin: 0 });
+
+        db.prepare('PRAGMA foreign_keys = OFF').run();
+        for (const table of ['user_channels', 'category_mappings', 'sync_configs', 'provider_channels', 'providers', 'user_categories', 'users']) {
+            db.prepare(`DELETE FROM ${table}`).run();
+        }
+        db.prepare('PRAGMA foreign_keys = ON').run();
+        fs.writeFileSync(tempFilePath, exportedBuffer);
+
+        const resImport = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+        await systemController.importData(
+            {
+              user: { is_admin: true },
+              body: { password: TEST_EXPORT_PASSWORD, allow_cross_owner: true },
+              file: { path: tempFilePath }
+            },
             resImport
         );
 
         expect(resImport.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
         const assignments = db.prepare(`
-            SELECT cat.name, uc.is_hidden, uc.granted_by_admin
+            SELECT cat.name, uc.is_hidden, uc.granted_by_admin, uc.authorization_revoked
             FROM user_channels uc
             JOIN user_categories cat ON cat.id = uc.user_category_id
             ORDER BY cat.name
         `).all();
         expect(assignments).toEqual([
-            { name: 'Cross granted', is_hidden: 0, granted_by_admin: 1 },
-            { name: 'Cross ungranted', is_hidden: 1, granted_by_admin: 0 },
-            { name: 'Same owner', is_hidden: 0, granted_by_admin: 0 },
+            { name: 'Cross granted', is_hidden: 0, granted_by_admin: 1, authorization_revoked: 0 },
+            { name: 'Cross ungranted', is_hidden: 0, granted_by_admin: 0, authorization_revoked: 1 },
+            { name: 'Same owner', is_hidden: 0, granted_by_admin: 0, authorization_revoked: 0 },
         ]);
 
         const configs = db.prepare(`

--- a/tests/export_regression.test.js
+++ b/tests/export_regression.test.js
@@ -261,7 +261,7 @@ describe('Export/Import Regression Tests', () => {
         await systemController.importData(
             {
               user: { is_admin: true },
-              body: { password: TEST_EXPORT_PASSWORD, allow_cross_owner: true },
+              body: { password: TEST_EXPORT_PASSWORD, allow_cross_owner: 'true' },
               file: { path: tempFilePath }
             },
             resImport

--- a/tests/functional/sync_service_category_update.test.js
+++ b/tests/functional/sync_service_category_update.test.js
@@ -83,7 +83,7 @@ describe('Sync Service Functional Tests', () => {
 
   it('should sync the live channel and assign to user category', async () => {
     // 1. Perform first sync. The mock returns a live channel with category 10 and stream_id 1234.
-    const result = await performSync(providerId, userId, true);
+    const result = await performSync(providerId, userId, { mode: 'manual', allowCrossOwner: true });
 
     expect(result.channelsAdded).toBe(1);
 
@@ -132,7 +132,7 @@ describe('Sync Service Functional Tests', () => {
     xtreamApi.Xtream.prototype.getChannels = vi.fn().mockResolvedValue([]);
 
     // Perform second sync
-    const result = await performSync(providerId, userId, true);
+    const result = await performSync(providerId, userId, { mode: 'manual', allowCrossOwner: true });
 
     expect(result.channelsUpdated).toBe(1); // The channel 1234 should have been updated
 

--- a/tests/hdhr.test.js
+++ b/tests/hdhr.test.js
@@ -104,6 +104,7 @@ describe('HDHomeRun Controller', () => {
 
             // Verify SQL filters for live streams
             expect(db.prepare).toHaveBeenCalledWith(expect.stringContaining("pc.stream_type = 'live'"));
+            expect(db.prepare).toHaveBeenCalledWith(expect.stringContaining('FROM authorized_user_channels uc'));
 
             expect(res.json).toHaveBeenCalledWith([
                 {
@@ -135,6 +136,7 @@ describe('HDHomeRun Controller', () => {
 
             await hdhrController.auto(req, res);
 
+            expect(db.prepare).toHaveBeenCalledWith(expect.stringContaining('FROM authorized_user_channels uc'));
             expect(res.redirect).toHaveBeenCalledWith('http://localhost:3000/hdhr/testtoken/stream/1.ts');
         });
 

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { isAdultCategory, getSetting, clearSettingsCache, getCookie, redactUrl, getBaseUrl, providerSourceKey } from '../src/utils/helpers.js';
+import { isAdultCategory, getSetting, clearSettingsCache, getCookie, redactUrl, getBaseUrl, providerSourceKey, resolveAssignmentGrant } from '../src/utils/helpers.js';
 
 describe('isAdultCategory', () => {
   const adultKeywords = [
@@ -229,6 +229,17 @@ describe('redactUrl', () => {
     expect(redactUrl('/api/shares/secret-token?foo=bar')).toBe('/api/shares/********?foo=bar');
   });
 
+  it('should redact public share slugs and preserve the query', () => {
+    expect(redactUrl('/share/family-tv-a8f31c92')).toBe('/share/********');
+    expect(redactUrl('/share/family-tv-a8f31c92?foo=bar')).toBe('/share/********?foo=bar');
+    expect(redactUrl('https://example.test/share/family-tv-a8f31c92?foo=bar')).toBe('https://example.test/share/********?foo=bar');
+  });
+
+  it('should not redact unrelated routes containing share', () => {
+    expect(redactUrl('/api/share/settings')).toBe('/api/share/settings');
+    expect(redactUrl('/shareholder/report')).toBe('/shareholder/report');
+  });
+
   it('should redact credential query parameters', () => {
     expect(redactUrl('/api/test?password=secret')).toBe('/api/test?password=********');
     expect(redactUrl('/api/test?foo=bar&password=secret')).toBe('/api/test?foo=bar&password=********');
@@ -254,6 +265,18 @@ describe('redactUrl', () => {
   it('should handle multiple redactions in one URL', () => {
     const mixedUrl = '/live/user/pass/1.ts?password=secret&token=123';
     expect(redactUrl(mixedUrl)).toBe('/live/user/********/1.ts?password=********&token=********');
+  });
+});
+
+describe('resolveAssignmentGrant', () => {
+  it('normalizes same-owner assignments to a normal grant', () => {
+    expect(resolveAssignmentGrant({ categoryOwnerId: 7, providerOwnerId: '7', isAdmin: true, allowExplicitAdminGrant: true })).toBe(0);
+  });
+
+  it('requires an explicit administrator grant for cross-owner assignments', () => {
+    expect(resolveAssignmentGrant({ categoryOwnerId: 7, providerOwnerId: 8 })).toBe(null);
+    expect(resolveAssignmentGrant({ categoryOwnerId: 7, providerOwnerId: 8, isAdmin: true })).toBe(null);
+    expect(resolveAssignmentGrant({ categoryOwnerId: 7, providerOwnerId: 8, isAdmin: true, allowExplicitAdminGrant: true })).toBe(1);
   });
 });
 

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -224,6 +224,11 @@ describe('redactUrl', () => {
     expect(redactUrl('http://myserver/hdhr/SECRET_TOKEN')).toBe('http://myserver/hdhr/********');
   });
 
+  it('should redact share tokens in path segments and preserve the query', () => {
+    expect(redactUrl('/api/shares/550e8400-e29b-41d4-a716-446655440000')).toBe('/api/shares/********');
+    expect(redactUrl('/api/shares/secret-token?foo=bar')).toBe('/api/shares/********?foo=bar');
+  });
+
   it('should redact credential query parameters', () => {
     expect(redactUrl('/api/test?password=secret')).toBe('/api/test?password=********');
     expect(redactUrl('/api/test?foo=bar&password=secret')).toBe('/api/test?foo=bar&password=********');
@@ -242,6 +247,8 @@ describe('redactUrl', () => {
   it('should return original URL if no sensitive info found', () => {
     const safeUrl = '/api/status?id=123';
     expect(redactUrl(safeUrl)).toBe(safeUrl);
+    expect(redactUrl('/api/users/550e8400-e29b-41d4-a716-446655440000')).toBe('/api/users/550e8400-e29b-41d4-a716-446655440000');
+    expect(redactUrl('/%E0%A4%A')).toBe('/%E0%A4%A');
   });
 
   it('should handle multiple redactions in one URL', () => {

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -224,11 +224,13 @@ describe('redactUrl', () => {
     expect(redactUrl('http://myserver/hdhr/SECRET_TOKEN')).toBe('http://myserver/hdhr/********');
   });
 
-  it('should redact password query parameters', () => {
+  it('should redact credential query parameters', () => {
     expect(redactUrl('/api/test?password=secret')).toBe('/api/test?password=********');
     expect(redactUrl('/api/test?foo=bar&password=secret')).toBe('/api/test?foo=bar&password=********');
     expect(redactUrl('/api/test?password=secret&foo=bar')).toBe('/api/test?password=********&foo=bar');
     expect(redactUrl('/api/test?PASSWORD=secret')).toBe('/api/test?PASSWORD=********');
+    expect(redactUrl('/api/test?token=jwt-secret')).toBe('/api/test?token=********');
+    expect(redactUrl('/api/test?TOKEN=jwt-secret')).toBe('/api/test?TOKEN=********');
   });
 
   it('should return non-string inputs as-is', () => {
@@ -244,7 +246,7 @@ describe('redactUrl', () => {
 
   it('should handle multiple redactions in one URL', () => {
     const mixedUrl = '/live/user/pass/1.ts?password=secret&token=123';
-    expect(redactUrl(mixedUrl)).toBe('/live/user/********/1.ts?password=********&token=123');
+    expect(redactUrl(mixedUrl)).toBe('/live/user/********/1.ts?password=********&token=********');
   });
 });
 

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -247,6 +247,9 @@ describe('redactUrl', () => {
     expect(redactUrl('/api/test?PASSWORD=secret')).toBe('/api/test?PASSWORD=********');
     expect(redactUrl('/api/test?token=jwt-secret')).toBe('/api/test?token=********');
     expect(redactUrl('/api/test?TOKEN=jwt-secret')).toBe('/api/test?TOKEN=********');
+    expect(redactUrl('/api/test?access_token=jwt-secret')).toBe('/api/test?access_token=********');
+    expect(redactUrl('/api/test?ACCESS_TOKEN=jwt-secret')).toBe('/api/test?ACCESS_TOKEN=********');
+    expect(redactUrl('/api/test?mac=00:11:22:33:44:55')).toBe('/api/test?mac=********');
   });
 
   it('should return non-string inputs as-is', () => {
@@ -263,8 +266,8 @@ describe('redactUrl', () => {
   });
 
   it('should handle multiple redactions in one URL', () => {
-    const mixedUrl = '/live/user/pass/1.ts?password=secret&token=123';
-    expect(redactUrl(mixedUrl)).toBe('/live/user/********/1.ts?password=********&token=********');
+    const mixedUrl = '/live/user/pass/1.ts?password=secret&token=123&ACCESS_TOKEN=456&mac=00:11&safe=%ZZ';
+    expect(redactUrl(mixedUrl)).toBe('/live/user/********/1.ts?password=********&token=********&ACCESS_TOKEN=********&mac=********&safe=%ZZ');
   });
 });
 

--- a/tests/managers/stream_manager_smart.test.js
+++ b/tests/managers/stream_manager_smart.test.js
@@ -77,6 +77,7 @@ describe('StreamManager Smart Limits', () => {
       // 3. User 1, Channel B, 1.1.1.1 (from '4')
       // Total 3
       expect(count).toBe(3);
+      expect(mockRedis.hGetAll).toHaveBeenCalledOnce();
     });
 
     it('should identify active sessions correctly', async () => {

--- a/tests/migration_regression.test.js
+++ b/tests/migration_regression.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import Database from 'better-sqlite3';
 import db, { initDb } from '../src/database/db.js';
 import { encrypt, decrypt } from '../src/utils/crypto.js';
-import { migrateProviderPasswords, migrateOtpSecrets, migrateUserChannelAdminGrants } from '../src/database/migrations.js';
+import { migrateProviderPasswords, migrateOtpSecrets, migrateUserChannelAdminGrants, migrateSyncConfigAdminGrants } from '../src/database/migrations.js';
 
 describe('Migration Bug Regression', () => {
     beforeAll(() => {
@@ -85,6 +85,40 @@ describe('Migration Bug Regression', () => {
             legacyDb.prepare('UPDATE user_channels SET is_hidden = 0, granted_by_admin = 1 WHERE id = 41').run();
             expect(migrateUserChannelAdminGrants(legacyDb)).toBe(0);
             expect(legacyDb.prepare('SELECT id FROM authorized_user_channels ORDER BY id').all()).toEqual([{ id: 40 }, { id: 41 }]);
+        } finally {
+            legacyDb.close();
+        }
+    });
+
+    it('disables legacy cross-owner sync configs idempotently without changing IDs', () => {
+        const legacyDb = new Database(':memory:');
+        try {
+            legacyDb.exec(`
+              CREATE TABLE providers (id INTEGER PRIMARY KEY, user_id INTEGER);
+              CREATE TABLE sync_configs (
+                id INTEGER PRIMARY KEY,
+                provider_id INTEGER NOT NULL,
+                user_id INTEGER NOT NULL,
+                enabled INTEGER DEFAULT 1
+              );
+              INSERT INTO providers (id, user_id) VALUES (10, 1), (11, 2);
+              INSERT INTO sync_configs (id, provider_id, user_id, enabled)
+                VALUES (20, 10, 1, 1), (21, 11, 1, 1);
+            `);
+
+            expect(migrateSyncConfigAdminGrants(legacyDb)).toBe(1);
+            expect(legacyDb.prepare('SELECT id, enabled, granted_by_admin FROM sync_configs ORDER BY id').all()).toEqual([
+                { id: 20, enabled: 1, granted_by_admin: 0 },
+                { id: 21, enabled: 0, granted_by_admin: 0 }
+            ]);
+
+            legacyDb.prepare('UPDATE sync_configs SET enabled = 1, granted_by_admin = 1 WHERE id = 21').run();
+            expect(migrateSyncConfigAdminGrants(legacyDb)).toBe(0);
+            expect(legacyDb.prepare('SELECT id, enabled, granted_by_admin FROM sync_configs WHERE id = 21').get()).toEqual({
+                id: 21,
+                enabled: 1,
+                granted_by_admin: 1
+            });
         } finally {
             legacyDb.close();
         }

--- a/tests/migration_regression.test.js
+++ b/tests/migration_regression.test.js
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import Database from 'better-sqlite3';
 import db, { initDb } from '../src/database/db.js';
 import { encrypt, decrypt } from '../src/utils/crypto.js';
-import { migrateProviderPasswords, migrateOtpSecrets } from '../src/database/migrations.js';
+import { migrateProviderPasswords, migrateOtpSecrets, migrateUserChannelAdminGrants } from '../src/database/migrations.js';
 
 describe('Migration Bug Regression', () => {
     beforeAll(() => {
@@ -47,5 +48,45 @@ describe('Migration Bug Regression', () => {
         const row = db.prepare('SELECT otp_secret FROM users WHERE id = ?').get(id);
         const decryptedOnce = decrypt(row.otp_secret);
         expect(decryptedOnce).toBe(secret);
+    });
+
+    it('should revoke legacy ownership mismatches idempotently without changing IDs', () => {
+        const legacyDb = new Database(':memory:');
+        try {
+            legacyDb.exec(`
+              CREATE TABLE providers (id INTEGER PRIMARY KEY, user_id INTEGER);
+              CREATE TABLE provider_channels (id INTEGER PRIMARY KEY, provider_id INTEGER NOT NULL);
+              CREATE TABLE user_categories (id INTEGER PRIMARY KEY, user_id INTEGER NOT NULL);
+              CREATE TABLE user_channels (
+                id INTEGER PRIMARY KEY,
+                user_category_id INTEGER NOT NULL,
+                provider_channel_id INTEGER NOT NULL,
+                sort_order INTEGER DEFAULT 0,
+                custom_name TEXT DEFAULT '',
+                is_hidden INTEGER DEFAULT 0
+              );
+              INSERT INTO providers (id, user_id) VALUES (10, 1);
+              INSERT INTO provider_channels (id, provider_id) VALUES (20, 10);
+              INSERT INTO user_categories (id, user_id) VALUES (30, 1), (31, 2);
+              INSERT INTO user_channels (id, user_category_id, provider_channel_id)
+                VALUES (40, 30, 20), (41, 31, 20);
+            `);
+
+            expect(migrateUserChannelAdminGrants(legacyDb)).toBe(1);
+            expect(legacyDb.prepare('SELECT id, is_hidden, granted_by_admin FROM user_channels ORDER BY id').all()).toEqual([
+                { id: 40, is_hidden: 0, granted_by_admin: 0 },
+                { id: 41, is_hidden: 1, granted_by_admin: 0 }
+            ]);
+            expect(legacyDb.prepare('SELECT id FROM authorized_user_channels ORDER BY id').all()).toEqual([{ id: 40 }]);
+
+            expect(migrateUserChannelAdminGrants(legacyDb)).toBe(0);
+            expect(legacyDb.prepare('SELECT id FROM user_channels ORDER BY id').all()).toEqual([{ id: 40 }, { id: 41 }]);
+
+            legacyDb.prepare('UPDATE user_channels SET is_hidden = 0, granted_by_admin = 1 WHERE id = 41').run();
+            expect(migrateUserChannelAdminGrants(legacyDb)).toBe(0);
+            expect(legacyDb.prepare('SELECT id FROM authorized_user_channels ORDER BY id').all()).toEqual([{ id: 40 }, { id: 41 }]);
+        } finally {
+            legacyDb.close();
+        }
     });
 });

--- a/tests/migration_regression.test.js
+++ b/tests/migration_regression.test.js
@@ -2,7 +2,13 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import Database from 'better-sqlite3';
 import db, { initDb } from '../src/database/db.js';
 import { encrypt, decrypt } from '../src/utils/crypto.js';
-import { migrateProviderPasswords, migrateOtpSecrets, migrateUserChannelAdminGrants, migrateSyncConfigAdminGrants } from '../src/database/migrations.js';
+import {
+    migrateProviderPasswords,
+    migrateOtpSecrets,
+    migrateSeriesEpisodes,
+    migrateUserChannelAdminGrants,
+    migrateSyncConfigAdminGrants
+} from '../src/database/migrations.js';
 
 describe('Migration Bug Regression', () => {
     beforeAll(() => {
@@ -70,6 +76,7 @@ describe('Migration Bug Regression', () => {
               INSERT INTO user_categories (id, user_id) VALUES (30, 1), (31, 2);
               INSERT INTO user_channels (id, user_category_id, provider_channel_id)
                 VALUES (40, 30, 20), (41, 31, 20);
+              CREATE VIEW authorized_user_channels AS SELECT * FROM user_channels;
             `);
 
             expect(migrateUserChannelAdminGrants(legacyDb)).toBe(1);
@@ -85,6 +92,57 @@ describe('Migration Bug Regression', () => {
             legacyDb.prepare('UPDATE user_channels SET is_hidden = 0, granted_by_admin = 1 WHERE id = 41').run();
             expect(migrateUserChannelAdminGrants(legacyDb)).toBe(0);
             expect(legacyDb.prepare('SELECT id FROM authorized_user_channels ORDER BY id').all()).toEqual([{ id: 40 }, { id: 41 }]);
+        } finally {
+            legacyDb.close();
+        }
+    });
+
+    it('rebuilds the episode cache with series-scoped uniqueness exactly once', () => {
+        const legacyDb = new Database(':memory:');
+        try {
+            legacyDb.exec(`
+              CREATE TABLE sync_configs (id INTEGER PRIMARY KEY);
+              CREATE TABLE provider_series_episodes (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                source_key TEXT NOT NULL,
+                series_remote_id INTEGER NOT NULL,
+                remote_episode_id INTEGER NOT NULL,
+                UNIQUE(source_key, remote_episode_id)
+              );
+              CREATE TABLE provider_series_state (
+                source_key TEXT NOT NULL,
+                series_remote_id INTEGER NOT NULL,
+                PRIMARY KEY (source_key, series_remote_id)
+              );
+              INSERT INTO provider_series_episodes
+                (source_key, series_remote_id, remote_episode_id)
+              VALUES ('source', 10, 7);
+            `);
+
+            migrateSeriesEpisodes(legacyDb);
+            expect(legacyDb.prepare('SELECT COUNT(*) AS count FROM provider_series_episodes').get().count).toBe(0);
+
+            legacyDb.prepare(`
+              INSERT INTO provider_series_episodes
+                (source_key, series_remote_id, remote_episode_id)
+              VALUES ('source', 10, 7), ('source', 11, 7)
+            `).run();
+            migrateSeriesEpisodes(legacyDb);
+
+            expect(legacyDb.prepare(`
+              SELECT series_remote_id, remote_episode_id
+              FROM provider_series_episodes
+              ORDER BY series_remote_id
+            `).all()).toEqual([
+                { series_remote_id: 10, remote_episode_id: 7 },
+                { series_remote_id: 11, remote_episode_id: 7 }
+            ]);
+            expect(legacyDb.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'series_episode_aliases'").get()).toBeTruthy();
+            expect(legacyDb.prepare(`
+              INSERT INTO series_episode_aliases
+                (user_channel_id, source_key, series_remote_id, remote_episode_id)
+              VALUES (1, 'source', 10, 7)
+            `).run().lastInsertRowid).toBe(900000001);
         } finally {
             legacyDb.close();
         }

--- a/tests/migration_regression.test.js
+++ b/tests/migration_regression.test.js
@@ -148,6 +148,8 @@ describe('Migration Bug Regression', () => {
         try {
             legacyDb.exec(`
               CREATE TABLE sync_configs (id INTEGER PRIMARY KEY);
+              CREATE TABLE user_channels (id INTEGER PRIMARY KEY);
+              INSERT INTO user_channels (id) VALUES (1);
               CREATE TABLE provider_series_episodes (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 source_key TEXT NOT NULL,
@@ -189,6 +191,58 @@ describe('Migration Bug Regression', () => {
                 (user_channel_id, source_key, series_remote_id, remote_episode_id)
               VALUES (1, 'source', 10, 7)
             `).run().lastInsertRowid).toBe(900000001);
+        } finally {
+            legacyDb.close();
+        }
+    });
+
+    it('rebuilds episode aliases with cascade, preserves valid IDs, and removes orphans idempotently', () => {
+        const legacyDb = new Database(':memory:');
+        try {
+            legacyDb.exec(`
+              CREATE TABLE sync_configs (id INTEGER PRIMARY KEY);
+              CREATE TABLE user_channels (id INTEGER PRIMARY KEY);
+              INSERT INTO user_channels (id) VALUES (1), (2);
+              CREATE TABLE series_episode_aliases (
+                id INTEGER PRIMARY KEY AUTOINCREMENT CHECK(id >= 900000000 AND id < 1000000000),
+                user_channel_id INTEGER NOT NULL,
+                source_key TEXT NOT NULL,
+                series_remote_id INTEGER NOT NULL,
+                remote_episode_id INTEGER NOT NULL,
+                UNIQUE(user_channel_id, source_key, series_remote_id, remote_episode_id)
+              );
+              INSERT INTO series_episode_aliases
+                (id, user_channel_id, source_key, series_remote_id, remote_episode_id)
+              VALUES
+                (900000005, 1, 'source', 10, 7),
+                (900000006, 99, 'source', 10, 8);
+            `);
+            legacyDb.pragma('foreign_keys = ON');
+
+            migrateSeriesEpisodes(legacyDb);
+
+            expect(legacyDb.prepare(`
+              SELECT id, user_channel_id FROM series_episode_aliases ORDER BY id
+            `).all()).toEqual([{ id: 900000005, user_channel_id: 1 }]);
+            expect(legacyDb.prepare("PRAGMA foreign_key_list('series_episode_aliases')").all()).toEqual(
+              expect.arrayContaining([expect.objectContaining({
+                table: 'user_channels', from: 'user_channel_id', to: 'id', on_delete: 'CASCADE'
+              })])
+            );
+
+            migrateSeriesEpisodes(legacyDb);
+            expect(legacyDb.prepare('SELECT COUNT(*) AS count FROM series_episode_aliases').get().count).toBe(1);
+
+            const nextId = legacyDb.prepare(`
+              INSERT INTO series_episode_aliases
+                (user_channel_id, source_key, series_remote_id, remote_episode_id)
+              VALUES (2, 'source', 10, 9)
+            `).run().lastInsertRowid;
+            expect(nextId).toBeGreaterThanOrEqual(900000000);
+            expect(nextId).toBeLessThan(1000000000);
+
+            legacyDb.prepare('DELETE FROM user_channels WHERE id = 1').run();
+            expect(legacyDb.prepare('SELECT id FROM series_episode_aliases WHERE id = 900000005').get()).toBeUndefined();
         } finally {
             legacyDb.close();
         }

--- a/tests/migration_regression.test.js
+++ b/tests/migration_regression.test.js
@@ -61,6 +61,7 @@ describe('Migration Bug Regression', () => {
         try {
             legacyDb.exec(`
               CREATE TABLE providers (id INTEGER PRIMARY KEY, user_id INTEGER);
+              CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT);
               CREATE TABLE provider_channels (id INTEGER PRIMARY KEY, provider_id INTEGER NOT NULL);
               CREATE TABLE user_categories (id INTEGER PRIMARY KEY, user_id INTEGER NOT NULL);
               CREATE TABLE user_channels (
@@ -86,7 +87,17 @@ describe('Migration Bug Regression', () => {
             ]);
             expect(legacyDb.prepare('SELECT id FROM authorized_user_channels ORDER BY id').all()).toEqual([{ id: 40 }]);
 
+            expect(legacyDb.prepare("SELECT value FROM settings WHERE key = 'user_channel_authorization_v1'").get())
+              .toEqual({ value: 'true' });
+            legacyDb.exec(`
+              CREATE TRIGGER reject_repeated_authorization_backfill
+              BEFORE UPDATE ON user_channels
+              BEGIN
+                SELECT RAISE(FAIL, 'authorization backfill repeated');
+              END;
+            `);
             expect(migrateUserChannelAdminGrants(legacyDb)).toBe(0);
+            legacyDb.exec('DROP TRIGGER reject_repeated_authorization_backfill');
             expect(legacyDb.prepare('SELECT id FROM user_channels ORDER BY id').all()).toEqual([{ id: 40 }, { id: 41 }]);
 
             legacyDb.prepare('UPDATE user_channels SET granted_by_admin = 1, authorization_revoked = 0 WHERE id = 41').run();
@@ -102,6 +113,7 @@ describe('Migration Bug Regression', () => {
         try {
             legacyDb.exec(`
               CREATE TABLE providers (id INTEGER PRIMARY KEY, user_id INTEGER);
+              CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT);
               CREATE TABLE provider_channels (id INTEGER PRIMARY KEY, provider_id INTEGER NOT NULL);
               CREATE TABLE user_categories (id INTEGER PRIMARY KEY, user_id INTEGER NOT NULL);
               CREATE TABLE user_channels (

--- a/tests/migration_regression.test.js
+++ b/tests/migration_regression.test.js
@@ -80,18 +80,64 @@ describe('Migration Bug Regression', () => {
             `);
 
             expect(migrateUserChannelAdminGrants(legacyDb)).toBe(1);
-            expect(legacyDb.prepare('SELECT id, is_hidden, granted_by_admin FROM user_channels ORDER BY id').all()).toEqual([
-                { id: 40, is_hidden: 0, granted_by_admin: 0 },
-                { id: 41, is_hidden: 1, granted_by_admin: 0 }
+            expect(legacyDb.prepare('SELECT id, is_hidden, granted_by_admin, authorization_revoked FROM user_channels ORDER BY id').all()).toEqual([
+                { id: 40, is_hidden: 0, granted_by_admin: 0, authorization_revoked: 0 },
+                { id: 41, is_hidden: 0, granted_by_admin: 0, authorization_revoked: 1 }
             ]);
             expect(legacyDb.prepare('SELECT id FROM authorized_user_channels ORDER BY id').all()).toEqual([{ id: 40 }]);
 
             expect(migrateUserChannelAdminGrants(legacyDb)).toBe(0);
             expect(legacyDb.prepare('SELECT id FROM user_channels ORDER BY id').all()).toEqual([{ id: 40 }, { id: 41 }]);
 
-            legacyDb.prepare('UPDATE user_channels SET is_hidden = 0, granted_by_admin = 1 WHERE id = 41').run();
+            legacyDb.prepare('UPDATE user_channels SET granted_by_admin = 1, authorization_revoked = 0 WHERE id = 41').run();
             expect(migrateUserChannelAdminGrants(legacyDb)).toBe(0);
             expect(legacyDb.prepare('SELECT id FROM authorized_user_channels ORDER BY id').all()).toEqual([{ id: 40 }, { id: 41 }]);
+        } finally {
+            legacyDb.close();
+        }
+    });
+
+    it('preserves user-hidden state while marking an earlier pre-release revocation candidate', () => {
+        const legacyDb = new Database(':memory:');
+        try {
+            legacyDb.exec(`
+              CREATE TABLE providers (id INTEGER PRIMARY KEY, user_id INTEGER);
+              CREATE TABLE provider_channels (id INTEGER PRIMARY KEY, provider_id INTEGER NOT NULL);
+              CREATE TABLE user_categories (id INTEGER PRIMARY KEY, user_id INTEGER NOT NULL);
+              CREATE TABLE user_channels (
+                id INTEGER PRIMARY KEY,
+                user_category_id INTEGER NOT NULL,
+                provider_channel_id INTEGER NOT NULL,
+                is_hidden INTEGER DEFAULT 0,
+                granted_by_admin INTEGER NOT NULL DEFAULT 0
+              );
+              INSERT INTO providers VALUES (10, 1);
+              INSERT INTO provider_channels VALUES (20, 10);
+              INSERT INTO user_categories VALUES (30, 2);
+              INSERT INTO user_channels VALUES (40, 30, 20, 1, 0);
+            `);
+
+            expect(migrateUserChannelAdminGrants(legacyDb)).toBe(1);
+            expect(legacyDb.prepare(`
+              SELECT id, is_hidden, granted_by_admin, authorization_revoked
+              FROM user_channels
+            `).get()).toEqual({
+              id: 40,
+              is_hidden: 1,
+              granted_by_admin: 0,
+              authorization_revoked: 1,
+            });
+
+            legacyDb.prepare(`
+              UPDATE user_channels
+              SET granted_by_admin = 1, authorization_revoked = 0
+              WHERE id = 40
+            `).run();
+            migrateUserChannelAdminGrants(legacyDb);
+            expect(legacyDb.prepare('SELECT id FROM authorized_user_channels').get()).toBeUndefined();
+
+            legacyDb.prepare('UPDATE user_channels SET is_hidden = 0 WHERE id = 40').run();
+            expect(legacyDb.prepare('SELECT id FROM authorized_user_channels').get()).toEqual({ id: 40 });
         } finally {
             legacyDb.close();
         }

--- a/tests/network.test.js
+++ b/tests/network.test.js
@@ -47,12 +47,14 @@ describe('fetchSafe', () => {
   it('should follow redirects for safe URLs', async () => {
     const initialUrl = 'http://example.com';
     const redirectUrl = 'http://example.com/redirected';
+    const destroy = vi.fn();
 
     // First response: 301 Redirect
     const redirectResponse = {
       ok: false,
       status: 301,
       headers: { get: (name) => name === 'location' ? redirectUrl : null },
+      body: { destroy },
     };
 
     // Second response: 200 OK
@@ -77,6 +79,7 @@ describe('fetchSafe', () => {
     expect(fetch).toHaveBeenNthCalledWith(1, initialUrl, expect.any(Object));
     expect(fetch).toHaveBeenNthCalledWith(2, redirectUrl, expect.any(Object));
     expect(response).toBe(finalResponse);
+    expect(destroy).toHaveBeenCalledOnce();
   });
 
   it('should handle relative redirects', async () => {

--- a/tests/network.test.js
+++ b/tests/network.test.js
@@ -17,11 +17,13 @@ describe('fetchSafe', () => {
 
   it('should fetch a safe URL successfully', async () => {
     const url = 'http://example.com';
+    const destroy = vi.fn();
     const mockResponse = {
       ok: true,
       status: 200,
       headers: { get: () => null },
       text: () => Promise.resolve('Success'),
+      body: { destroy },
     };
 
     helpers.isSafeUrl.mockResolvedValue(true);
@@ -34,6 +36,7 @@ describe('fetchSafe', () => {
       redirect: 'manual',
     }));
     expect(response).toBe(mockResponse);
+    expect(destroy).not.toHaveBeenCalled();
   });
 
   it('should throw an error for unsafe URLs', async () => {
@@ -87,10 +90,12 @@ describe('fetchSafe', () => {
     const relativeRedirect = '/new-path';
     const expectedNewUrl = 'http://example.com/new-path';
 
+    const destroy = vi.fn();
     const redirectResponse = {
         ok: false,
         status: 302,
         headers: { get: (name) => name === 'location' ? relativeRedirect : null },
+        body: { destroy },
     };
 
     const finalResponse = { ok: true, status: 200, headers: { get: () => null } };
@@ -102,16 +107,36 @@ describe('fetchSafe', () => {
     await fetchSafe(initialUrl);
 
     expect(fetch).toHaveBeenNthCalledWith(2, expectedNewUrl, expect.any(Object));
+    expect(destroy).toHaveBeenCalledOnce();
+  });
+
+  it('should destroy the redirect body when Location is invalid', async () => {
+    const initialUrl = 'http://example.com';
+    const destroy = vi.fn();
+    helpers.isSafeUrl.mockResolvedValue(true);
+    fetch.mockResolvedValue({
+      ok: false,
+      status: 302,
+      headers: { get: (name) => name === 'location' ? 'http://[invalid' : null },
+      body: { destroy },
+    });
+
+    await expect(fetchSafe(initialUrl)).rejects.toThrow();
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(destroy).toHaveBeenCalledOnce();
   });
 
   it('should throw error on unsafe redirect', async () => {
     const initialUrl = 'http://example.com';
     const unsafeRedirect = 'http://unsafe-redirect.com';
 
+    const destroy = vi.fn();
     const redirectResponse = {
       ok: false,
       status: 302,
       headers: { get: (name) => name === 'location' ? unsafeRedirect : null },
+      body: { destroy },
     };
 
     // isSafeUrl returns true for initial, false for redirect
@@ -123,14 +148,17 @@ describe('fetchSafe', () => {
 
     await expect(fetchSafe(initialUrl)).rejects.toThrow(`Unsafe URL: ${unsafeRedirect}`);
     expect(fetch).toHaveBeenCalledTimes(1);
+    expect(destroy).toHaveBeenCalledOnce();
   });
 
   it('should throw error after too many redirects', async () => {
     const url = 'http://example.com';
+    const destroy = vi.fn();
     const redirectResponse = {
       ok: false,
       status: 302,
       headers: { get: (name) => name === 'location' ? url : null }, // Circular redirect
+      body: { destroy },
     };
 
     helpers.isSafeUrl.mockResolvedValue(true);
@@ -146,6 +174,7 @@ describe('fetchSafe', () => {
     // Call 6: redirectCount=6. if(6>5) true. throw.
     // So fetch is called 6 times (0,1,2,3,4,5).
     expect(fetch).toHaveBeenCalledTimes(6);
+    expect(destroy).toHaveBeenCalledTimes(6);
   });
 
   it('should use correct agent for protocol', async () => {

--- a/tests/perf_sync_update.test.js
+++ b/tests/perf_sync_update.test.js
@@ -96,7 +96,7 @@ http://stream.url/1.ts
 
   it('Optimization Verification: Should NOT call updateChannel if data is identical', async () => {
     // 1. First Run
-    await performSync(1, 1, true);
+    await performSync(1, 1, { mode: 'manual', allowCrossOwner: true });
 
     expect(mockInsertRun).toHaveBeenCalled();
     const args = mockInsertRun.mock.calls[0];
@@ -135,7 +135,7 @@ http://stream.url/1.ts
     mockUpdateRun.mockClear();
 
     // 3. Second Run execution with Identical Data
-    const result = await performSync(1, 1, true);
+    const result = await performSync(1, 1, { mode: 'manual', allowCrossOwner: true });
 
     // Check behavior (Optimized)
     expect(mockUpdateRun).not.toHaveBeenCalled();

--- a/tests/perf_sync_update.test.js
+++ b/tests/perf_sync_update.test.js
@@ -58,7 +58,7 @@ describe('performSync Optimization', () => {
       if (sqlStr.includes('SELECT * FROM PROVIDERS')) {
         return { get: () => ({ id: 1, name: 'Test', url: 'http://test.com/m3u', username: '', password: '' }) };
       }
-      if (sqlStr.includes('SELECT * FROM CATEGORY_MAPPINGS')) {
+      if (sqlStr.includes('FROM CATEGORY_MAPPINGS CM')) {
         return { all: () => [] };
       }
       // Relaxed check for existing channels query (fetching all columns)

--- a/tests/provider_backup.test.js
+++ b/tests/provider_backup.test.js
@@ -143,10 +143,12 @@ describe('Stream Controller - Backup Failover', () => {
     });
 
     it('should failover to first backup if primary fails', async () => {
+        const destroy = vi.fn();
         // First call fails
         mockFetch.mockResolvedValueOnce({
             ok: false,
-            status: 503
+            status: 503,
+            body: { destroy }
         });
         // Second call succeeds
         mockFetch.mockResolvedValueOnce({
@@ -162,6 +164,7 @@ describe('Stream Controller - Backup Failover', () => {
         expect(mockFetch).toHaveBeenNthCalledWith(1, expect.stringContaining('http://primary.com'), expect.any(Object));
         expect(mockFetch).toHaveBeenNthCalledWith(2, expect.stringContaining('http://backup1.com'), expect.any(Object));
         expect(mockRes.sendStatus).not.toHaveBeenCalled();
+        expect(destroy).toHaveBeenCalledOnce();
     });
 
     it('should failover to second backup if first backup also fails', async () => {

--- a/tests/provider_backup.test.js
+++ b/tests/provider_backup.test.js
@@ -3,14 +3,15 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as streamController from '../src/controllers/streamController.js';
 
 // Mocks
-const { mockDb, mockFetch } = vi.hoisted(() => {
+const { mockDb, mockFetch, mockProviderPoolAll } = vi.hoisted(() => {
     return {
         mockDb: {
             prepare: vi.fn(),
             exec: vi.fn(),
             pragma: vi.fn(),
         },
-        mockFetch: vi.fn()
+        mockFetch: vi.fn(),
+        mockProviderPoolAll: vi.fn()
     };
 });
 
@@ -72,6 +73,15 @@ describe('Stream Controller - Backup Failover', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
+        mockProviderPoolAll.mockReturnValue([{
+            id: 100,
+            user_id: 1,
+            url: 'http://primary.com',
+            username: 'user',
+            password: 'pass',
+            max_connections: 10,
+            backup_urls: JSON.stringify(['http://backup1.com', 'http://backup2.com'])
+        }]);
         mockReq = {
             params: { stream_id: '123', username: 'u', password: 'p' },
             query: {},
@@ -95,27 +105,21 @@ describe('Stream Controller - Backup Failover', () => {
                     get: vi.fn().mockReturnValue({
                         user_channel_id: 1,
                         provider_channel_id: 10,
+                        provider_id: 100,
                         remote_stream_id: 555,
                         name: 'Test Channel',
                         metadata: '{}',
                         provider_url: 'http://primary.com',
                         provider_user: 'user',
                         provider_pass: 'pass',
+                        provider_max_connections: 10,
                         backup_urls: JSON.stringify(['http://backup1.com', 'http://backup2.com'])
                     })
                 };
             }
             if (query.includes('FROM providers WHERE user_id = ? AND url LIKE ?')) {
                 return {
-                    all: vi.fn().mockReturnValue([{
-                        id: 100,
-                        user_id: 1,
-                        url: 'http://primary.com',
-                        username: 'user',
-                        password: 'pass',
-                        max_connections: 10,
-                        backup_urls: JSON.stringify(['http://backup1.com', 'http://backup2.com'])
-                    }])
+                    all: mockProviderPoolAll
                 };
             }
             // Stats or other queries
@@ -128,16 +132,34 @@ describe('Stream Controller - Backup Failover', () => {
     });
 
     it('should use primary URL if it succeeds', async () => {
+        const destroy = vi.fn();
         mockFetch.mockResolvedValueOnce({
             ok: true,
             status: 200,
             headers: { get: () => null },
-            body: { pipe: vi.fn(), on: vi.fn() }
+            body: { pipe: vi.fn(), on: vi.fn(), destroy }
         });
 
         await streamController.proxyLive(mockReq, mockRes);
 
+        expect(mockDb.prepare).toHaveBeenCalledWith(expect.stringContaining('FROM authorized_user_channels uc'));
         expect(mockFetch).toHaveBeenCalledTimes(1);
+        expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining('http://primary.com'), expect.any(Object));
+        expect(mockRes.sendStatus).not.toHaveBeenCalled();
+        expect(destroy).not.toHaveBeenCalled();
+    });
+
+    it('should keep an explicitly authorized source playable outside the user provider pool', async () => {
+        mockProviderPoolAll.mockReturnValue([]);
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            headers: { get: () => null },
+            body: { pipe: vi.fn(), on: vi.fn(), destroy: vi.fn() }
+        });
+
+        await streamController.proxyLive(mockReq, mockRes);
+
         expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining('http://primary.com'), expect.any(Object));
         expect(mockRes.sendStatus).not.toHaveBeenCalled();
     });
@@ -168,28 +190,41 @@ describe('Stream Controller - Backup Failover', () => {
     });
 
     it('should failover to second backup if first backup also fails', async () => {
+        const primaryDestroy = vi.fn();
+        const firstBackupDestroy = vi.fn();
+        const successDestroy = vi.fn();
         mockFetch
-            .mockResolvedValueOnce({ ok: false, status: 500 }) // Primary
-            .mockResolvedValueOnce({ ok: false, status: 404 }) // Backup 1
+            .mockResolvedValueOnce({ ok: false, status: 500, body: { destroy: primaryDestroy } }) // Primary
+            .mockResolvedValueOnce({ ok: false, status: 404, body: { destroy: firstBackupDestroy } }) // Backup 1
             .mockResolvedValueOnce({ // Backup 2
                 ok: true,
                 status: 200,
                 headers: { get: () => null },
-                body: { pipe: vi.fn(), on: vi.fn() }
+                body: { pipe: vi.fn(), on: vi.fn(), destroy: successDestroy }
             });
 
         await streamController.proxyLive(mockReq, mockRes);
 
         expect(mockFetch).toHaveBeenCalledTimes(3);
         expect(mockFetch).toHaveBeenLastCalledWith(expect.stringContaining('http://backup2.com'), expect.any(Object));
+        expect(primaryDestroy).toHaveBeenCalledOnce();
+        expect(firstBackupDestroy).toHaveBeenCalledOnce();
+        expect(successDestroy).not.toHaveBeenCalled();
     });
 
     it('should return 502 if all URLs fail', async () => {
-        mockFetch.mockResolvedValue({ ok: false, status: 500 }); // All fail
+        const destroys = [];
+        mockFetch.mockImplementation(async () => {
+            const destroy = vi.fn();
+            destroys.push(destroy);
+            return { ok: false, status: 500, body: { destroy } };
+        });
 
         await streamController.proxyLive(mockReq, mockRes);
 
         expect(mockFetch).toHaveBeenCalledTimes(3); // Primary + 2 backups
         expect(mockRes.sendStatus).toHaveBeenCalledWith(502);
+        expect(destroys).toHaveLength(3);
+        destroys.forEach(destroy => expect(destroy).toHaveBeenCalledOnce());
     });
 });

--- a/tests/provider_backup.test.js
+++ b/tests/provider_backup.test.js
@@ -43,7 +43,8 @@ vi.mock('../src/utils/helpers.js', () => ({
     redactUrl: vi.fn(url => url),
     getBaseUrl: vi.fn(() => 'http://localhost:3000'),
     isSafeUrl: vi.fn(async () => true),
-    safeLookup: vi.fn((hostname, options, cb) => cb(null, '127.0.0.1', 4))
+    safeLookup: vi.fn((hostname, options, cb) => cb(null, '127.0.0.1', 4)),
+    providerSourceKey: vi.fn((url) => String(url || ''))
 }));
 
 vi.mock('../src/utils/crypto.js', () => ({

--- a/tests/provider_backup_validation.test.js
+++ b/tests/provider_backup_validation.test.js
@@ -44,7 +44,10 @@ vi.mock('../src/utils/helpers.js', async () => {
         checkProviderExpiry: vi.fn(),
         isAdultCategory: vi.fn().mockReturnValue(false),
         safeLookup: vi.fn(),
-        redactUrl: vi.fn((url) => url)
+        redactUrl: vi.fn((url) => url),
+        providerSourceKey: vi.fn((url) => String(url || '')),
+        resolveAssignmentGrant: vi.fn(({ categoryOwnerId, providerOwnerId, isAdmin }) =>
+          Number(categoryOwnerId) === Number(providerOwnerId) ? 0 : (isAdmin ? 1 : null))
     };
 });
 

--- a/tests/scheduler/sync_scheduler.test.js
+++ b/tests/scheduler/sync_scheduler.test.js
@@ -61,7 +61,7 @@ describe('Sync Scheduler', () => {
     await vi.advanceTimersByTimeAsync(60000);
 
     expect(mockDb.prepare).toHaveBeenCalledWith(expect.stringContaining('SELECT * FROM sync_configs'));
-    expect(syncService.performSync).toHaveBeenCalledWith(101, 201, false);
+    expect(syncService.performSync).toHaveBeenCalledWith(101, 201, { mode: 'scheduled' });
   });
 
   it('should not schedule concurrent syncs for the same config', async () => {

--- a/tests/security/m3u_injection.test.js
+++ b/tests/security/m3u_injection.test.js
@@ -11,6 +11,7 @@ const { mockDb } = vi.hoisted(() => {
 
 vi.mock('../../src/database/db.js', () => ({
   default: mockDb,
+  openDbConnection: vi.fn(() => ({ prepare: mockDb.prepare, close: vi.fn() })),
 }));
 
 vi.mock('node-fetch', () => ({

--- a/tests/series_episode_id.test.js
+++ b/tests/series_episode_id.test.js
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { decodeSeriesEpisodeId, encodeSeriesEpisodeId, SERIES_EPISODE_OFFSET } from '../src/utils/seriesEpisodeId.js';
+
+describe('series episode identifiers', () => {
+  it('round-trips an exact user-channel assignment and remote episode', () => {
+    const encoded = encodeSeriesEpisodeId(42, 123);
+
+    expect(encoded).toBe('42000000123');
+    expect(decodeSeriesEpisodeId(encoded)).toEqual({ assignmentId: 42, remoteEpisodeId: 123 });
+  });
+
+  it('rejects malformed and ambiguous identifiers', () => {
+    for (const value of [null, '', 'abc', '1.5', '1000000000', '0', '-1']) {
+      expect(decodeSeriesEpisodeId(value)).toBe(null);
+    }
+    expect(encodeSeriesEpisodeId(0, 1)).toBe(null);
+    expect(encodeSeriesEpisodeId(1, 0)).toBe(null);
+    expect(encodeSeriesEpisodeId(1, SERIES_EPISODE_OFFSET)).toBe(null);
+    expect(encodeSeriesEpisodeId(Number.MAX_SAFE_INTEGER, 1)).toBe(null);
+  });
+});

--- a/tests/series_episode_id.test.js
+++ b/tests/series_episode_id.test.js
@@ -1,21 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { decodeSeriesEpisodeId, encodeSeriesEpisodeId, SERIES_EPISODE_OFFSET } from '../src/utils/seriesEpisodeId.js';
+import { decodeSeriesEpisodeId } from '../src/utils/seriesEpisodeId.js';
 
-describe('series episode identifiers', () => {
-  it('round-trips an exact user-channel assignment and remote episode', () => {
-    const encoded = encodeSeriesEpisodeId(42, 123);
-
-    expect(encoded).toBe('42000000123');
-    expect(decodeSeriesEpisodeId(encoded)).toEqual({ assignmentId: 42, remoteEpisodeId: 123 });
+describe('legacy series episode identifiers', () => {
+  it('decodes the provider/assignment prefix and remote episode', () => {
+    expect(decodeSeriesEpisodeId('42000000123')).toEqual({ assignmentId: 42, remoteEpisodeId: 123 });
   });
 
   it('rejects malformed and ambiguous identifiers', () => {
     for (const value of [null, '', 'abc', '1.5', '1000000000', '0', '-1']) {
       expect(decodeSeriesEpisodeId(value)).toBe(null);
     }
-    expect(encodeSeriesEpisodeId(0, 1)).toBe(null);
-    expect(encodeSeriesEpisodeId(1, 0)).toBe(null);
-    expect(encodeSeriesEpisodeId(1, SERIES_EPISODE_OFFSET)).toBe(null);
-    expect(encodeSeriesEpisodeId(Number.MAX_SAFE_INTEGER, 1)).toBe(null);
   });
 });

--- a/tests/series_episode_sync.test.js
+++ b/tests/series_episode_sync.test.js
@@ -93,7 +93,7 @@ describe('Series episode sync', () => {
         container_extension TEXT DEFAULT 'mp4',
         logo TEXT DEFAULT '',
         added TEXT DEFAULT '',
-        UNIQUE(source_key, remote_episode_id)
+        UNIQUE(source_key, series_remote_id, remote_episode_id)
       );
       CREATE TABLE provider_series_state (
         source_key TEXT NOT NULL,
@@ -207,6 +207,27 @@ describe('Series episode sync', () => {
 
       // Only ONE copy of the episode exists
       expect(memDb.prepare('SELECT COUNT(*) as c FROM provider_series_episodes').get().c).toBe(1);
+    });
+
+    it('keeps reused remote episode IDs separate across series', async () => {
+      memDb.prepare(`INSERT INTO provider_channels (provider_id, remote_stream_id, name, stream_type, metadata)
+        VALUES (1, 555, 'Show One', 'series', '{"last_modified":"1000"}'),
+               (1, 556, 'Show Two', 'series', '{"last_modified":"1000"}')`).run();
+      fetchSafeMock.mockResolvedValue(seriesInfoResponse({
+        '1': [{ id: 100, episode_num: 1, season: 1 }]
+      }));
+
+      const result = await syncSeriesEpisodes(1);
+
+      expect(result.synced).toBe(2);
+      expect(memDb.prepare(`
+        SELECT series_remote_id, remote_episode_id
+        FROM provider_series_episodes
+        ORDER BY series_remote_id
+      `).all()).toEqual([
+        { series_remote_id: 555, remote_episode_id: 100 },
+        { series_remote_id: 556, remote_episode_id: 100 },
+      ]);
     });
 
     it('skips unchanged series and prunes episodes of removed series', async () => {

--- a/tests/series_episode_sync.test.js
+++ b/tests/series_episode_sync.test.js
@@ -213,6 +213,27 @@ describe('Series episode sync', () => {
       expect(memDb.prepare('SELECT COUNT(*) as c FROM provider_series_episodes').get().c).toBe(1);
     });
 
+    it('keeps the first current panel record authoritative across conflicting sibling metadata', async () => {
+      memDb.prepare(`INSERT INTO provider_channels (provider_id, remote_stream_id, name, stream_type, metadata)
+        VALUES (1, 555, 'Account A Show', 'series', '{"last_modified":"1000"}'),
+               (2, 555, 'Account B Show', 'series', '{"last_modified":"1000"}')`).run();
+      fetchSafeMock.mockResolvedValueOnce(seriesInfoResponse({
+        '1': [{ id: 100, episode_num: 1, season: 1, title: 'Account A Title' }]
+      })).mockResolvedValueOnce(seriesInfoResponse({
+        '1': [{ id: 100, episode_num: 1, season: 1, title: 'Account B Title' }]
+      }));
+
+      await syncSeriesEpisodes(1);
+      const sibling = await syncSeriesEpisodes(2);
+
+      expect(sibling.synced).toBe(0);
+      expect(fetchSafeMock).toHaveBeenCalledTimes(1);
+      expect(memDb.prepare(`
+        SELECT title FROM provider_series_episodes
+        WHERE source_key = ? AND series_remote_id = 555 AND remote_episode_id = 100
+      `).get(SOURCE)).toEqual({ title: 'Account A Title' });
+    });
+
     it('keeps reused remote episode IDs separate across series', async () => {
       memDb.prepare(`INSERT INTO provider_channels (provider_id, remote_stream_id, name, stream_type, metadata)
         VALUES (1, 555, 'Show One', 'series', '{"last_modified":"1000"}'),

--- a/tests/series_episode_sync.test.js
+++ b/tests/series_episode_sync.test.js
@@ -144,12 +144,16 @@ describe('Series episode sync', () => {
     it('parses array-of-seasons payloads and skips invalid entries', () => {
       const eps = parseSeriesInfoEpisodes({
         episodes: [
-          [ { id: 5, episode_num: 1, season: 1 }, { title: 'no id' } ],
+          [
+            { id: 5, episode_num: 1, season: 1, container_extension: 'mp4\r\n#EXTINF:-1,Injected' },
+            { title: 'no id' }
+          ],
           'garbage'
         ]
       });
       expect(eps).toHaveLength(1);
       expect(eps[0].remote_episode_id).toBe(5);
+      expect(eps[0].container_extension).toBe('mp4');
     });
 
     it('returns empty for missing/invalid payloads', () => {

--- a/tests/share_slug.test.js
+++ b/tests/share_slug.test.js
@@ -70,13 +70,13 @@ describe('Share Controller - Slug Generation', () => {
             '[1,2,3]', // channels
             null, // start
             null, // end
-            'soccer-night' // slug
+            expect.stringMatching(/^soccer-night-[a-f0-9]{16}$/) // slug
         );
 
         expect(mockRes.json).toHaveBeenCalledWith(expect.objectContaining({
             success: true,
-            slug: 'soccer-night',
-            short_link: 'http://localhost:3000/share/soccer-night'
+            slug: expect.stringMatching(/^soccer-night-[a-f0-9]{16}$/),
+            short_link: expect.stringMatching(/^http:\/\/localhost:3000\/share\/soccer-night-[a-f0-9]{16}$/)
         }));
     });
 
@@ -91,7 +91,7 @@ describe('Share Controller - Slug Generation', () => {
         expect(mockRes.json).toHaveBeenCalledWith({ error: 'Name required' });
     });
 
-    it('should handle duplicate slugs by appending a counter', () => {
+    it('should handle random suffix collisions by retrying', () => {
         mockReq.body = {
             channels: [1],
             name: 'My Share'
@@ -107,14 +107,25 @@ describe('Share Controller - Slug Generation', () => {
 
         shareController.createShare(mockReq, mockRes);
 
-        // Should check 'my-share' then 'my-share-1'
         expect(stmtMock.run).toHaveBeenCalledWith(
-            expect.any(String), 1, 'My Share', '[1]', null, null, 'my-share-1'
+            expect.any(String), 1, 'My Share', '[1]', null, null, expect.stringMatching(/^my-share-[a-f0-9]{16}$/)
         );
+        expect(stmtMock.get).toHaveBeenCalledTimes(2);
+        expect(stmtMock.get.mock.calls[0][0]).not.toBe(stmtMock.get.mock.calls[1][0]);
+    });
 
-        expect(mockRes.json).toHaveBeenCalledWith(expect.objectContaining({
-            slug: 'my-share-1'
-        }));
+    it('uses different unguessable slugs for shares with the same name', () => {
+        mockReq.body = { channels: [1], name: 'Family TV' };
+        const stmtMock = { run: vi.fn(), get: vi.fn().mockReturnValue(undefined) };
+        mockDb.prepare.mockReturnValue(stmtMock);
+
+        shareController.createShare(mockReq, mockRes);
+        shareController.createShare(mockReq, mockRes);
+
+        const slugs = mockRes.json.mock.calls.map(([payload]) => payload.slug);
+        expect(slugs[0]).toMatch(/^family-tv-[a-f0-9]{16}$/);
+        expect(slugs[1]).toMatch(/^family-tv-[a-f0-9]{16}$/);
+        expect(slugs[0]).not.toBe(slugs[1]);
     });
 
     it('should redirect to player when accessing valid slug', () => {

--- a/tests/sync_service_regression.test.js
+++ b/tests/sync_service_regression.test.js
@@ -1,113 +1,185 @@
-import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import Database from 'better-sqlite3';
 
+const { fetchSafe, xtreamState } = vi.hoisted(() => ({
+  fetchSafe: vi.fn(),
+  xtreamState: { channels: [] },
+}));
 const memDb = new Database(':memory:');
 
-// Mock dependencies before importing the module under test
-vi.doMock('../src/database/db.js', () => ({
-  default: memDb,
-  initDb: () => {}
-}));
-
-vi.mock('node-fetch', () => ({
-  default: vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => [],
-      headers: { get: () => 'application/json' }
-  })
-}));
-
+vi.mock('../src/database/db.js', () => ({ default: memDb, initDb: vi.fn() }));
+vi.mock('../src/utils/network.js', () => ({ fetchSafe }));
 vi.mock('@iptv/xtream-api', () => ({
   Xtream: class {
-      constructor() {}
-      getChannels() { return Promise.resolve([]); }
-  }
+    getChannels() { return Promise.resolve(xtreamState.channels.map(channel => ({ ...channel }))); }
+  },
 }));
+vi.mock('../src/utils/crypto.js', () => ({ decrypt: value => value, encrypt: value => value }));
+vi.mock('../src/utils/playlistParser.js', () => ({ parseM3uStream: vi.fn().mockResolvedValue({ isM3u: false }) }));
+vi.mock('../src/services/logoResolver.js', () => ({ prePopulateProviderIconCache: vi.fn() }));
 
-vi.mock('../src/utils/crypto.js', () => ({
-  decrypt: (val) => val,
-  encrypt: (val) => val
-}));
-
-vi.mock('../src/utils/helpers.js', () => ({
-    isAdultCategory: () => false,
-    safeLookup: vi.fn(),
-    isSafeUrl: vi.fn().mockResolvedValue(true)
-}));
-
-// Also need to mock playlist_parser since it's imported
-vi.mock('../src/utils/playlistParser.js', () => ({
-    parseM3uStream: () => ({ isM3u: false })
-}));
-
-describe('Sync Service Regression', () => {
+describe('sync authorization regression', () => {
   let performSync;
 
   beforeAll(async () => {
-    // Import the service dynamically so doMock applies
-    const service = await import('../src/services/syncService.js');
-    performSync = service.performSync;
-
-    // Setup minimal schema for performSync
+    ({ performSync } = await import('../src/services/syncService.js'));
     memDb.exec(`
-      CREATE TABLE IF NOT EXISTS provider_icon_cache (id INTEGER PRIMARY KEY, provider_id INTEGER, logo_url TEXT, cache_hash TEXT, last_accessed INTEGER, access_count INTEGER);
-      CREATE TABLE providers (id INTEGER PRIMARY KEY, name TEXT, url TEXT, username TEXT, password TEXT, expiry_date INTEGER);
-      CREATE TABLE sync_configs (id INTEGER PRIMARY KEY, provider_id INTEGER, user_id INTEGER, sync_interval TEXT, auto_add_channels INTEGER, auto_add_categories INTEGER, last_sync INTEGER, next_sync INTEGER);
-      CREATE TABLE provider_channels (
-          id INTEGER PRIMARY KEY,
-          provider_id INTEGER,
-          remote_stream_id INTEGER,
-          name TEXT,
-          original_category_id INTEGER,
-          logo TEXT,
-          stream_type TEXT,
-          epg_channel_id TEXT,
-          original_sort_order INTEGER,
-          tv_archive INTEGER,
-          tv_archive_duration INTEGER,
-          metadata TEXT,
-          mime_type TEXT,
-          rating TEXT,
-          rating_5based REAL,
-          added TEXT,
-          plot TEXT,
-          "cast" TEXT,
-          director TEXT,
-          genre TEXT,
-          releaseDate TEXT,
-          youtube_trailer TEXT,
-          episode_run_time TEXT,
-          UNIQUE(provider_id, remote_stream_id)
+      CREATE TABLE providers (
+        id INTEGER PRIMARY KEY, name TEXT, url TEXT, username TEXT, password TEXT,
+        expiry_date INTEGER, user_id INTEGER
       );
-      CREATE TABLE sync_logs (id INTEGER PRIMARY KEY, provider_id INTEGER, user_id INTEGER, sync_time INTEGER, status TEXT, channels_added INTEGER, channels_updated INTEGER, categories_added INTEGER, error_message TEXT);
-      CREATE TABLE category_mappings (id INTEGER PRIMARY KEY, provider_id INTEGER, user_id INTEGER, provider_category_id INTEGER, provider_category_name TEXT, user_category_id INTEGER, auto_created INTEGER, category_type TEXT);
-      CREATE TABLE user_channels (id INTEGER PRIMARY KEY, user_category_id INTEGER, provider_channel_id INTEGER, sort_order INTEGER);
-      CREATE TABLE user_categories (id INTEGER PRIMARY KEY, user_id INTEGER, name TEXT, is_adult INTEGER, sort_order INTEGER, type TEXT);
+      CREATE TABLE sync_configs (
+        id INTEGER PRIMARY KEY, provider_id INTEGER, user_id INTEGER, enabled INTEGER,
+        sync_interval TEXT, auto_add_channels INTEGER, auto_add_categories INTEGER,
+        last_sync INTEGER, next_sync INTEGER, sync_series_episodes INTEGER,
+        granted_by_admin INTEGER NOT NULL DEFAULT 0
+      );
+      CREATE TABLE provider_channels (
+        id INTEGER PRIMARY KEY, provider_id INTEGER, remote_stream_id INTEGER, name TEXT,
+        original_category_id INTEGER, logo TEXT, stream_type TEXT, epg_channel_id TEXT,
+        original_sort_order INTEGER, tv_archive INTEGER, tv_archive_duration INTEGER,
+        metadata TEXT, mime_type TEXT, rating TEXT, rating_5based REAL, added TEXT,
+        plot TEXT, "cast" TEXT, director TEXT, genre TEXT, releaseDate TEXT,
+        youtube_trailer TEXT, episode_run_time TEXT,
+        UNIQUE(provider_id, remote_stream_id)
+      );
+      CREATE TABLE sync_logs (
+        id INTEGER PRIMARY KEY, provider_id INTEGER, user_id INTEGER, sync_time INTEGER,
+        status TEXT, channels_added INTEGER, channels_updated INTEGER,
+        categories_added INTEGER, error_message TEXT
+      );
+      CREATE TABLE security_logs (
+        id INTEGER PRIMARY KEY, ip TEXT, action TEXT, details TEXT, timestamp INTEGER
+      );
+      CREATE TABLE category_mappings (
+        id INTEGER PRIMARY KEY, provider_id INTEGER, user_id INTEGER,
+        provider_category_id INTEGER, provider_category_name TEXT,
+        user_category_id INTEGER, auto_created INTEGER, category_type TEXT
+      );
+      CREATE TABLE user_channels (
+        id INTEGER PRIMARY KEY, user_category_id INTEGER, provider_channel_id INTEGER,
+        sort_order INTEGER, is_hidden INTEGER DEFAULT 0,
+        granted_by_admin INTEGER NOT NULL DEFAULT 0
+      );
+      CREATE TABLE user_categories (
+        id INTEGER PRIMARY KEY, user_id INTEGER, name TEXT, is_adult INTEGER,
+        sort_order INTEGER, type TEXT
+      );
     `);
-
-    // Insert dummy data
-    memDb.prepare("INSERT INTO providers (id, name, url, username, password) VALUES (1, 'Test', 'http://test.com', 'u', 'p')").run();
-    memDb.prepare("INSERT INTO sync_configs (provider_id, user_id, sync_interval, auto_add_channels, auto_add_categories) VALUES (1, 1, 'daily', 1, 1)").run();
   });
 
-  afterAll(() => {
-      memDb.close();
-  });
-
-  it('should not throw syntax error on existingChannels query', async () => {
-    const result = await performSync(1, 1);
-
-    if (result.errorMessage) {
-        if (result.errorMessage.includes('syntax error')) {
-            throw new Error(result.errorMessage);
-        }
+  beforeEach(() => {
+    for (const table of [
+      'security_logs', 'sync_logs', 'user_channels', 'provider_channels',
+      'category_mappings', 'user_categories', 'sync_configs', 'providers',
+    ]) {
+      memDb.prepare(`DELETE FROM ${table}`).run();
     }
-
-    const log = memDb.prepare('SELECT * FROM sync_logs ORDER BY id DESC LIMIT 1').get();
-    if (log && log.status === 'error') {
-         if (log.error_message && log.error_message.includes('syntax error')) {
-            throw new Error(log.error_message);
-        }
-    }
+    vi.clearAllMocks();
+    xtreamState.channels = [{
+      name: 'Channel', stream_id: 101, category_id: 10,
+      stream_icon: '', epg_channel_id: '', stream_type: 'live',
+    }];
+    fetchSafe.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => 'application/json' },
+      json: async () => [],
+    });
+    memDb.prepare("INSERT INTO user_categories (id, user_id, name, type, sort_order) VALUES (10, 1, 'Live', 'live', 0)").run();
+    memDb.prepare(`
+      INSERT INTO category_mappings
+        (provider_id, user_id, provider_category_id, provider_category_name, user_category_id, auto_created, category_type)
+      VALUES (1, 1, 10, 'Live', 10, 0, 'live')
+    `).run();
   });
+
+  const configure = ({ providerOwner = 1, targetUser = 1, enabled = 1, grant = 0 } = {}) => {
+    memDb.prepare(`
+      INSERT INTO providers (id, name, url, username, password, user_id)
+      VALUES (1, 'Provider', 'http://panel.test', 'provider-user', 'super-secret', ?)
+    `).run(providerOwner);
+    memDb.prepare(`
+      INSERT INTO sync_configs
+        (id, provider_id, user_id, enabled, sync_interval, auto_add_channels,
+         auto_add_categories, sync_series_episodes, granted_by_admin)
+      VALUES (7, 1, ?, ?, 'daily', 1, 0, 0, ?)
+    `).run(targetUser, enabled, grant);
+  };
+
+  it('creates same-owner scheduled assignments with a normal grant', async () => {
+    configure();
+
+    const result = await performSync(1, 1, { mode: 'scheduled' });
+
+    expect(result.errorMessage).toBe(null);
+    expect(result.channelsAdded).toBe(1);
+    expect(memDb.prepare('SELECT granted_by_admin, is_hidden FROM user_channels').get()).toEqual({
+      granted_by_admin: 0,
+      is_hidden: 0,
+    });
+  });
+
+  it('disables an unapproved cross-owner config before network or writes', async () => {
+    configure({ providerOwner: 2 });
+    const categoriesBefore = memDb.prepare('SELECT COUNT(*) AS count FROM user_categories').get().count;
+
+    const result = await performSync(1, 1, { mode: 'scheduled' });
+
+    expect(result.errorMessage).toMatch(/explicit administrator approval/i);
+    expect(fetchSafe).not.toHaveBeenCalled();
+    expect(memDb.prepare('SELECT COUNT(*) AS count FROM provider_channels').get().count).toBe(0);
+    expect(memDb.prepare('SELECT COUNT(*) AS count FROM user_channels').get().count).toBe(0);
+    expect(memDb.prepare('SELECT COUNT(*) AS count FROM user_categories').get().count).toBe(categoriesBefore);
+    expect(memDb.prepare('SELECT enabled, granted_by_admin FROM sync_configs WHERE id = 7').get()).toEqual({
+      enabled: 0,
+      granted_by_admin: 0,
+    });
+    const log = memDb.prepare("SELECT details FROM security_logs WHERE action = 'cross_owner_sync_blocked'").get();
+    expect(log.details).toContain('disabled 1 config(s)');
+    expect(log.details).not.toContain('provider-user');
+    expect(log.details).not.toContain('super-secret');
+  });
+
+  it('uses the persisted admin grant for a cross-owner scheduled sync', async () => {
+    configure({ providerOwner: 2, grant: 1 });
+
+    const result = await performSync(1, 1, { mode: 'scheduled' });
+
+    expect(result.errorMessage).toBe(null);
+    expect(memDb.prepare('SELECT granted_by_admin FROM user_channels').get()).toEqual({ granted_by_admin: 1 });
+  });
+
+  it('allows a trusted manual operation without authorizing future schedules', async () => {
+    configure({ providerOwner: 2, enabled: 0, grant: 0 });
+
+    const manual = await performSync(1, 1, { mode: 'manual', allowCrossOwner: true });
+    expect(manual.errorMessage).toBe(null);
+    expect(memDb.prepare('SELECT granted_by_admin FROM user_channels').get()).toEqual({ granted_by_admin: 1 });
+    expect(memDb.prepare('SELECT enabled, granted_by_admin FROM sync_configs WHERE id = 7').get()).toEqual({
+      enabled: 0,
+      granted_by_admin: 0,
+    });
+
+    memDb.prepare('DELETE FROM user_channels').run();
+    xtreamState.channels = [{ ...xtreamState.channels[0], stream_id: 102 }];
+    fetchSafe.mockClear();
+    await performSync(1, 1, { mode: 'scheduled' });
+
+    expect(fetchSafe).not.toHaveBeenCalled();
+    expect(memDb.prepare('SELECT COUNT(*) AS count FROM user_channels').get().count).toBe(0);
+  });
+
+  it('blocks a formerly same-owner config after the provider owner changes', async () => {
+    configure();
+    memDb.prepare('UPDATE providers SET user_id = 2 WHERE id = 1').run();
+
+    await performSync(1, 1, { mode: 'scheduled' });
+
+    expect(memDb.prepare('SELECT enabled FROM sync_configs WHERE id = 7').get()).toEqual({ enabled: 0 });
+    expect(memDb.prepare('SELECT COUNT(*) AS count FROM user_channels').get().count).toBe(0);
+    expect(fetchSafe).not.toHaveBeenCalled();
+  });
+
+  afterAll(() => memDb.close());
 });

--- a/tests/sync_service_regression.test.js
+++ b/tests/sync_service_regression.test.js
@@ -157,6 +157,18 @@ describe('sync authorization regression', () => {
     });
   });
 
+  it('ignores a legacy mapping that targets another tenant during sync', async () => {
+    configure();
+    memDb.prepare("INSERT INTO user_categories (id, user_id, name, type, sort_order) VALUES (20, 2, 'Foreign', 'live', 0)").run();
+    memDb.prepare('UPDATE category_mappings SET user_category_id = 20 WHERE id = 1').run();
+
+    const result = await performSync(1, 1, { mode: 'scheduled' });
+
+    expect(result.errorMessage).toBe(null);
+    expect(memDb.prepare('SELECT COUNT(*) AS count FROM provider_channels').get().count).toBe(1);
+    expect(memDb.prepare('SELECT COUNT(*) AS count FROM user_channels').get().count).toBe(0);
+  });
+
   it('allows a trusted manual operation without authorizing future schedules', async () => {
     configure({ providerOwner: 2, enabled: 0, grant: 0 });
 

--- a/tests/sync_service_regression.test.js
+++ b/tests/sync_service_regression.test.js
@@ -59,7 +59,8 @@ describe('sync authorization regression', () => {
       CREATE TABLE user_channels (
         id INTEGER PRIMARY KEY, user_category_id INTEGER, provider_channel_id INTEGER,
         sort_order INTEGER, is_hidden INTEGER DEFAULT 0,
-        granted_by_admin INTEGER NOT NULL DEFAULT 0
+        granted_by_admin INTEGER NOT NULL DEFAULT 0,
+        authorization_revoked INTEGER NOT NULL DEFAULT 0
       );
       CREATE TABLE user_categories (
         id INTEGER PRIMARY KEY, user_id INTEGER, name TEXT, is_adult INTEGER,
@@ -109,15 +110,18 @@ describe('sync authorization regression', () => {
 
   it('creates same-owner scheduled assignments with a normal grant', async () => {
     configure();
+    xtreamState.channels[0].container_extension = 'ts\r\n#EXTINF:-1,Injected';
 
     const result = await performSync(1, 1, { mode: 'scheduled' });
 
     expect(result.errorMessage).toBe(null);
     expect(result.channelsAdded).toBe(1);
-    expect(memDb.prepare('SELECT granted_by_admin, is_hidden FROM user_channels').get()).toEqual({
+    expect(memDb.prepare('SELECT granted_by_admin, authorization_revoked, is_hidden FROM user_channels').get()).toEqual({
       granted_by_admin: 0,
+      authorization_revoked: 0,
       is_hidden: 0,
     });
+    expect(memDb.prepare('SELECT mime_type FROM provider_channels').get()).toEqual({ mime_type: 'ts' });
   });
 
   it('disables an unapproved cross-owner config before network or writes', async () => {
@@ -147,7 +151,10 @@ describe('sync authorization regression', () => {
     const result = await performSync(1, 1, { mode: 'scheduled' });
 
     expect(result.errorMessage).toBe(null);
-    expect(memDb.prepare('SELECT granted_by_admin FROM user_channels').get()).toEqual({ granted_by_admin: 1 });
+    expect(memDb.prepare('SELECT granted_by_admin, authorization_revoked FROM user_channels').get()).toEqual({
+      granted_by_admin: 1,
+      authorization_revoked: 0,
+    });
   });
 
   it('allows a trusted manual operation without authorizing future schedules', async () => {
@@ -155,7 +162,10 @@ describe('sync authorization regression', () => {
 
     const manual = await performSync(1, 1, { mode: 'manual', allowCrossOwner: true });
     expect(manual.errorMessage).toBe(null);
-    expect(memDb.prepare('SELECT granted_by_admin FROM user_channels').get()).toEqual({ granted_by_admin: 1 });
+    expect(memDb.prepare('SELECT granted_by_admin, authorization_revoked FROM user_channels').get()).toEqual({
+      granted_by_admin: 1,
+      authorization_revoked: 0,
+    });
     expect(memDb.prepare('SELECT enabled, granted_by_admin FROM sync_configs WHERE id = 7').get()).toEqual({
       enabled: 0,
       granted_by_admin: 0,
@@ -179,6 +189,59 @@ describe('sync authorization regression', () => {
     expect(memDb.prepare('SELECT enabled FROM sync_configs WHERE id = 7').get()).toEqual({ enabled: 0 });
     expect(memDb.prepare('SELECT COUNT(*) AS count FROM user_channels').get().count).toBe(0);
     expect(fetchSafe).not.toHaveBeenCalled();
+  });
+
+  it('an approved scheduled sync restores authorization without unhiding the assignment', async () => {
+    configure({ providerOwner: 2, grant: 1 });
+    memDb.prepare(`
+      INSERT INTO provider_channels
+        (id, provider_id, remote_stream_id, name, original_category_id, stream_type)
+      VALUES (20, 1, 101, 'Old Channel', 10, 'live')
+    `).run();
+    memDb.prepare(`
+      INSERT INTO user_channels
+        (id, user_category_id, provider_channel_id, sort_order, is_hidden,
+         granted_by_admin, authorization_revoked)
+      VALUES (30, 10, 20, 0, 1, 0, 1)
+    `).run();
+
+    const result = await performSync(1, 1, { mode: 'scheduled' });
+
+    expect(result.errorMessage).toBe(null);
+    expect(memDb.prepare(`
+      SELECT is_hidden, granted_by_admin, authorization_revoked
+      FROM user_channels WHERE id = 30
+    `).get()).toEqual({
+      is_hidden: 1,
+      granted_by_admin: 1,
+      authorization_revoked: 0,
+    });
+  });
+
+  it('requires the explicit restore flag for a manual cross-owner reconciliation', async () => {
+    configure({ providerOwner: 2, enabled: 0 });
+    memDb.prepare(`
+      INSERT INTO provider_channels
+        (id, provider_id, remote_stream_id, name, original_category_id, stream_type)
+      VALUES (20, 1, 101, 'Old Channel', 10, 'live')
+    `).run();
+    memDb.prepare(`
+      INSERT INTO user_channels
+        (id, user_category_id, provider_channel_id, authorization_revoked)
+      VALUES (30, 10, 20, 1)
+    `).run();
+
+    await performSync(1, 1, { mode: 'manual', allowCrossOwner: true });
+    expect(memDb.prepare('SELECT granted_by_admin, authorization_revoked FROM user_channels WHERE id = 30').get())
+      .toEqual({ granted_by_admin: 0, authorization_revoked: 1 });
+
+    await performSync(1, 1, {
+      mode: 'manual',
+      allowCrossOwner: true,
+      restoreRevokedAssignments: true,
+    });
+    expect(memDb.prepare('SELECT granted_by_admin, authorization_revoked FROM user_channels WHERE id = 30').get())
+      .toEqual({ granted_by_admin: 1, authorization_revoked: 0 });
   });
 
   afterAll(() => memDb.close());

--- a/tests/user_clone_regression.test.js
+++ b/tests/user_clone_regression.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockPrepare, mockTransaction, insertChannelRun, insertProviderRun, providerChannelsAll, providerChannelsIterate } = vi.hoisted(() => {
+const { mockPrepare, mockTransaction, insertChannelRun, insertProviderRun, insertUserChannelRun, insertSyncRun, providerChannelsAll, providerChannelsIterate } = vi.hoisted(() => {
   const insertChannelRun = vi.fn();
   const insertProviderRun = vi.fn().mockReturnValue({ lastInsertRowid: 20 });
   const providerChannelsAll = vi.fn();
@@ -8,6 +8,8 @@ const { mockPrepare, mockTransaction, insertChannelRun, insertProviderRun, provi
   return {
     insertChannelRun,
     insertProviderRun,
+    insertUserChannelRun: vi.fn(),
+    insertSyncRun: vi.fn(),
     providerChannelsAll,
     providerChannelsIterate,
     mockPrepare: vi.fn(),
@@ -113,10 +115,18 @@ describe('User clone regression', () => {
         return { run: insertProviderRun };
       }
       if (query.includes('FROM sync_configs')) {
-        return { all: vi.fn().mockReturnValue([]) };
+        return { all: vi.fn().mockReturnValue([{
+          provider_id: 10,
+          enabled: 1,
+          sync_interval: 'daily',
+          auto_add_categories: 1,
+          auto_add_channels: 1,
+          sync_series_episodes: 1,
+          granted_by_admin: 1,
+        }]) };
       }
       if (query.includes('INSERT OR IGNORE INTO sync_configs')) {
-        return { run: vi.fn() };
+        return { run: insertSyncRun };
       }
       if (query.includes('SELECT * FROM provider_channels')) {
         return {
@@ -134,7 +144,14 @@ describe('User clone regression', () => {
         return { run: vi.fn() };
       }
       if (query.includes('SELECT * FROM user_categories')) {
-        return { all: vi.fn().mockReturnValue([]) };
+        return { all: vi.fn().mockReturnValue([{
+          id: 400,
+          user_id: 1,
+          name: 'Source category',
+          sort_order: 0,
+          is_adult: 0,
+          type: 'live',
+        }]) };
       }
       if (query.includes('INSERT INTO user_categories')) {
         return { run: vi.fn().mockReturnValue({ lastInsertRowid: 40 }) };
@@ -146,10 +163,17 @@ describe('User clone regression', () => {
         return { run: vi.fn() };
       }
       if (query.includes('FROM user_channels uc')) {
-        return { all: vi.fn().mockReturnValue([]) };
+        return { all: vi.fn().mockReturnValue([{
+          user_category_id: 400,
+          provider_channel_id: 100,
+          sort_order: 0,
+          custom_name: '',
+          is_hidden: 0,
+          granted_by_admin: 1,
+        }]) };
       }
       if (query.includes('INSERT INTO user_channels')) {
-        return { run: vi.fn() };
+        return { run: insertUserChannelRun };
       }
       return {
         get: vi.fn(),
@@ -185,5 +209,8 @@ describe('User clone regression', () => {
     expect(providerChannelsIterate).not.toHaveBeenCalled();
     expect(insertChannelRun.mock.calls[0][2]).toBe('Channel 123');
     expect(insertProviderRun.mock.calls[0][12]).toBe(1);
+    expect(insertSyncRun).toHaveBeenCalledWith(20, 200, 1, 'daily', 1, 1, 1);
+    expect(insertUserChannelRun).toHaveBeenCalledWith(40, 30, 0, '', 0);
+    expect(mockPrepare).toHaveBeenCalledWith(expect.stringContaining('VALUES (?, ?, ?, ?, ?, 0)'));
   });
 });

--- a/tests/user_clone_regression.test.js
+++ b/tests/user_clone_regression.test.js
@@ -211,6 +211,6 @@ describe('User clone regression', () => {
     expect(insertProviderRun.mock.calls[0][12]).toBe(1);
     expect(insertSyncRun).toHaveBeenCalledWith(20, 200, 1, 'daily', 1, 1, 1);
     expect(insertUserChannelRun).toHaveBeenCalledWith(40, 30, 0, '', 0);
-    expect(mockPrepare).toHaveBeenCalledWith(expect.stringContaining('VALUES (?, ?, ?, ?, ?, 0)'));
+    expect(mockPrepare).toHaveBeenCalledWith(expect.stringContaining('VALUES (?, ?, ?, ?, ?, 0, 0)'));
   });
 });


### PR DESCRIPTION
## Summary

This PR hardens channel authorization, tenant-scoped ordering and category mapping, stream/provider compatibility, series alias lifecycle, dependency validation, and release CI. It contains no Stalker/MAG feature code; that work remains in separate PR #610.

## Tenant-safe writes

- User-category reorder IDs must be unique positive safe integers.
- Every requested category must belong to the route user; validation and scoped updates run in one transaction.
- Channel-assignment reorder IDs must be unique positive safe integers and belong to the route category.
- Unknown, malformed, duplicate, cross-category, and cross-tenant IDs reject the complete operation without partial writes.
- Administrator requests remain scoped to the target user/category.
- Category mappings can be explicitly unmapped with null; non-null targets must exist, belong to the mapping owner, and match its live/movie/series content type.
- Sync treats corrupt legacy foreign or wrong-type mappings as unmapped.

## Atomic bulk deletion

- Bulk channel and category deletion validate every submitted ID before any write.
- Unknown, malformed, duplicate, or unauthorized IDs reject the complete request.
- Visibility/deletion changes run in one transaction and report the actual changed-row count.
- Caches are cleared only after success for every affected user.
- Existing series-alias foreign-key cascade coverage remains intact for physical assignment deletion.

## Authorization and provider selection

Assignments retain separate visibility (is_hidden) and ownership authorization (authorization_revoked) state. Explicit administrator grants remain distinguishable through granted_by_admin.

The one-time legacy authorization repair records user_channel_authorization_v1 in settings after its transactional backfill and view creation. Later startups perform only cheap marker/schema/view checks and skip the table scan, backfill, and view rebuild.

Same-owner playback keeps the existing compatible-account pool. For an explicit cross-owner grant, IPTV-Manager tries the exact source provider first and does not substitute an unrelated target-user account merely because it has the same normalized panel URL. Account-level failover is allowed only when the source provider explicitly lists the candidate URL in backup_urls; the selected provider's connection limit, credentials, headers, and backup URLs stay authoritative.

## Movie extension authority

The public movie URL suffix is cosmetic. Direct, proxied, transcoded, track, subtitle, and backup-provider upstream URLs use only normalizeContainerExtension(channel.mime_type, 'mp4'). Stored metadata therefore wins (for example, stored mkv remains mkv even when a client requests .ts), and missing metadata falls back to mp4.

## Series aliases and cache identity

The idempotent SQLite migration rebuilds series_episode_aliases with a foreign key to user_channels(id) ON DELETE CASCADE. It preserves valid alias IDs and relationships, removes orphan rows, keeps the public alias range and uniqueness constraints, recreates the index, and remains safe on repeated startup. User-channel, category, provider, and user deletion now cascade without path-specific cleanup.

Episode catalogs intentionally use the normalized panel URL as their cache identity. Accounts on the same normalized panel URL therefore share panel-global series IDs, episode IDs, metadata, and extensions. The first successful current record is authoritative; an eligible later refresh may replace it. Regression coverage proves that equal-version conflicting sibling-account metadata does not silently overwrite the authoritative record.

## Compatibility notes

Existing live and movie identifiers remain stable. Series without cached episodes remain absent from direct-play lists until synchronization rather than appearing as known-broken entries. Legacy episode URLs remain accepted only when they resolve to exactly one currently authorized series episode. The stricter reorder and mapping endpoints return a non-sensitive failure instead of accepting partial or foreign IDs.

## Validation

Commit `b97c8cbeaaece3bf49281f53249219bad801a543` passed GitHub Actions run [30631009996](https://github.com/Bladestar2105/IPTV-Manager/actions/runs/30631009996):

- `validate`: passed (install, lint, isolated tests, build, and both audits);
- `build-docker`: passed without publishing a pull-request image;
- `release-package`: correctly skipped for the pull request.

Fresh local validation:

- `npm ci`: passed; 381 packages audited, 0 vulnerabilities.
- `npm run lint`: passed with 0 errors and 144 existing warnings.
- `npm audit --audit-level=high`: passed, 0 vulnerabilities.
- `npm audit --omit=dev --audit-level=high`: passed, 0 vulnerabilities.
- isolated full `npm test`: **89 files, 546 tests passed**.
- focused bulk/authorization/reorder/mapping/alias/migration/provider-owner/backup/Xtream/HDHomeRun/share/EPG suites: **11 files, 87 tests passed**.
- `npm run build`: passed.
- `npm ci --dry-run`: passed.
- `docker build -t iptv-manager-pr608-final .`: passed; local image manifest `sha256:69b2f4d55e26c4d8e13c48a4b65d6425b53d90c02e84ac7ce79e25d60ba07f6e`.
- `git diff --check origin/main`: passed.
- working tree: clean.

## Readiness

All PR #608 acceptance criteria and required local/CI checks pass. PR #608 is ready to merge once the required review state is clear.
