### PR TITLE
fix: harden catch-up and radio synchronization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,5 +17,10 @@ All notable changes to this project are documented here.
   responses.
 - Added provider-timezone-aware catch-up formatting with epoch-preserving
   internal archive links.
+- Reject internal epoch catch-up links for programmes that have not ended.
+- Synchronize radio category mappings for live provider channels alongside live
+  mappings without duplicating provider channels.
+- Run bulk category deletion and channel hiding validation and writes in one
+  transaction with post-commit cache invalidation.
 - Validated the experimental portal with real software clients.
 - Hardware-specific MAG UI and favorites remain unsupported.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -186,6 +186,12 @@ rebuilt ownership relationships. Imported cross-owner administrator grants are
 restored only when the admin import request also includes
 `allow_cross_owner: true`; otherwise their sync configs remain disabled and
 their channel assignments remain authorization-revoked.
+
+Radio categories are user-facing mappings of live provider channels. A live
+provider category may be mapped to both live and radio user categories, and
+automatic synchronization maintains both mappings independently. The same
+provider channel record is reused while each user-facing mapping has its own
+`user_channels` assignment.
 - `GET /api/sync-logs`
 - `GET /api/statistics`
 - `POST /api/statistics/streams/:streamId/terminate`
@@ -343,6 +349,10 @@ commands must target the same type; `vod` accepts movies plus the documented
 series episode command only when both its positive season and `series` episode
 number are present. `tv_archive` accepts only the opaque archive command emitted
 for an authorized EPG row. Cross-module commands return `nothing_to_play`.
+
+Epoch-based internal catch-up links are accepted only for completed EPG
+programmes inside the configured archive window. Formatted Xtream timeshift
+starts remain supported.
 
 Bulk EPG clamps `period` to 168 hours. The response window determines a maximum
 of four programme rows per hour, capped at 500 rows per channel, with a global

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -131,6 +131,12 @@ their authorization revocation, while an administrator must explicitly restore
 a selected channel to clear its hidden state. Re-running the migration is
 idempotent and does not infer administrator grants.
 
+Automatic category synchronization records ownership of new assignments in the
+nullable `user_channels.mapping_id` column. Legacy or manually curated rows
+remain unowned (`NULL`) so a category move cannot delete them; only assignments
+created by an active mapping are reconciled. The migration adds the column and
+an index without changing public IDs.
+
 ## Series Episode Cache Identity
 
 Series episode metadata is keyed by the normalized upstream panel URL. Provider

--- a/src/controllers/backupController.js
+++ b/src/controllers/backupController.js
@@ -77,6 +77,11 @@ export const restoreBackup = (req, res) => {
     if ([...restoredCategoryIds].some(id => !Number.isInteger(id) || id <= 0)) {
       return res.status(400).json({ error: 'Invalid backup data' });
     }
+    const backupMappingTargets = new Map(
+      data.categoryMappings
+        .filter(map => Number.isInteger(Number(map.id)) && Number(map.id) > 0)
+        .map(map => [Number(map.id), Number(map.user_category_id)])
+    );
 
     const stats = { channels_restored: 0, channels_hidden: 0, channels_skipped: 0 };
 
@@ -98,9 +103,10 @@ export const restoreBackup = (req, res) => {
       const insertChannel = db.prepare(`
         INSERT INTO user_channels
           (id, user_category_id, provider_channel_id, sort_order, custom_name, is_hidden,
-           granted_by_admin, authorization_revoked)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+           mapping_id, granted_by_admin, authorization_revoked)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
       `);
+      const getMapping = db.prepare('SELECT id FROM category_mappings WHERE id = ? AND user_id = ?');
       const getProviderOwner = db.prepare(`
         SELECT p.user_id AS provider_owner_id
         FROM provider_channels pc
@@ -135,6 +141,11 @@ export const restoreBackup = (req, res) => {
         });
         const isHidden = Number(chan.is_hidden) === 1 ? 1 : 0;
         const authorizationRevoked = grant === null ? 1 : 0;
+        const mappingId = Number(chan.mapping_id);
+        const restoredMappingId = Number.isInteger(mappingId) && mappingId > 0 &&
+          backupMappingTargets.get(mappingId) === categoryId && getMapping.get(mappingId, userId)
+          ? mappingId
+          : null;
 
         insertChannel.run(
           chan.id,
@@ -143,6 +154,7 @@ export const restoreBackup = (req, res) => {
           chan.sort_order,
           chan.custom_name || '',
           isHidden,
+          restoredMappingId,
           grant === 1 ? 1 : 0,
           authorizationRevoked
         );

--- a/src/controllers/channelController.js
+++ b/src/controllers/channelController.js
@@ -16,6 +16,12 @@ function parseUniquePositiveIds(values) {
   return ids;
 }
 
+function bulkOperationError(status, message) {
+  const error = new Error(message);
+  error.status = status;
+  return error;
+}
+
 export const getUserCategories = (req, res) => {
   try {
     const userId = Number(req.params.userId);
@@ -101,24 +107,28 @@ export const bulkDeleteUserCategories = (req, res) => {
     const categoryIds = parseUniquePositiveIds(ids);
     if (!categoryIds) return res.status(400).json({error: 'Invalid ids'});
     const placeholders = Array(categoryIds.length).fill('?').join(',');
-    const categories = db.prepare(`SELECT id, user_id FROM user_categories WHERE id IN (${placeholders})`).all(...categoryIds);
-    if (categories.length !== categoryIds.length) return res.status(400).json({error: 'Category not found'});
-    if (!req.user.is_admin && categories.some(category => category.user_id !== req.user.id)) {
-      return res.status(403).json({error: 'Access denied'});
-    }
+    const result = db.transaction(() => {
+      const categories = db.prepare(`SELECT id, user_id FROM user_categories WHERE id IN (${placeholders})`).all(...categoryIds);
+      if (categories.length !== categoryIds.length) throw bulkOperationError(400, 'Category not found');
+      if (!req.user.is_admin && categories.some(category => category.user_id !== req.user.id)) {
+        throw bulkOperationError(403, 'Access denied');
+      }
 
-    const userIdsToClear = [...new Set(categories.map(category => category.user_id))];
-    const deleted = db.transaction(() => {
       db.prepare(`DELETE FROM user_channels WHERE user_category_id IN (${placeholders})`).run(...categoryIds);
       db.prepare(`UPDATE category_mappings SET user_category_id = NULL, auto_created = 0 WHERE user_category_id IN (${placeholders})`).run(...categoryIds);
-      return db.prepare(`DELETE FROM user_categories WHERE id IN (${placeholders})`).run(...categoryIds).changes;
+      const deleted = db.prepare(`DELETE FROM user_categories WHERE id IN (${placeholders})`).run(...categoryIds).changes;
+      if (deleted !== categoryIds.length) throw bulkOperationError(400, 'Category not found');
+
+      db.prepare('INSERT INTO security_logs (ip, action, details, timestamp) VALUES (?, ?, ?, ?)').run(req.ip, 'category_bulk_deleted', `User ${req.user.username} bulk deleted ${deleted} categories`, Math.floor(Date.now() / 1000));
+      return {
+        userIdsToClear: [...new Set(categories.map(category => category.user_id))],
+        deleted
+      };
     })();
 
-    db.prepare('INSERT INTO security_logs (ip, action, details, timestamp) VALUES (?, ?, ?, ?)').run(req.ip, 'category_bulk_deleted', `User ${req.user.username} bulk deleted ${ids.length} categories`, Math.floor(Date.now() / 1000));
-
-    userIdsToClear.forEach(uId => clearChannelsCache(uId));
-    res.json({success: true, deleted});
-  } catch (e) { res.status(500).json({error: e.message}); }
+    result.userIdsToClear.forEach(uId => clearChannelsCache(uId));
+    res.json({success: true, deleted: result.deleted});
+  } catch (e) { res.status(e.status || 500).json({error: e.message}); }
 };
 
 export const reorderUserCategories = (req, res) => {
@@ -367,25 +377,30 @@ export const bulkDeleteUserChannels = (req, res) => {
     const channelIds = parseUniquePositiveIds(ids);
     if (!channelIds) return res.status(400).json({error: 'Invalid ids'});
     const placeholders = Array(channelIds.length).fill('?').join(',');
-    const channels = db.prepare(`
-        SELECT uc.id, uc.is_hidden, cat.user_id
-        FROM user_channels uc
-        JOIN user_categories cat ON cat.id = uc.user_category_id
-        WHERE uc.id IN (${placeholders})
-    `).all(...channelIds);
-    if (channels.length !== channelIds.length) return res.status(400).json({error: 'Channel not found'});
-    if (!req.user.is_admin && channels.some(channel => channel.user_id !== req.user.id)) {
-      return res.status(403).json({error: 'Access denied'});
-    }
+    const result = db.transaction(() => {
+      const channels = db.prepare(`
+          SELECT uc.id, uc.is_hidden, cat.user_id
+          FROM user_channels uc
+          JOIN user_categories cat ON cat.id = uc.user_category_id
+          WHERE uc.id IN (${placeholders})
+      `).all(...channelIds);
+      if (channels.length !== channelIds.length) throw bulkOperationError(400, 'Channel not found');
+      if (!req.user.is_admin && channels.some(channel => channel.user_id !== req.user.id)) {
+        throw bulkOperationError(403, 'Access denied');
+      }
 
-    const userIdsToClear = [...new Set(channels.map(channel => channel.user_id))];
-    const deleted = db.transaction(() => db.prepare(
-      `UPDATE user_channels SET is_hidden = 1 WHERE id IN (${placeholders}) AND is_hidden <> 1`
-    ).run(...channelIds).changes)();
+      const deleted = db.prepare(
+        `UPDATE user_channels SET is_hidden = 1 WHERE id IN (${placeholders}) AND is_hidden <> 1`
+      ).run(...channelIds).changes;
+      return {
+        userIdsToClear: [...new Set(channels.map(channel => channel.user_id))],
+        deleted
+      };
+    })();
 
-    userIdsToClear.forEach(uId => clearChannelsCache(uId));
-    res.json({success: true, deleted});
-  } catch (e) { res.status(500).json({error: e.message}); }
+    result.userIdsToClear.forEach(uId => clearChannelsCache(uId));
+    res.json({success: true, deleted: result.deleted});
+  } catch (e) { res.status(e.status || 500).json({error: e.message}); }
 };
 
 export const getCategoryMappings = (req, res) => {

--- a/src/controllers/providerController.js
+++ b/src/controllers/providerController.js
@@ -734,6 +734,10 @@ export const importCategory = async (req, res) => {
       ON CONFLICT(provider_id, user_id, provider_category_id, category_type)
       DO UPDATE SET user_category_id = excluded.user_category_id
     `).run(providerId, targetUserId, Number(category_id), category_name, newCategoryId, catType);
+    const mapping = db.prepare(`
+      SELECT id FROM category_mappings
+      WHERE provider_id = ? AND user_id = ? AND provider_category_id = ? AND category_type = ?
+    `).get(providerId, targetUserId, Number(category_id), catType);
 
     if (import_channels) {
       let streamType = 'live';
@@ -748,14 +752,14 @@ export const importCategory = async (req, res) => {
 
       const insertChannel = db.prepare(`
         INSERT INTO user_channels
-          (user_category_id, provider_channel_id, sort_order, granted_by_admin, authorization_revoked)
-        VALUES (?, ?, ?, ?, 0)
+          (user_category_id, provider_channel_id, sort_order, mapping_id, granted_by_admin, authorization_revoked)
+        VALUES (?, ?, ?, ?, ?, 0)
       `);
       const channels = stmt.all(providerId, Number(category_id), streamType);
       const importedCount = channels.length;
       db.transaction(() => {
         channels.forEach((ch, idx) => {
-          insertChannel.run(newCategoryId, ch.id, idx, grantedByAdmin);
+          insertChannel.run(newCategoryId, ch.id, idx, mapping?.id || null, grantedByAdmin);
         });
       })();
 
@@ -813,8 +817,8 @@ export const importCategories = async (req, res) => {
     const insertUserCategory = db.prepare('INSERT INTO user_categories (user_id, name, is_adult, sort_order, type) VALUES (?, ?, ?, ?, ?)');
     const insertChannel = db.prepare(`
       INSERT INTO user_channels
-        (user_category_id, provider_channel_id, sort_order, granted_by_admin, authorization_revoked)
-      VALUES (?, ?, ?, ?, 0)
+        (user_category_id, provider_channel_id, sort_order, mapping_id, granted_by_admin, authorization_revoked)
+      VALUES (?, ?, ?, ?, ?, 0)
     `);
     const getMaxSort = db.prepare('SELECT COALESCE(MAX(sort_order), -1) as max_sort FROM user_categories WHERE user_id = ?');
 
@@ -851,6 +855,10 @@ export const importCategories = async (req, res) => {
         ON CONFLICT(provider_id, user_id, provider_category_id, category_type)
         DO UPDATE SET user_category_id = excluded.user_category_id
       `);
+      const getCategoryMapping = db.prepare(`
+        SELECT id FROM category_mappings
+        WHERE provider_id = ? AND user_id = ? AND provider_category_id = ? AND category_type = ?
+      `);
 
       for (const cat of categories) {
         if (!cat.id || !cat.name) continue;
@@ -864,6 +872,7 @@ export const importCategories = async (req, res) => {
         totalCategories++;
 
         insertCategoryMapping.run(providerId, targetUserId, Number(cat.id), cat.name, newCategoryId, catType);
+        const mapping = getCategoryMapping.get(providerId, targetUserId, Number(cat.id), catType);
 
         let channelsImported = 0;
         if (cat.import_channels) {
@@ -874,7 +883,7 @@ export const importCategories = async (req, res) => {
           const channels = channelsMap.get(`${Number(cat.id)}_${streamType}`) || [];
 
           channels.forEach((ch, idx) => {
-            insertChannel.run(newCategoryId, ch.id, idx, grantedByAdmin);
+            insertChannel.run(newCategoryId, ch.id, idx, mapping?.id || null, grantedByAdmin);
           });
           channelsImported = channels.length;
           totalChannels += channelsImported;

--- a/src/controllers/streamController.js
+++ b/src/controllers/streamController.js
@@ -1439,10 +1439,23 @@ export const proxyTimeshift = async (req, res) => {
       } catch {
         archiveProgram = null;
       }
-      const expectedDuration = archiveProgram
-        ? Math.min(Math.max(Math.ceil((Number(archiveProgram.stop) - epochStart) / 60), 1), 1440)
+      const archiveStart = Number(archiveProgram?.start);
+      const archiveStop = Number(archiveProgram?.stop);
+      const expectedDuration = isSupportedEpoch(archiveStart) && isSupportedEpoch(archiveStop) && archiveStop > archiveStart
+        ? Math.min(Math.max(Math.ceil((archiveStop - archiveStart) / 60), 1), 1440)
         : 0;
-      if (!channel.tv_archive || !archiveProgram || epochStart > now || epochStart < now - archiveDays * 86400 || expectedDuration !== durationNumber) {
+      if (
+        !channel.tv_archive ||
+        !archiveProgram ||
+        !isSupportedEpoch(archiveStart) ||
+        !isSupportedEpoch(archiveStop) ||
+        archiveStart !== epochStart ||
+        archiveStop <= archiveStart ||
+        archiveStop > now ||
+        epochStart > now ||
+        epochStart < now - archiveDays * 86400 ||
+        expectedDuration !== durationNumber
+      ) {
         return res.sendStatus(404);
       }
     }

--- a/src/controllers/systemController.js
+++ b/src/controllers/systemController.js
@@ -588,6 +588,7 @@ export const importData = async (req, res) => {
         INSERT INTO category_mappings (provider_id, user_id, provider_category_id, provider_category_name, user_category_id, auto_created, category_type)
         VALUES (?, ?, ?, ?, ?, ?, ?)
       `);
+      const mappingIdMap = new Map();
 
       for (const m of importData.mappings) {
         const newProvId = providerIdMap.get(m.provider_id);
@@ -595,7 +596,8 @@ export const importData = async (req, res) => {
         const newUserCatId = m.user_category_id ? categoryIdMap.get(m.user_category_id) : null;
 
         if (newProvId && newUserId) {
-           insertMappingStmt.run(newProvId, newUserId, m.provider_category_id, m.provider_category_name, newUserCatId, m.auto_created, m.category_type || 'live');
+           const info = insertMappingStmt.run(newProvId, newUserId, m.provider_category_id, m.provider_category_name, newUserCatId, m.auto_created, m.category_type || 'live');
+           mappingIdMap.set(Number(m.id), info.lastInsertRowid);
         }
       }
 
@@ -635,8 +637,8 @@ export const importData = async (req, res) => {
       const insertUserChannel = db.prepare(`
         INSERT INTO user_channels
           (user_category_id, provider_channel_id, sort_order, custom_name, is_hidden,
-           granted_by_admin, authorization_revoked)
-        VALUES (?, ?, ?, ?, ?, ?, ?)
+           mapping_id, granted_by_admin, authorization_revoked)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
       `);
 
       for (const ua of userAssignments) {
@@ -657,6 +659,7 @@ export const importData = async (req, res) => {
             ua.sort_order,
             ua.custom_name || '',
             Number(ua.is_hidden) === 1 ? 1 : 0,
+            Number(ua.mapping_id) > 0 ? (mappingIdMap.get(Number(ua.mapping_id)) || null) : null,
             grant === 1 ? 1 : 0,
             grant === null ? 1 : 0
           );

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -308,10 +308,11 @@ export const createUser = async (req, res) => {
                     INSERT OR IGNORE INTO category_mappings (provider_id, user_id, provider_category_id, provider_category_name, user_category_id, auto_created, category_type)
                     VALUES (?, ?, ?, ?, ?, ?, ?)
                 `);
+                const mappingIdMap = new Map();
 
                 for (const m of sourceMappings) {
                     if (providerMap[m.provider_id]) {
-                        insertMapping.run(
+                        const mappingInfo = insertMapping.run(
                             providerMap[m.provider_id],
                             newUserId,
                             m.provider_category_id,
@@ -320,6 +321,7 @@ export const createUser = async (req, res) => {
                             m.auto_created,
                             m.category_type || 'live'
                         );
+                        mappingIdMap.set(Number(m.id), Number(mappingInfo.lastInsertRowid));
                     }
                 }
 
@@ -329,13 +331,13 @@ export const createUser = async (req, res) => {
                 const insertUserChan = db.prepare(`
                     INSERT INTO user_channels
                       (user_category_id, provider_channel_id, sort_order, custom_name, is_hidden,
-                       granted_by_admin, authorization_revoked)
-                    VALUES (?, ?, ?, ?, ?, 0, 0)
+                       mapping_id, granted_by_admin, authorization_revoked)
+                    VALUES (?, ?, ?, ?, ?, ?, 0, 0)
                 `);
 
                 // Fetch all user channels for source user categories
                 const sourceUserChans = db.prepare(`
-                    SELECT uc.user_category_id, uc.provider_channel_id, uc.sort_order, uc.custom_name, uc.is_hidden
+                    SELECT uc.user_category_id, uc.provider_channel_id, uc.sort_order, uc.custom_name, uc.is_hidden, uc.mapping_id
                     FROM user_channels uc
                     JOIN user_categories cat ON uc.user_category_id = cat.id
                     WHERE cat.user_id = ?
@@ -346,7 +348,7 @@ export const createUser = async (req, res) => {
                     const newProvChanId = channelMap[uc.provider_channel_id];
 
                     if (newCatId && newProvChanId) {
-                        insertUserChan.run(newCatId, newProvChanId, uc.sort_order, uc.custom_name || '', uc.is_hidden || 0);
+                        insertUserChan.run(newCatId, newProvChanId, uc.sort_order, uc.custom_name || '', uc.is_hidden || 0, mappingIdMap.get(Number(uc.mapping_id)) || null);
                     }
                 }
             }

--- a/src/database/db.js
+++ b/src/database/db.js
@@ -120,7 +120,8 @@ export function initDb(isPrimary) {
       custom_name TEXT DEFAULT '',
       is_hidden INTEGER DEFAULT 0,
       granted_by_admin INTEGER NOT NULL DEFAULT 0,
-      authorization_revoked INTEGER NOT NULL DEFAULT 0
+      authorization_revoked INTEGER NOT NULL DEFAULT 0,
+      mapping_id INTEGER
     );
 
     CREATE TABLE IF NOT EXISTS user_backups (
@@ -308,6 +309,7 @@ export function initDb(isPrimary) {
             migrations.migrateUserAllowedCountries(db);
             migrations.migrateUserChannelsCustomName(db);
             migrations.migrateUserChannelsIsHidden(db);
+            migrations.migrateUserChannelMappingId(db);
             migrations.migrateUserChannelAdminGrants(db);
             migrations.migrateSyncConfigAdminGrants(db);
             migrations.migrateUserNotes(db);

--- a/src/database/migrations.js
+++ b/src/database/migrations.js
@@ -773,6 +773,19 @@ export function migrateUserChannelsIsHidden(db) {
   }
 }
 
+export function migrateUserChannelMappingId(db) {
+  try {
+    const columns = db.prepare('PRAGMA table_info(user_channels)').all().map(column => column.name);
+    if (!columns.includes('mapping_id')) {
+      db.exec('ALTER TABLE user_channels ADD COLUMN mapping_id INTEGER');
+      console.log('✅ DB Migration: mapping_id column added to user_channels');
+    }
+    db.exec('CREATE INDEX IF NOT EXISTS idx_user_channels_mapping ON user_channels(mapping_id)');
+  } catch (e) {
+    console.error('User channel mapping migration error:', e);
+  }
+}
+
 export function migrateUserChannelAdminGrants(db) {
   const migrate = db.transaction(() => {
     const columns = db.prepare('PRAGMA table_info(user_channels)').all().map(column => column.name);

--- a/src/services/syncService.js
+++ b/src/services/syncService.js
@@ -117,15 +117,18 @@ export async function performSync(providerId, userId, options = {}) {
 
     let allChannels = [];
     let allCategories = [];
+    const completeStreamTypes = new Set();
 
     // 1. Live & M3U Fallback
     try {
        let liveChans = [];
        let m3uMode = false;
+       let liveFetchComplete = false;
 
        // Try Xtream API
        try {
          liveChans = await xtream.getChannels();
+         liveFetchComplete = Array.isArray(liveChans);
        } catch {
           try {
              const resp = await fetchSafe(`${baseUrl}/player_api.php?${authParams}&action=get_live_streams`, { timeout: 60000 });
@@ -133,6 +136,7 @@ export async function performSync(providerId, userId, options = {}) {
                  const contentType = resp.headers.get('content-type');
                  if (contentType && contentType.includes('application/json')) {
                      liveChans = await resp.json();
+                     liveFetchComplete = Array.isArray(liveChans);
                  }
              }
           } catch(e) {}
@@ -140,6 +144,8 @@ export async function performSync(providerId, userId, options = {}) {
 
        // M3U Fallback if Xtream failed or empty
        if (!Array.isArray(liveChans) || liveChans.length === 0) {
+           const apiFetchComplete = liveFetchComplete;
+           liveFetchComplete = false;
            try {
              // Try fetching as M3U
              const m3uResp = await fetchSafe(provider.url, { timeout: 60000 }); // Use original URL
@@ -148,6 +154,7 @@ export async function performSync(providerId, userId, options = {}) {
                  if (parsed.isM3u) {
                      console.debug('  📂 Detected M3U Playlist');
                      m3uMode = true;
+                     liveFetchComplete = true;
 
                      // Map to Xtream format
                      parsed.channels.forEach((ch, idx) => {
@@ -184,6 +191,7 @@ export async function performSync(providerId, userId, options = {}) {
                  }
              }
            } catch (e) { console.error('M3U fallback error:', e.message); }
+           if (!liveFetchComplete && apiFetchComplete) liveFetchComplete = true;
        }
 
        // Normalize
@@ -195,6 +203,7 @@ export async function performSync(providerId, userId, options = {}) {
            }
            allChannels.push(c);
          });
+         if (liveFetchComplete) completeStreamTypes.add('live');
        }
 
        if (!m3uMode) {
@@ -221,6 +230,7 @@ export async function performSync(providerId, userId, options = {}) {
                 c.category_type = 'movie';
                 allChannels.push(c);
             });
+            completeStreamTypes.add('movie');
          }
        } else {
          console.error(`VOD fetch failed: ${resp.status}`);
@@ -249,6 +259,7 @@ export async function performSync(providerId, userId, options = {}) {
                 c.stream_icon = c.cover;
                 allChannels.push(c);
             });
+            completeStreamTypes.add('series');
          }
        }
 
@@ -262,8 +273,6 @@ export async function performSync(providerId, userId, options = {}) {
     } catch(e) { console.error('Series sync error:', e); }
 
     // Process categories and create mappings
-    const categoryMap = new Map(); // Map<String, Int> -> "catId_type" -> userCatId
-
     // Performance Optimization: Pre-fetch all mappings to avoid N+1 queries
     const allMappings = db.prepare(`
       SELECT cm.*,
@@ -280,14 +289,11 @@ export async function performSync(providerId, userId, options = {}) {
 
     const isFirstSync = allMappings.length === 0;
 
-    // Create lookup map and populate initial categoryMap
+    // Create lookup map
     const mappingLookup = new Map(); // Key: "catId_type"
     for (const m of allMappings) {
       const key = `${m.provider_category_id}_${m.category_type || 'live'}`;
       mappingLookup.set(key, m);
-      if (m.user_category_id) {
-        categoryMap.set(key, m.user_category_id);
-      }
     }
 
     // Prepare channel statements
@@ -325,20 +331,21 @@ export async function performSync(providerId, userId, options = {}) {
     // Prepare statement unconditionally to avoid potential undefined issues
     const insertUserChannel = db.prepare(`
       INSERT INTO user_channels
-        (user_category_id, provider_channel_id, sort_order, granted_by_admin, authorization_revoked)
-      VALUES (?, ?, ?, ?, 0)
+        (user_category_id, provider_channel_id, sort_order, mapping_id, granted_by_admin, authorization_revoked)
+      VALUES (?, ?, ?, ?, ?, 0)
     `);
     const authorizeExistingAssignment = db.prepare(`
       UPDATE user_channels
       SET granted_by_admin = ?, authorization_revoked = 0
       WHERE id = ?
     `);
-    const deleteUserChannel = db.prepare('DELETE FROM user_channels WHERE user_category_id = ? AND provider_channel_id = ?');
+    const updateAssignmentMapping = db.prepare('UPDATE user_channels SET mapping_id = ? WHERE id = ?');
+    const deleteMappedAssignment = db.prepare('DELETE FROM user_channels WHERE id = ? AND mapping_id = ?');
 
     if (config && config.auto_add_channels) {
       const existingAssignmentsRows = db.prepare(`
         SELECT uc.id, uc.user_category_id, uc.provider_channel_id,
-               uc.granted_by_admin, uc.authorization_revoked
+               uc.mapping_id, uc.granted_by_admin, uc.authorization_revoked
         FROM user_channels uc
         JOIN provider_channels pc ON pc.id = uc.provider_channel_id
         WHERE pc.provider_id = ?
@@ -365,6 +372,17 @@ export async function performSync(providerId, userId, options = {}) {
       INSERT INTO category_mappings (provider_id, user_id, provider_category_id, provider_category_name, user_category_id, auto_created, category_type)
       VALUES (?, ?, ?, ?, ?, 1, ?)
     `);
+
+    const getMappedTargets = (categoryId, categoryType) => {
+      const keys = [`${categoryId}_${categoryType}`];
+      if (categoryType === 'live') keys.push(`${categoryId}_radio`);
+      return keys.map(key => ({ key, mapping: mappingLookup.get(key) })).filter(({ key, mapping }) => {
+        if (!mapping?.user_category_id || !mapping.id) return false;
+        const expectedType = key.endsWith('_radio') ? 'radio' : categoryType;
+        return (mapping.category_type || 'live') === expectedType;
+      }).map(({ mapping }) => mapping);
+    };
+    const seenRemoteIdsByType = new Map();
 
     // Execute all DB operations in a single transaction
     db.transaction(() => {
@@ -397,9 +415,7 @@ export async function performSync(providerId, userId, options = {}) {
           const newCategoryId = catInfo.lastInsertRowid;
 
           // Create new mapping (only for new categories)
-          insertCategoryMapping.run(providerId, userId, catId, catName, newCategoryId, catType);
-
-          categoryMap.set(lookupKey, newCategoryId);
+          const mappingInfo = insertCategoryMapping.run(providerId, userId, catId, catName, newCategoryId, catType);
 
           // Update lookup to prevent duplicates in current run
           mappingLookup.set(lookupKey, {
@@ -408,6 +424,7 @@ export async function performSync(providerId, userId, options = {}) {
             provider_category_id: catId,
             provider_category_name: catName,
             user_category_id: newCategoryId,
+            id: Number(mappingInfo.lastInsertRowid),
             auto_created: 1,
             category_type: catType
           });
@@ -416,7 +433,7 @@ export async function performSync(providerId, userId, options = {}) {
           console.debug(`  ✅ Created category: ${catName} (${catType}) (id=${newCategoryId})`);
         } else if (!mapping && isFirstSync) {
           // First sync: Create mapping without user category
-          db.prepare(`
+          const mappingInfo = db.prepare(`
             INSERT INTO category_mappings (provider_id, user_id, provider_category_id, provider_category_name, user_category_id, auto_created, category_type)
             VALUES (?, ?, ?, ?, NULL, 0, ?)
           `).run(providerId, userId, catId, catName, catType);
@@ -428,6 +445,7 @@ export async function performSync(providerId, userId, options = {}) {
             provider_category_id: catId,
             provider_category_name: catName,
             user_category_id: null,
+            id: Number(mappingInfo.lastInsertRowid),
             auto_created: 0,
             category_type: catType
           });
@@ -448,6 +466,11 @@ export async function performSync(providerId, userId, options = {}) {
           const tvArchive = Number(ch.tv_archive) === 1 ? 1 : 0;
           const tvArchiveDuration = Number(ch.tv_archive_duration) || 0;
           const streamType = ch.stream_type || 'live';
+          const catId = Number(ch.category_id || 0);
+          const catType = ch.category_type || 'live';
+          const mappingTargets = getMappedTargets(catId, catType);
+          if (!seenRemoteIdsByType.has(streamType)) seenRemoteIdsByType.set(streamType, new Set());
+          seenRemoteIdsByType.get(streamType).add(sid);
           const mimeType = normalizeContainerExtension(
             ch.container_extension,
             streamType === 'live' ? 'ts' : 'mp4'
@@ -547,16 +570,20 @@ export async function performSync(providerId, userId, options = {}) {
               // remove it from the old user category (if auto_add_channels is enabled).
               // The subsequent logic will add it to the new user category if applicable.
               if (categoryChanged && config && config.auto_add_channels) {
-                const oldLookupKey = `${existingRow.original_category_id}_${existingRow.stream_type || 'live'}`;
-                const oldUserCatId = categoryMap.get(oldLookupKey);
+                const oldCategoryId = Number(existingRow.original_category_id || 0);
+                const oldCategoryType = existingRow.stream_type || 'live';
+                const oldKeys = [`${oldCategoryId}_${oldCategoryType}`];
+                if (oldCategoryType === 'live') oldKeys.push(`${oldCategoryId}_radio`);
+                const oldMappingIds = new Set(oldKeys
+                  .map(key => mappingLookup.get(key)?.id)
+                  .filter(Boolean)
+                  .map(Number));
 
-                if (oldUserCatId) {
-                  const assignmentKey = `${oldUserCatId}_${existingId}`;
-                  if (existingAssignments.has(assignmentKey)) {
-                    deleteUserChannel.run(oldUserCatId, existingId);
-                    existingAssignments.delete(assignmentKey);
-                    console.debug(`  🗑️ Removed moved channel "${newName}" from old user category (id=${oldUserCatId})`);
-                  }
+                for (const [assignmentKey, assignment] of existingAssignments) {
+                  if (Number(assignment.provider_channel_id) !== Number(existingId) || !oldMappingIds.has(Number(assignment.mapping_id))) continue;
+                  deleteMappedAssignment.run(assignment.id, assignment.mapping_id);
+                  existingAssignments.delete(assignmentKey);
+                  console.debug(`  🗑️ Removed mapped assignment for moved channel "${newName}"`);
                 }
               }
 
@@ -620,13 +647,9 @@ export async function performSync(providerId, userId, options = {}) {
 
           // Auto-add to user categories if enabled
           if (config && config.auto_add_channels) {
-            const catId = Number(ch.category_id || 0);
-            const catType = ch.category_type || 'live';
-            const lookupKey = `${catId}_${catType}`;
-
-            const userCatId = categoryMap.get(lookupKey);
-
-            if (userCatId) {
+            for (const mapping of mappingTargets) {
+              const userCatId = Number(mapping.user_category_id);
+              const mappingId = Number(mapping.id);
               // Check if already added (Optimized in-memory check)
               const assignmentKey = `${userCatId}_${provChannelId}`;
 
@@ -637,22 +660,47 @@ export async function performSync(providerId, userId, options = {}) {
                 if (currentMax === undefined) currentMax = -1;
                 const newSortOrder = currentMax + 1;
 
-                const assignmentInfo = insertUserChannel.run(userCatId, provChannelId, newSortOrder, assignmentGrant);
+                const assignmentInfo = insertUserChannel.run(userCatId, provChannelId, newSortOrder, mappingId, assignmentGrant);
 
                 // Update in-memory state
                 existingAssignments.set(assignmentKey, {
                   id: Number(assignmentInfo.lastInsertRowid),
+                  user_category_id: userCatId,
+                  provider_channel_id: Number(provChannelId),
+                  mapping_id: mappingId,
                   granted_by_admin: assignmentGrant,
                   authorization_revoked: 0
                 });
                 maxSortMap.set(userCatId, newSortOrder);
-              } else if (!crossOwner) {
-                authorizeExistingAssignment.run(0, existingAssignment.id);
-              } else if (Number(existingAssignment.granted_by_admin) === 1 || restoreRevokedAssignments) {
-                authorizeExistingAssignment.run(1, existingAssignment.id);
+              } else {
+                if (existingAssignment.mapping_id && Number(existingAssignment.mapping_id) !== mappingId) {
+                  updateAssignmentMapping.run(mappingId, existingAssignment.id);
+                  existingAssignment.mapping_id = mappingId;
+                }
+                if (!crossOwner) {
+                  authorizeExistingAssignment.run(0, existingAssignment.id);
+                } else if (Number(existingAssignment.granted_by_admin) === 1 || restoreRevokedAssignments) {
+                  authorizeExistingAssignment.run(1, existingAssignment.id);
+                }
               }
             }
           }
+        }
+      }
+
+      // Remove provider entries that were confirmed absent from a complete
+      // stream-type response. Explicitly remove assignments first because
+      // legacy databases do not enforce a foreign key on user_channels.
+      for (const streamType of completeStreamTypes) {
+        const seenIds = [...(seenRemoteIdsByType.get(streamType) || [])];
+        const notInSeen = seenIds.length ? ` AND remote_stream_id NOT IN (${Array(seenIds.length).fill('?').join(',')})` : '';
+        const staleRows = db.prepare(`
+          SELECT id FROM provider_channels
+          WHERE provider_id = ? AND COALESCE(stream_type, 'live') = ?${notInSeen}
+        `).all(providerId, streamType, ...seenIds);
+        for (const stale of staleRows) {
+          db.prepare('DELETE FROM user_channels WHERE provider_channel_id = ?').run(stale.id);
+          db.prepare('DELETE FROM provider_channels WHERE id = ? AND provider_id = ?').run(stale.id, providerId);
         }
       }
     })();

--- a/tests/controllers/channelController.test.js
+++ b/tests/controllers/channelController.test.js
@@ -665,4 +665,48 @@ describe('Channel Controller - createUserCategory', () => {
         expect(res.status).toHaveBeenCalledWith(400);
         expect(db.prepare('SELECT id FROM user_categories WHERE id = ?').get(category)).toEqual({ id: category });
     });
+
+    it('deletes categories, assignments, and mappings atomically after validation', () => {
+        const own = addAssignment(2);
+        const providerId = db.prepare(`
+          SELECT pc.provider_id
+          FROM provider_channels pc
+          JOIN user_channels uc ON uc.provider_channel_id = pc.id
+          WHERE uc.id = ?
+        `).get(own.assignmentId).provider_id;
+        const mappingId = db.prepare(`
+          INSERT INTO category_mappings
+            (provider_id, user_id, provider_category_id, provider_category_name, user_category_id, category_type)
+          VALUES (?, 2, 10, 'Mapped', ?, 'live')
+        `).run(providerId, own.categoryId).lastInsertRowid;
+        channelsJsonCache.set('user_2_live', ['cached']);
+        const res = response();
+
+        channelController.bulkDeleteUserCategories({
+            body: { ids: [own.categoryId] },
+            user: { id: 2, is_admin: false, username: 'user' }, ip: '127.0.0.1'
+        }, res);
+
+        expect(res.json).toHaveBeenCalledWith({ success: true, deleted: 1 });
+        expect(db.prepare('SELECT id FROM user_categories WHERE id = ?').get(own.categoryId)).toBeUndefined();
+        expect(db.prepare('SELECT id FROM user_channels WHERE id = ?').get(own.assignmentId)).toBeUndefined();
+        expect(db.prepare('SELECT user_category_id FROM category_mappings WHERE id = ?').get(mappingId))
+          .toEqual({ user_category_id: null });
+        expect(channelsJsonCache.has('user_2_live')).toBe(false);
+    });
+
+    it('rejects a mixed-owner category request without deleting either category', () => {
+        const own = addAssignment(2);
+        const foreign = addAssignment(3);
+        const res = response();
+
+        channelController.bulkDeleteUserCategories({
+            body: { ids: [own.categoryId, foreign.categoryId] },
+            user: { id: 2, is_admin: false, username: 'user' }, ip: '127.0.0.1'
+        }, res);
+
+        expect(res.status).toHaveBeenCalledWith(403);
+        expect(db.prepare('SELECT id FROM user_categories WHERE id IN (?, ?) ORDER BY id').all(own.categoryId, foreign.categoryId))
+          .toEqual([{ id: own.categoryId }, { id: foreign.categoryId }]);
+    });
 });

--- a/tests/migration_regression.test.js
+++ b/tests/migration_regression.test.js
@@ -6,6 +6,7 @@ import {
     migrateProviderPasswords,
     migrateOtpSecrets,
     migrateSeriesEpisodes,
+    migrateUserChannelMappingId,
     migrateUserChannelAdminGrants,
     migrateSyncConfigAdminGrants
 } from '../src/database/migrations.js';
@@ -54,6 +55,21 @@ describe('Migration Bug Regression', () => {
         const row = db.prepare('SELECT otp_secret FROM users WHERE id = ?').get(id);
         const decryptedOnce = decrypt(row.otp_secret);
         expect(decryptedOnce).toBe(secret);
+    });
+
+    it('adds the nullable mapping ownership column idempotently', () => {
+        const legacyDb = new Database(':memory:');
+        try {
+            legacyDb.exec('CREATE TABLE user_channels (id INTEGER PRIMARY KEY, user_category_id INTEGER, provider_channel_id INTEGER)');
+            migrateUserChannelMappingId(legacyDb);
+            migrateUserChannelMappingId(legacyDb);
+            expect(legacyDb.prepare('PRAGMA table_info(user_channels)').all().map(column => column.name))
+              .toContain('mapping_id');
+            expect(legacyDb.prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_user_channels_mapping'").get())
+              .toEqual({ name: 'idx_user_channels_mapping' });
+        } finally {
+            legacyDb.close();
+        }
     });
 
     it('should revoke legacy ownership mismatches idempotently without changing IDs', () => {

--- a/tests/stalker.test.js
+++ b/tests/stalker.test.js
@@ -1051,6 +1051,51 @@ describe('Stalker/MAG portal flow', () => {
     expect(unknown.body).toEqual({ js: {} });
   });
 
+  it('accepts completed epoch catch-up only and rejects incomplete or invalid programmes', async () => {
+    await registerDevice();
+    const token = await handshake();
+    const current = epgDb.prepare(`
+      SELECT start, stop FROM epg_programs
+      WHERE channel_id = ? AND title = 'Current Show'
+    `).get(epgIds[0]);
+    const requestEpoch = (start, duration, channelId = authorizedChannelIds[0]) => request(app)
+      .get(`/timeshift/token/auth/${duration}/epoch-${start}/${channelId}.ts`)
+      .query({ token });
+
+    const completed = await requestEpoch(archivedProgramStart, 60);
+    // The fixture upstream is intentionally unavailable; a 502 proves the
+    // completed programme passed archive validation and reached proxy fetch.
+    expect(completed.status).toBe(502);
+
+    expect((await requestEpoch(current.start, Math.ceil((current.stop - current.start) / 60))).status).toBe(404);
+    expect((await requestEpoch(current.stop + 1, 31)).status).toBe(404);
+    expect((await requestEpoch(archivedProgramStart, 61)).status).toBe(404);
+
+    const originalStop = epgDb.prepare('SELECT stop FROM epg_programs WHERE channel_id = ? AND title = \'Archived Show\'').get(epgIds[0]).stop;
+    epgDb.prepare("UPDATE epg_programs SET stop = 'invalid-stop' WHERE channel_id = ? AND title = 'Archived Show'").run(epgIds[0]);
+    expect((await requestEpoch(archivedProgramStart, 60)).status).toBe(404);
+    epgDb.prepare("UPDATE epg_programs SET stop = ? WHERE channel_id = ? AND title = 'Archived Show'").run(originalStop, epgIds[0]);
+
+    epgDb.prepare("UPDATE epg_programs SET stop = ? WHERE channel_id = ? AND title = 'Archived Show'").run(archivedProgramStart - 1, epgIds[0]);
+    expect((await requestEpoch(archivedProgramStart, 60)).status).toBe(404);
+    epgDb.prepare("UPDATE epg_programs SET stop = ? WHERE channel_id = ? AND title = 'Archived Show'").run(originalStop, epgIds[0]);
+
+    expect((await requestEpoch(archivedProgramStart, 60, hiddenChannelIds[0])).status).toBe(404);
+    expect((await requestEpoch(archivedProgramStart, 60, unauthorizedChannelIds[0])).status).toBe(404);
+
+    const formatted = await request(app)
+      .get(`/timeshift/token/auth/60/2026-01-15:12-00/${authorizedChannelIds[0]}.ts`)
+      .query({ token });
+    expect(formatted.status).toBe(502);
+
+    await request(app)
+      .put(`/api/users/${userId}/stalker-devices/${(await db.prepare('SELECT id FROM stalker_devices WHERE user_id = ?').get(userId)).id}`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ enabled: false })
+      .expect(200);
+    expect((await requestEpoch(archivedProgramStart, 60)).status).toBe(401);
+  });
+
   it('enforces the create_link module type matrix', async () => {
     await registerDevice();
     const token = await handshake();

--- a/tests/sync_service_regression.test.js
+++ b/tests/sync_service_regression.test.js
@@ -59,6 +59,7 @@ describe('sync authorization regression', () => {
       CREATE TABLE user_channels (
         id INTEGER PRIMARY KEY, user_category_id INTEGER, provider_channel_id INTEGER,
         sort_order INTEGER, is_hidden INTEGER DEFAULT 0,
+        mapping_id INTEGER,
         granted_by_admin INTEGER NOT NULL DEFAULT 0,
         authorization_revoked INTEGER NOT NULL DEFAULT 0
       );
@@ -254,6 +255,96 @@ describe('sync authorization regression', () => {
     });
     expect(memDb.prepare('SELECT granted_by_admin, authorization_revoked FROM user_channels WHERE id = 30').get())
       .toEqual({ granted_by_admin: 1, authorization_revoked: 0 });
+  });
+
+  it('maintains parallel live and radio mappings without duplicate assignments', async () => {
+    configure();
+    memDb.prepare("INSERT INTO user_categories (id, user_id, name, type, sort_order) VALUES (20, 1, 'Radio', 'radio', 1)").run();
+    memDb.prepare(`
+      INSERT INTO category_mappings
+        (provider_id, user_id, provider_category_id, provider_category_name, user_category_id, auto_created, category_type)
+      VALUES (1, 1, 10, 'Live as Radio', 20, 0, 'radio')
+    `).run();
+
+    await performSync(1, 1, { mode: 'scheduled' });
+    let assignments = memDb.prepare(`
+      SELECT user_category_id, provider_channel_id, mapping_id, is_hidden
+      FROM user_channels ORDER BY user_category_id
+    `).all();
+    expect(assignments).toHaveLength(2);
+    expect(assignments[0].provider_channel_id).toBe(assignments[1].provider_channel_id);
+    expect(assignments.every(assignment => assignment.mapping_id)).toBe(true);
+
+    memDb.prepare('UPDATE user_channels SET is_hidden = 1 WHERE user_category_id = 20').run();
+    await performSync(1, 1, { mode: 'scheduled' });
+    expect(memDb.prepare('SELECT is_hidden FROM user_channels WHERE user_category_id = 20').get()).toEqual({ is_hidden: 1 });
+    expect(memDb.prepare('SELECT COUNT(*) AS count FROM user_channels').get().count).toBe(2);
+  });
+
+  it('reconciles mapped radio assignments on category movement but preserves manual assignments', async () => {
+    configure();
+    memDb.prepare("INSERT INTO user_categories (id, user_id, name, type, sort_order) VALUES (20, 1, 'Radio A', 'radio', 1)").run();
+    memDb.prepare("INSERT INTO user_categories (id, user_id, name, type, sort_order) VALUES (30, 1, 'Live B', 'live', 2)").run();
+    memDb.prepare("INSERT INTO user_categories (id, user_id, name, type, sort_order) VALUES (40, 1, 'Radio B', 'radio', 3)").run();
+    memDb.prepare(`
+      INSERT INTO category_mappings
+        (provider_id, user_id, provider_category_id, provider_category_name, user_category_id, auto_created, category_type)
+      VALUES
+        (1, 1, 10, 'Live as Radio A', 20, 0, 'radio'),
+        (1, 1, 11, 'Live B', 30, 0, 'live'),
+        (1, 1, 11, 'Live B as Radio', 40, 0, 'radio')
+    `).run();
+    await performSync(1, 1, { mode: 'scheduled' });
+    const providerChannelId = memDb.prepare('SELECT id FROM provider_channels WHERE remote_stream_id = 101').get().id;
+    memDb.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id, sort_order) VALUES (30, ?, 99)').run(providerChannelId);
+
+    xtreamState.channels = [{ ...xtreamState.channels[0], category_id: 11 }];
+    await performSync(1, 1, { mode: 'scheduled' });
+
+    const assignments = memDb.prepare(`
+      SELECT user_category_id, mapping_id
+      FROM user_channels WHERE provider_channel_id = ? ORDER BY user_category_id
+    `).all(providerChannelId);
+    expect(assignments.map(assignment => assignment.user_category_id)).toEqual([30, 40]);
+    expect(assignments.filter(assignment => assignment.user_category_id === 30 && assignment.mapping_id === null)).toHaveLength(1);
+  });
+
+  it('applies existing cross-owner authorization rules to radio mappings', async () => {
+    configure({ providerOwner: 2, grant: 1 });
+    memDb.prepare("INSERT INTO user_categories (id, user_id, name, type, sort_order) VALUES (20, 1, 'Radio', 'radio', 1)").run();
+    memDb.prepare(`
+      INSERT INTO category_mappings
+        (provider_id, user_id, provider_category_id, provider_category_name, user_category_id, auto_created, category_type)
+      VALUES (1, 1, 10, 'Live as Radio', 20, 0, 'radio')
+    `).run();
+
+    await performSync(1, 1, { mode: 'scheduled' });
+    expect(memDb.prepare('SELECT granted_by_admin, authorization_revoked FROM user_channels WHERE user_category_id = 20').get())
+      .toEqual({ granted_by_admin: 1, authorization_revoked: 0 });
+
+    memDb.prepare('DELETE FROM user_channels').run();
+    memDb.prepare('UPDATE sync_configs SET granted_by_admin = 0').run();
+    const blocked = await performSync(1, 1, { mode: 'scheduled' });
+    expect(blocked.errorMessage).toMatch(/explicit administrator approval/i);
+    expect(memDb.prepare('SELECT COUNT(*) AS count FROM user_channels').get().count).toBe(0);
+  });
+
+  it('removes disappeared provider channels and both mapped assignments', async () => {
+    configure();
+    memDb.prepare("INSERT INTO user_categories (id, user_id, name, type, sort_order) VALUES (20, 1, 'Radio', 'radio', 1)").run();
+    memDb.prepare(`
+      INSERT INTO category_mappings
+        (provider_id, user_id, provider_category_id, provider_category_name, user_category_id, auto_created, category_type)
+      VALUES (1, 1, 10, 'Live as Radio', 20, 0, 'radio')
+    `).run();
+
+    await performSync(1, 1, { mode: 'scheduled' });
+    expect(memDb.prepare('SELECT COUNT(*) AS count FROM user_channels').get().count).toBe(2);
+
+    xtreamState.channels = [];
+    await performSync(1, 1, { mode: 'scheduled' });
+    expect(memDb.prepare('SELECT COUNT(*) AS count FROM provider_channels').get().count).toBe(0);
+    expect(memDb.prepare('SELECT COUNT(*) AS count FROM user_channels').get().count).toBe(0);
   });
 
   afterAll(() => memDb.close());

--- a/tests/user_clone_regression.test.js
+++ b/tests/user_clone_regression.test.js
@@ -212,7 +212,7 @@ describe('User clone regression', () => {
     expect(insertProviderRun.mock.calls[0][12]).toBe(1);
     expect(insertProviderRun.mock.calls[0][13]).toBe('Europe/Berlin');
     expect(insertSyncRun).toHaveBeenCalledWith(20, 200, 1, 'daily', 1, 1, 1);
-    expect(insertUserChannelRun).toHaveBeenCalledWith(40, 30, 0, '', 0);
-    expect(mockPrepare).toHaveBeenCalledWith(expect.stringContaining('VALUES (?, ?, ?, ?, ?, 0, 0)'));
+    expect(insertUserChannelRun).toHaveBeenCalledWith(40, 30, 0, '', 0, null);
+    expect(mockPrepare).toHaveBeenCalledWith(expect.stringContaining('VALUES (?, ?, ?, ?, ?, ?, 0, 0)'));
   });
 });


### PR DESCRIPTION
## Summary

- Reject internal epoch catch-up URLs unless the exact EPG programme has ended, matches the requested interval, and remains inside the archive window.
- Reconcile live provider channels against both live and radio category mappings without duplicating provider channels or deleting manually curated assignments.
- Add nullable `user_channels.mapping_id` ownership metadata with an idempotent column/index migration and preserve it through import, clone, backup, and category import flows.
- Run bulk category deletion and channel hiding validation and writes in one SQLite transaction; invalidate caches only after commit.

## Compatibility

Formatted Xtream timeshift starts, provider-timezone formatting/failover, Stalker authentication/session revocation, live/VOD/series/radio playback, and existing authorization rules remain covered.

## Validation

- Focused latest run: 2 files / 22 tests passed (`sync_service_regression`, `stalker`).
- Full isolated suite twice: 92 files / 575 tests passed on each run.
- `npm run lint`: 0 errors (146 existing warnings).
- `npm audit --audit-level=high`: 0 vulnerabilities.
- `npm audit --omit=dev --audit-level=high`: 0 vulnerabilities.
- `npm run build`, `npm ci --dry-run`, and `docker build -t iptv-manager-post-merge-hotfix .` passed.
- Docker image digest: `sha256:ee7536f7756570f4fab35692d6556c14000ee6e8bcbf78642d5583f9487b66bb`.

## Client smoke

- OTT Navigator 1.7.4.1 on Android TV `Television_1080p` emulator: handshake/profile, 253-channel listing, EPG, live playback, radio playback, and archive UI verified. The sanitized UTC fixture smoke returned completed epoch `200` with media bytes, running/future/mismatched epochs `404`, formatted Xtream timeshift `200`, and revoked-session media `401`.
- IPTVnator 0.22.0 (macOS arm64): handshake, channel listing, live playback, radio listing/playback, EPG, VOD, series playback, and session revocation smoke passed against the same fixture. Radio playback reached `/live/.../263.mp3` with HTTP 200.
- Fixture logs mask tokens, MACs, PINs, passwords, and share tokens; evidence remains outside the repository.

No release, tag, publication, or deployment is included.
