### PR TITLE
fix: harden provider sync cleanup and mapping lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,5 +22,15 @@ All notable changes to this project are documented here.
   mappings without duplicating provider channels.
 - Run bulk category deletion and channel hiding validation and writes in one
   transaction with post-commit cache invalidation.
+- Delete stale provider channels with their EPG, statistics, assignment, and
+  series-alias dependents before removing the provider row.
+- Synchronize large live, movie, and series catalogs without unbounded SQLite
+  placeholder lists.
+- Require two consecutive authoritative empty snapshots before removing an
+  existing content catalog.
+- Reconcile mapping-owned assignments when mappings are retargeted or removed,
+  while preserving manual assignments and hidden state.
+- Backfill legacy `mapping_id` values only for unambiguous matches and merge
+  duplicate user-channel assignments before enforcing uniqueness.
 - Validated the experimental portal with real software clients.
 - Hardware-specific MAG UI and favorites remain unsupported.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -53,6 +53,12 @@ Deleting a provider removes dependent channel assignments, EPG mappings, stream
 stats, sync data, category mappings, and provider icon cache entries before the
 provider row is deleted.
 
+Provider synchronization treats a complete empty response conservatively: one
+empty snapshot preserves an existing local catalog, while a second consecutive
+authoritative empty snapshot permits cleanup. Failed, invalid, or incomplete
+responses do not advance the empty-snapshot counter. A provider with no local
+rows may accept an empty catalog immediately.
+
 `POST /api/providers/bulk-url` is admin-only. It replaces matching provider
 base URLs across all users, for example `from_url: "http://provider1.com"` to
 `to_url: "http://provider2.com"`. Default provider EPG URLs under
@@ -87,6 +93,14 @@ the route category; otherwise the complete request is rejected without writes.
 Category mappings accept `null` for an explicit unmap, or a category owned by
 the mapping user with the same content type. Invalid, foreign, and mixed-type
 targets are rejected without changing the mapping.
+
+Assignments created by category synchronization are owned through
+`user_channels.mapping_id`. Retargeting a mapping moves or merges only those
+owned assignments into the validated target category; explicitly unmapping a
+mapping removes its owned assignments. Manual assignments (`mapping_id IS NULL`)
+remain unchanged. Each user category can contain at most one assignment for a
+given provider channel. Bulk category and channel requests accept at most 5,000
+IDs per request.
 
 ## EPG and Mapping
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -137,6 +137,22 @@ remain unowned (`NULL`) so a category move cannot delete them; only assignments
 created by an active mapping are reconciled. The migration adds the column and
 an index without changing public IDs.
 
+The versioned `user_channel_mapping_backfill_v1` migration assigns ownership to
+legacy rows only when exactly one mapping matches the provider, source
+category, category owner, and content type (including the live-to-radio rule).
+Ambiguous, unmatched, and manual rows remain unowned. The
+`user_channel_deduplication_v1` migration deterministically merges duplicate
+category/provider-channel assignments, rebinds series aliases, and then creates
+the `uq_user_channels_category_provider` unique index. Both markers make the
+migrations idempotent.
+
+Provider sync state is persisted per provider and stream type in
+`provider_sync_state`. A first complete empty snapshot with local rows is
+recorded but is not destructive; cleanup requires a second consecutive empty
+snapshot. Non-empty snapshots reset the counter, and failed or invalid fetches
+leave it unchanged. Provider deletion removes the state through its foreign-key
+cascade.
+
 ## Series Episode Cache Identity
 
 Series episode metadata is keyed by the normalized upstream panel URL. Provider

--- a/src/controllers/backupController.js
+++ b/src/controllers/backupController.js
@@ -105,6 +105,7 @@ export const restoreBackup = (req, res) => {
           (id, user_category_id, provider_channel_id, sort_order, custom_name, is_hidden,
            mapping_id, granted_by_admin, authorization_revoked)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT DO NOTHING
       `);
       const getMapping = db.prepare('SELECT id FROM category_mappings WHERE id = ? AND user_id = ?');
       const getProviderOwner = db.prepare(`

--- a/src/controllers/channelController.js
+++ b/src/controllers/channelController.js
@@ -3,6 +3,8 @@ import db from '../database/db.js';
 import { isAdultCategory, resolveAssignmentGrant } from '../utils/helpers.js';
 import { getEpgLogo, loadEpgLogosCache } from '../services/logoResolver.js';
 
+const MAX_BULK_IDS = 5000;
+
 function parsePositiveSafeInteger(value) {
   if (typeof value === 'string' && !/^[1-9]\d*$/.test(value)) return null;
   if (typeof value !== 'string' && typeof value !== 'number') return null;
@@ -20,6 +22,116 @@ function bulkOperationError(status, message) {
   const error = new Error(message);
   error.status = status;
   return error;
+}
+
+function rebindSeriesAliases(survivorId, loserId) {
+  const aliasTable = db.prepare(`
+    SELECT name FROM sqlite_master
+    WHERE type = 'table' AND name = 'series_episode_aliases'
+  `).get();
+  if (!aliasTable) return;
+
+  const aliases = db.prepare(`
+    SELECT id, source_key, series_remote_id, remote_episode_id
+    FROM series_episode_aliases
+    WHERE user_channel_id = ?
+    ORDER BY id
+  `).all(loserId);
+  const findAlias = db.prepare(`
+    SELECT id FROM series_episode_aliases
+    WHERE user_channel_id = ? AND source_key = ?
+      AND series_remote_id = ? AND remote_episode_id = ?
+  `);
+  const updateAlias = db.prepare('UPDATE series_episode_aliases SET user_channel_id = ? WHERE id = ?');
+  const deleteAlias = db.prepare('DELETE FROM series_episode_aliases WHERE id = ?');
+  for (const alias of aliases) {
+    const existing = findAlias.get(
+      survivorId,
+      alias.source_key,
+      alias.series_remote_id,
+      alias.remote_episode_id
+    );
+    if (existing) deleteAlias.run(alias.id);
+    else updateAlias.run(survivorId, alias.id);
+  }
+}
+
+function mergeUserChannelAssignments(survivor, duplicate) {
+  rebindSeriesAliases(survivor.id, duplicate.id);
+  const hasValidGrant = [survivor, duplicate].some(
+    row => Number(row.granted_by_admin) === 1 && Number(row.authorization_revoked) !== 1
+  );
+  const hasGrant = [survivor, duplicate].some(row => Number(row.granted_by_admin) === 1);
+  const customName = String(survivor.custom_name || '').trim()
+    ? survivor.custom_name
+    : (String(duplicate.custom_name || '').trim() ? duplicate.custom_name : '');
+  db.prepare(`
+    UPDATE user_channels
+    SET is_hidden = ?,
+        custom_name = ?,
+        granted_by_admin = ?,
+        authorization_revoked = ?,
+        sort_order = ?
+    WHERE id = ?
+  `).run(
+    Number(survivor.is_hidden) === 1 || Number(duplicate.is_hidden) === 1 ? 1 : 0,
+    customName,
+    hasValidGrant || hasGrant ? 1 : 0,
+    hasValidGrant ? 0 : (
+      Number(survivor.authorization_revoked) === 1 || Number(duplicate.authorization_revoked) === 1 ? 1 : 0
+    ),
+    Math.min(Number(survivor.sort_order) || 0, Number(duplicate.sort_order) || 0),
+    survivor.id
+  );
+  db.prepare('DELETE FROM user_channels WHERE id = ?').run(duplicate.id);
+}
+
+function reconcileMappingAssignments(mapping, targetId) {
+  const ownedAssignments = db.prepare(`
+    SELECT uc.*
+    FROM user_channels uc
+    WHERE uc.mapping_id = ?
+    ORDER BY uc.id
+  `).all(mapping.id);
+  if (targetId === null) {
+    for (const assignment of ownedAssignments) {
+      db.prepare('DELETE FROM user_channels WHERE id = ? AND mapping_id = ?').run(assignment.id, mapping.id);
+    }
+    return { assignments_removed: ownedAssignments.length, assignments_moved: 0, duplicates_merged: 0 };
+  }
+
+  let assignmentsMoved = 0;
+  let duplicatesMerged = 0;
+  const findTarget = db.prepare(`
+    SELECT *
+    FROM user_channels
+    WHERE user_category_id = ? AND provider_channel_id = ?
+    ORDER BY id
+  `);
+  const move = db.prepare('UPDATE user_channels SET user_category_id = ? WHERE id = ? AND mapping_id = ?');
+
+  for (const assignment of ownedAssignments) {
+    if (Number(assignment.user_category_id) === Number(targetId)) continue;
+    const targetRows = findTarget.all(targetId, assignment.provider_channel_id);
+    if (targetRows.length === 0) {
+      if (move.run(targetId, assignment.id, mapping.id).changes === 1) assignmentsMoved++;
+      continue;
+    }
+
+    const target = targetRows.find(row => row.mapping_id === null || row.mapping_id === undefined) || targetRows[0];
+    if (target.id === assignment.id) continue;
+    const survivor = [target, assignment]
+      .filter(row => row.mapping_id === null || row.mapping_id === undefined)[0]
+      || ([target, assignment].sort((a, b) => Number(a.id) - Number(b.id))[0]);
+    const duplicate = survivor.id === assignment.id ? target : assignment;
+    mergeUserChannelAssignments(survivor, duplicate);
+    if (survivor.id === assignment.id) {
+      move.run(targetId, assignment.id, mapping.id);
+      assignmentsMoved++;
+    }
+    duplicatesMerged++;
+  }
+  return { assignments_removed: 0, assignments_moved: assignmentsMoved, duplicates_merged: duplicatesMerged };
 }
 
 export const getUserCategories = (req, res) => {
@@ -103,6 +215,7 @@ export const bulkDeleteUserCategories = (req, res) => {
   try {
     const { ids } = req.body;
     if (!Array.isArray(ids) || ids.length === 0) return res.status(400).json({error: 'ids array required'});
+    if (ids.length > MAX_BULK_IDS) return res.status(400).json({error: `A maximum of ${MAX_BULK_IDS} ids is allowed`});
 
     const categoryIds = parseUniquePositiveIds(ids);
     if (!categoryIds) return res.status(400).json({error: 'Invalid ids'});
@@ -373,6 +486,7 @@ export const bulkDeleteUserChannels = (req, res) => {
   try {
     const { ids } = req.body;
     if (!Array.isArray(ids) || ids.length === 0) return res.status(400).json({error: 'ids array required'});
+    if (ids.length > MAX_BULK_IDS) return res.status(400).json({error: `A maximum of ${MAX_BULK_IDS} ids is allowed`});
 
     const channelIds = parseUniquePositiveIds(ids);
     if (!channelIds) return res.status(400).json({error: 'Invalid ids'});
@@ -448,7 +562,7 @@ export const updateCategoryMapping = (req, res) => {
       return res.status(400).json({error: 'Invalid user_category_id'});
     }
 
-    const updated = db.transaction(() => {
+    const result = db.transaction(() => {
       if (targetId !== null) {
         const target = db.prepare(`
           SELECT id, user_id, COALESCE(type, 'live') AS type
@@ -460,17 +574,20 @@ export const updateCategoryMapping = (req, res) => {
         }
       }
 
-      return db.prepare(`
+      const reconciliation = reconcileMappingAssignments(mapping, targetId);
+      const updated = db.prepare(`
         UPDATE category_mappings
         SET user_category_id = ?
         WHERE id = ? AND user_id = ?
       `).run(targetId, id, mapping.user_id).changes === 1;
+      if (!updated) return false;
+      return { success: true, ...reconciliation };
     })();
 
-    if (!updated) return res.status(400).json({error: 'Invalid user_category_id'});
+    if (!result) return res.status(400).json({error: 'Invalid user_category_id'});
 
     clearChannelsCache(mapping.user_id);
-    res.json({success: true});
+    res.json(result);
   } catch (e) {
     res.status(500).json({error: e.message});
   }

--- a/src/controllers/providerController.js
+++ b/src/controllers/providerController.js
@@ -2,7 +2,7 @@ import db from '../database/db.js';
 import { fetchSafe } from '../utils/network.js';
 import { encrypt, decrypt } from '../utils/crypto.js';
 import { isSafeUrl, isAdultCategory, redactUrl, providerSourceKey, resolveAssignmentGrant } from '../utils/helpers.js';
-import { performSync, checkProviderExpiry } from '../services/syncService.js';
+import { performSync, checkProviderExpiry, deleteProviderChannelCascade } from '../services/syncService.js';
 import { updateProviderEpg } from '../services/epgService.js';
 import { clearChannelsCache } from '../services/cacheService.js';
 import { parseTimeshiftTimezone } from '../utils/timezone.js';
@@ -484,13 +484,16 @@ export const deleteProvider = (req, res) => {
     const providerRow = db.prepare('SELECT url FROM providers WHERE id = ?').get(id);
 
     db.transaction(() => {
-      db.prepare('DELETE FROM user_channels WHERE provider_channel_id IN (SELECT id FROM provider_channels WHERE provider_id = ?)').run(id);
-      db.prepare('DELETE FROM epg_channel_mappings WHERE provider_channel_id IN (SELECT id FROM provider_channels WHERE provider_id = ?)').run(id);
-      db.prepare('DELETE FROM stream_stats WHERE channel_id IN (SELECT id FROM provider_channels WHERE provider_id = ?)').run(id);
-      db.prepare('DELETE FROM provider_channels WHERE provider_id = ?').run(id);
+      const providerChannels = db.prepare(
+        'SELECT id FROM provider_channels WHERE provider_id = ? ORDER BY id'
+      ).all(id);
+      for (const channel of providerChannels) {
+        deleteProviderChannelCascade(db, id, channel.id);
+      }
 
       db.prepare('DELETE FROM sync_configs WHERE provider_id = ?').run(id);
       db.prepare('DELETE FROM sync_logs WHERE provider_id = ?').run(id);
+      db.prepare('DELETE FROM provider_sync_state WHERE provider_id = ?').run(id);
       db.prepare('DELETE FROM category_mappings WHERE provider_id = ?').run(id);
       db.prepare('DELETE FROM provider_icon_cache WHERE provider_id = ?').run(id);
       db.prepare('DELETE FROM providers WHERE id = ?').run(id);
@@ -754,6 +757,7 @@ export const importCategory = async (req, res) => {
         INSERT INTO user_channels
           (user_category_id, provider_channel_id, sort_order, mapping_id, granted_by_admin, authorization_revoked)
         VALUES (?, ?, ?, ?, ?, 0)
+        ON CONFLICT DO NOTHING
       `);
       const channels = stmt.all(providerId, Number(category_id), streamType);
       const importedCount = channels.length;
@@ -819,6 +823,7 @@ export const importCategories = async (req, res) => {
       INSERT INTO user_channels
         (user_category_id, provider_channel_id, sort_order, mapping_id, granted_by_admin, authorization_revoked)
       VALUES (?, ?, ?, ?, ?, 0)
+      ON CONFLICT DO NOTHING
     `);
     const getMaxSort = db.prepare('SELECT COALESCE(MAX(sort_order), -1) as max_sort FROM user_categories WHERE user_id = ?');
 

--- a/src/controllers/systemController.js
+++ b/src/controllers/systemController.js
@@ -639,6 +639,7 @@ export const importData = async (req, res) => {
           (user_category_id, provider_channel_id, sort_order, custom_name, is_hidden,
            mapping_id, granted_by_admin, authorization_revoked)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT DO NOTHING
       `);
 
       for (const ua of userAssignments) {

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -333,6 +333,7 @@ export const createUser = async (req, res) => {
                       (user_category_id, provider_channel_id, sort_order, custom_name, is_hidden,
                        mapping_id, granted_by_admin, authorization_revoked)
                     VALUES (?, ?, ?, ?, ?, ?, 0, 0)
+                    ON CONFLICT DO NOTHING
                 `);
 
                 // Fetch all user channels for source user categories

--- a/src/database/db.js
+++ b/src/database/db.js
@@ -164,6 +164,16 @@ export function initDb(isPrimary) {
       FOREIGN KEY (user_id) REFERENCES users(id)
     );
 
+    CREATE TABLE IF NOT EXISTS provider_sync_state (
+      provider_id INTEGER NOT NULL,
+      stream_type TEXT NOT NULL,
+      empty_snapshot_count INTEGER NOT NULL DEFAULT 0,
+      last_nonempty_count INTEGER NOT NULL DEFAULT 0,
+      last_snapshot_at INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (provider_id, stream_type),
+      FOREIGN KEY (provider_id) REFERENCES providers(id) ON DELETE CASCADE
+    );
+
     CREATE TABLE IF NOT EXISTS category_mappings (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       provider_id INTEGER NOT NULL,
@@ -299,6 +309,7 @@ export function initDb(isPrimary) {
             migrations.migrateAdminForcePasswordChange(db);
             migrations.migrateUserMaxConnections(db);
             migrations.migrateProviderMaxConnections(db);
+            migrations.migrateProviderSyncState(db);
             migrations.migrateCurrentStreamsProviderId(db);
             migrations.migrateCurrentStreamsLastActivity(db);
             migrations.migrateProviderLastEpgUpdate(db);
@@ -324,6 +335,12 @@ export function initDb(isPrimary) {
             }
             if (typeof migrations.migrateSeriesEpisodes === 'function') {
                 migrations.migrateSeriesEpisodes(db);
+            }
+            if (typeof migrations.migrateUserChannelMappingBackfillV1 === 'function') {
+                migrations.migrateUserChannelMappingBackfillV1(db);
+            }
+            if (typeof migrations.migrateUserChannelDeduplicationV1 === 'function') {
+                migrations.migrateUserChannelDeduplicationV1(db);
             }
             migrations.migrateStalkerTables(db);
 

--- a/src/database/migrations.js
+++ b/src/database/migrations.js
@@ -203,6 +203,31 @@ export function migrateChannelsSchemaV3(db) {
   }
 }
 
+export function migrateProviderSyncState(db) {
+  const migrate = db.transaction(() => {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS provider_sync_state (
+        provider_id INTEGER NOT NULL,
+        stream_type TEXT NOT NULL,
+        empty_snapshot_count INTEGER NOT NULL DEFAULT 0,
+        last_nonempty_count INTEGER NOT NULL DEFAULT 0,
+        last_snapshot_at INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY (provider_id, stream_type),
+        FOREIGN KEY (provider_id) REFERENCES providers(id) ON DELETE CASCADE
+      );
+      CREATE INDEX IF NOT EXISTS idx_provider_sync_state_provider
+        ON provider_sync_state(provider_id);
+    `);
+  });
+
+  try {
+    migrate();
+  } catch (e) {
+    console.error('Provider sync state migration error:', e);
+    throw e;
+  }
+}
+
 export function migrateUserCategoriesType(db) {
   try {
     const tableInfo = db.prepare("PRAGMA table_info(user_categories)").all();
@@ -784,6 +809,188 @@ export function migrateUserChannelMappingId(db) {
   } catch (e) {
     console.error('User channel mapping migration error:', e);
   }
+}
+
+export function migrateUserChannelMappingBackfillV1(db) {
+  const markerKey = 'user_channel_mapping_backfill_v1';
+  const migrate = db.transaction(() => {
+    if (db.prepare('SELECT value FROM settings WHERE key = ?').get(markerKey)?.value) {
+      return { assigned: 0, ambiguous: 0, unmatched: 0, skipped: true };
+    }
+
+    db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_category_mappings_backfill
+        ON category_mappings(provider_id, user_id, user_category_id, provider_category_id, category_type);
+    `);
+
+    const rows = db.prepare(`
+      SELECT uc.id AS user_channel_id,
+             cm.id AS mapping_id
+      FROM user_channels uc
+      JOIN user_categories cat ON cat.id = uc.user_category_id
+      JOIN provider_channels pc ON pc.id = uc.provider_channel_id
+      LEFT JOIN category_mappings cm
+        ON cm.provider_id = pc.provider_id
+       AND cm.user_id = cat.user_id
+       AND cm.user_category_id = uc.user_category_id
+       AND cm.provider_category_id = pc.original_category_id
+       AND COALESCE(cm.category_type, 'live') = COALESCE(cat.type, 'live')
+       AND (
+         COALESCE(pc.stream_type, 'live') = COALESCE(cm.category_type, 'live')
+         OR (
+           COALESCE(pc.stream_type, 'live') = 'live'
+           AND COALESCE(cat.type, 'live') = 'radio'
+           AND COALESCE(cm.category_type, 'live') = 'radio'
+         )
+       )
+      WHERE uc.mapping_id IS NULL
+      ORDER BY uc.id, cm.id
+    `).all();
+
+    const candidates = new Map();
+    for (const row of rows) {
+      if (!candidates.has(row.user_channel_id)) candidates.set(row.user_channel_id, []);
+      if (row.mapping_id !== null && row.mapping_id !== undefined) {
+        candidates.get(row.user_channel_id).push(Number(row.mapping_id));
+      }
+    }
+
+    const assign = db.prepare('UPDATE user_channels SET mapping_id = ? WHERE id = ? AND mapping_id IS NULL');
+    let assigned = 0;
+    let ambiguous = 0;
+    let unmatched = 0;
+    for (const [userChannelId, mappingIds] of candidates) {
+      const uniqueIds = [...new Set(mappingIds)];
+      if (uniqueIds.length === 1) {
+        assigned += assign.run(uniqueIds[0], userChannelId).changes;
+      } else if (uniqueIds.length > 1) {
+        ambiguous++;
+      } else {
+        unmatched++;
+      }
+    }
+
+    db.prepare('INSERT INTO settings (key, value) VALUES (?, ?)').run(
+      markerKey,
+      JSON.stringify({ assigned, ambiguous, unmatched })
+    );
+    console.info(`✅ Mapping backfill: ${assigned} assigned, ${ambiguous} ambiguous, ${unmatched} unmatched`);
+    return { assigned, ambiguous, unmatched, skipped: false };
+  });
+
+  return migrate();
+}
+
+export function migrateUserChannelDeduplicationV1(db) {
+  const markerKey = 'user_channel_deduplication_v1';
+  const migrate = db.transaction(() => {
+    const marker = db.prepare('SELECT value FROM settings WHERE key = ?').get(markerKey);
+    if (marker?.value) {
+      db.exec(`
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_user_channels_category_provider
+          ON user_channels(user_category_id, provider_channel_id);
+      `);
+      return { merged: 0, skipped: true };
+    }
+
+    const aliasTable = db.prepare(`
+      SELECT name FROM sqlite_master
+      WHERE type = 'table' AND name = 'series_episode_aliases'
+    `).get();
+    const duplicateGroups = db.prepare(`
+      SELECT user_category_id, provider_channel_id
+      FROM user_channels
+      GROUP BY user_category_id, provider_channel_id
+      HAVING COUNT(*) > 1
+      ORDER BY user_category_id, provider_channel_id
+    `).all();
+
+    const selectRows = db.prepare(`
+      SELECT id, user_category_id, provider_channel_id, sort_order, custom_name,
+             is_hidden, mapping_id, granted_by_admin, authorization_revoked
+      FROM user_channels
+      WHERE user_category_id = ? AND provider_channel_id = ?
+      ORDER BY id
+    `);
+    const updateSurvivor = db.prepare(`
+      UPDATE user_channels
+      SET is_hidden = ?,
+          custom_name = ?,
+          granted_by_admin = ?,
+          authorization_revoked = ?,
+          sort_order = ?
+      WHERE id = ?
+    `);
+    const deleteAssignment = db.prepare('DELETE FROM user_channels WHERE id = ?');
+    let merged = 0;
+
+    for (const group of duplicateGroups) {
+      const rows = selectRows.all(group.user_category_id, group.provider_channel_id);
+      const survivor = rows
+        .filter(row => row.mapping_id === null || row.mapping_id === undefined)
+        .sort((a, b) => Number(a.id) - Number(b.id))[0] || rows[0];
+      const losers = rows.filter(row => row.id !== survivor.id);
+      const customName = rows.find(row => String(row.custom_name || '').trim())?.custom_name || '';
+      const hasValidGrant = rows.some(row => Number(row.granted_by_admin) === 1 && Number(row.authorization_revoked) !== 1);
+      const hasGrant = rows.some(row => Number(row.granted_by_admin) === 1);
+      const revoked = hasValidGrant ? 0 : (rows.some(row => Number(row.authorization_revoked) === 1) ? 1 : 0);
+      const sortOrder = Math.min(...rows.map(row => Number(row.sort_order) || 0));
+
+      if (aliasTable) {
+        const selectAliases = db.prepare(`
+          SELECT id, source_key, series_remote_id, remote_episode_id
+          FROM series_episode_aliases
+          WHERE user_channel_id = ?
+          ORDER BY id
+        `);
+        const findAlias = db.prepare(`
+          SELECT id FROM series_episode_aliases
+          WHERE user_channel_id = ? AND source_key = ?
+            AND series_remote_id = ? AND remote_episode_id = ?
+        `);
+        const rebindAlias = db.prepare('UPDATE series_episode_aliases SET user_channel_id = ? WHERE id = ?');
+        const removeAlias = db.prepare('DELETE FROM series_episode_aliases WHERE id = ?');
+        for (const loser of losers) {
+          for (const alias of selectAliases.all(loser.id)) {
+            const existing = findAlias.get(
+              survivor.id,
+              alias.source_key,
+              alias.series_remote_id,
+              alias.remote_episode_id
+            );
+            if (existing) removeAlias.run(alias.id);
+            else rebindAlias.run(survivor.id, alias.id);
+          }
+        }
+      }
+
+      updateSurvivor.run(
+        rows.some(row => Number(row.is_hidden) === 1) ? 1 : 0,
+        customName,
+        hasValidGrant || hasGrant ? 1 : 0,
+        revoked,
+        sortOrder,
+        survivor.id
+      );
+      for (const loser of losers) {
+        deleteAssignment.run(loser.id);
+        merged++;
+      }
+    }
+
+    db.exec(`
+      CREATE UNIQUE INDEX IF NOT EXISTS uq_user_channels_category_provider
+        ON user_channels(user_category_id, provider_channel_id);
+    `);
+    db.prepare('INSERT INTO settings (key, value) VALUES (?, ?)').run(
+      markerKey,
+      JSON.stringify({ merged })
+    );
+    console.info(`✅ User channel deduplication: ${merged} duplicate assignment(s) merged`);
+    return { merged, skipped: false };
+  });
+
+  return migrate();
 }
 
 export function migrateUserChannelAdminGrants(db) {

--- a/src/services/syncService.js
+++ b/src/services/syncService.js
@@ -8,6 +8,96 @@ import { normalizeContainerExtension } from '../utils/containerExtension.js';
 import { parseM3uStream } from '../utils/playlistParser.js';
 import { prePopulateProviderIconCache } from './logoResolver.js';
 
+/**
+ * Delete one provider channel without violating the dependent foreign keys.
+ * The caller owns the surrounding transaction.
+ */
+export function deleteProviderChannelCascade(database, providerId, providerChannelId) {
+  const channel = database.prepare(`
+    SELECT id
+    FROM provider_channels
+    WHERE id = ? AND provider_id = ?
+  `).get(providerChannelId, providerId);
+  if (!channel) return 0;
+
+  database.prepare('DELETE FROM epg_channel_mappings WHERE provider_channel_id = ?').run(channel.id);
+  database.prepare('DELETE FROM stream_stats WHERE channel_id = ?').run(channel.id);
+  database.prepare('DELETE FROM user_channels WHERE provider_channel_id = ?').run(channel.id);
+
+  const deleted = database.prepare(
+    'DELETE FROM provider_channels WHERE id = ? AND provider_id = ?'
+  ).run(channel.id, providerId).changes;
+  if (deleted !== 1) {
+    throw new Error(`Provider channel cleanup removed ${deleted} rows instead of one`);
+  }
+  return deleted;
+}
+
+export function selectStaleProviderChannels(
+  existingChannels,
+  seenRemoteIdsByType,
+  completeStreamTypes,
+  currentTypeByRemoteId = new Map()
+) {
+  const stale = [];
+  for (const streamType of completeStreamTypes) {
+    const seenIds = seenRemoteIdsByType.get(streamType) || new Set();
+    for (const row of existingChannels) {
+      const rowType = row.stream_type || 'live';
+      const remoteId = Number(row.remote_stream_id);
+      if (rowType !== streamType || seenIds.has(remoteId)) continue;
+      // A provider may reuse a stream id while changing its stream type. The
+      // row is updated in-place; do not delete the newly retargeted channel.
+      const currentType = currentTypeByRemoteId.get(remoteId);
+      if (currentType && currentType !== streamType) continue;
+      stale.push(row);
+    }
+  }
+  return stale;
+}
+
+function updateProviderSyncState(database, providerId, streamType, snapshotCount, localCount, timestamp) {
+  const previous = database.prepare(`
+    SELECT empty_snapshot_count, last_nonempty_count
+    FROM provider_sync_state
+    WHERE provider_id = ? AND stream_type = ?
+  `).get(providerId, streamType);
+
+  let emptySnapshotCount = Number(previous?.empty_snapshot_count) || 0;
+  let lastNonemptyCount = Number(previous?.last_nonempty_count) || 0;
+  let allowCleanup = false;
+
+  if (snapshotCount > 0) {
+    emptySnapshotCount = 0;
+    lastNonemptyCount = snapshotCount;
+    allowCleanup = true;
+  } else if (localCount === 0) {
+    // An empty catalog is valid when there is nothing local to destroy.
+    emptySnapshotCount = 0;
+    allowCleanup = true;
+  } else {
+    emptySnapshotCount += 1;
+    allowCleanup = emptySnapshotCount >= 2;
+    if (!allowCleanup) {
+      console.warn(
+        `Preserving ${localCount} ${streamType} provider channel(s) after one empty snapshot for provider ${providerId}`
+      );
+    }
+  }
+
+  database.prepare(`
+    INSERT INTO provider_sync_state
+      (provider_id, stream_type, empty_snapshot_count, last_nonempty_count, last_snapshot_at)
+    VALUES (?, ?, ?, ?, ?)
+    ON CONFLICT(provider_id, stream_type) DO UPDATE SET
+      empty_snapshot_count = excluded.empty_snapshot_count,
+      last_nonempty_count = excluded.last_nonempty_count,
+      last_snapshot_at = excluded.last_snapshot_at
+  `).run(providerId, streamType, emptySnapshotCount, lastNonemptyCount, timestamp);
+
+  return allowCleanup;
+}
+
 function createXtreamClient(provider) {
   let baseUrl = (provider.url || '').trim();
   if (!/^https?:\/\//i.test(baseUrl)) baseUrl = 'http://' + baseUrl;
@@ -118,6 +208,7 @@ export async function performSync(providerId, userId, options = {}) {
     let allChannels = [];
     let allCategories = [];
     const completeStreamTypes = new Set();
+    const snapshotStates = new Map();
 
     // 1. Live & M3U Fallback
     try {
@@ -133,7 +224,7 @@ export async function performSync(providerId, userId, options = {}) {
           try {
              const resp = await fetchSafe(`${baseUrl}/player_api.php?${authParams}&action=get_live_streams`, { timeout: 60000 });
              if (resp.ok) {
-                 const contentType = resp.headers.get('content-type');
+                 const contentType = resp.headers?.get?.('content-type');
                  if (contentType && contentType.includes('application/json')) {
                      liveChans = await resp.json();
                      liveFetchComplete = Array.isArray(liveChans);
@@ -204,6 +295,7 @@ export async function performSync(providerId, userId, options = {}) {
            allChannels.push(c);
          });
          if (liveFetchComplete) completeStreamTypes.add('live');
+         if (liveFetchComplete) snapshotStates.set('live', { count: liveChans.length });
        }
 
        if (!m3uMode) {
@@ -231,6 +323,7 @@ export async function performSync(providerId, userId, options = {}) {
                 allChannels.push(c);
             });
             completeStreamTypes.add('movie');
+            snapshotStates.set('movie', { count: vods.length });
          }
        } else {
          console.error(`VOD fetch failed: ${resp.status}`);
@@ -260,6 +353,7 @@ export async function performSync(providerId, userId, options = {}) {
                 allChannels.push(c);
             });
             completeStreamTypes.add('series');
+            snapshotStates.set('series', { count: series.length });
          }
        }
 
@@ -276,12 +370,9 @@ export async function performSync(providerId, userId, options = {}) {
     // Performance Optimization: Pre-fetch all mappings to avoid N+1 queries
     const allMappings = db.prepare(`
       SELECT cm.*,
-             CASE
-               WHEN uc.user_id = cm.user_id
-                AND COALESCE(uc.type, 'live') = COALESCE(cm.category_type, 'live')
-               THEN cm.user_category_id
-               ELSE NULL
-             END AS user_category_id
+             cm.user_category_id AS mapping_user_category_id,
+             uc.user_id AS target_user_id,
+             COALESCE(uc.type, 'live') AS target_category_type
       FROM category_mappings cm
       LEFT JOIN user_categories uc ON uc.id = cm.user_category_id
       WHERE cm.provider_id = ? AND cm.user_id = ?
@@ -293,7 +384,27 @@ export async function performSync(providerId, userId, options = {}) {
     const mappingLookup = new Map(); // Key: "catId_type"
     for (const m of allMappings) {
       const key = `${m.provider_category_id}_${m.category_type || 'live'}`;
-      mappingLookup.set(key, m);
+      const mappingType = m.category_type || 'live';
+      const targetId = Number(m.mapping_user_category_id) || 0;
+      const targetValid = !targetId || (
+        Number(m.target_user_id) === Number(m.user_id) &&
+        (m.target_category_type || 'live') === mappingType
+      );
+      mappingLookup.set(key, {
+        ...m,
+        user_category_id: targetValid && targetId ? targetId : null,
+        target_valid: targetValid
+      });
+    }
+    const invalidMappingCount = allMappings.filter(m => {
+      const targetId = Number(m.mapping_user_category_id) || 0;
+      return targetId > 0 && (
+        Number(m.target_user_id) !== Number(m.user_id) ||
+        (m.target_category_type || 'live') !== (m.category_type || 'live')
+      );
+    }).length;
+    if (invalidMappingCount > 0) {
+      console.warn(`Ignored ${invalidMappingCount} invalid category mapping target(s) for provider ${providerId}`);
     }
 
     // Prepare channel statements
@@ -317,11 +428,12 @@ export async function performSync(providerId, userId, options = {}) {
              youtube_trailer, episode_run_time
       FROM provider_channels
       WHERE provider_id = ?
+      ORDER BY COALESCE(stream_type, 'live'), id
     `).all(providerId);
 
     const existingMap = new Map();
     for (const row of existingChannels) {
-      existingMap.set(row.remote_stream_id, row);
+      existingMap.set(Number(row.remote_stream_id), row);
     }
 
     // Optimization: Pre-fetch user channel assignments and sort orders to avoid N+1 queries
@@ -333,6 +445,7 @@ export async function performSync(providerId, userId, options = {}) {
       INSERT INTO user_channels
         (user_category_id, provider_channel_id, sort_order, mapping_id, granted_by_admin, authorization_revoked)
       VALUES (?, ?, ?, ?, ?, 0)
+      ON CONFLICT DO NOTHING
     `);
     const authorizeExistingAssignment = db.prepare(`
       UPDATE user_channels
@@ -377,12 +490,17 @@ export async function performSync(providerId, userId, options = {}) {
       const keys = [`${categoryId}_${categoryType}`];
       if (categoryType === 'live') keys.push(`${categoryId}_radio`);
       return keys.map(key => ({ key, mapping: mappingLookup.get(key) })).filter(({ key, mapping }) => {
-        if (!mapping?.user_category_id || !mapping.id) return false;
+        if (!mapping?.user_category_id || !mapping.id || mapping.target_valid === false) return false;
         const expectedType = key.endsWith('_radio') ? 'radio' : categoryType;
         return (mapping.category_type || 'live') === expectedType;
       }).map(({ mapping }) => mapping);
     };
     const seenRemoteIdsByType = new Map();
+    const currentTypeByRemoteId = new Map();
+    for (const channel of allChannels) {
+      const remoteId = Number(channel.stream_id || channel.series_id || channel.id || 0);
+      if (remoteId > 0) currentTypeByRemoteId.set(remoteId, channel.stream_type || 'live');
+    }
 
     // Execute all DB operations in a single transaction
     db.transaction(() => {
@@ -661,10 +779,17 @@ export async function performSync(providerId, userId, options = {}) {
                 const newSortOrder = currentMax + 1;
 
                 const assignmentInfo = insertUserChannel.run(userCatId, provChannelId, newSortOrder, mappingId, assignmentGrant);
+                const assignmentId = assignmentInfo.changes === 1
+                  ? Number(assignmentInfo.lastInsertRowid)
+                  : Number(db.prepare(`
+                    SELECT id FROM user_channels
+                    WHERE user_category_id = ? AND provider_channel_id = ?
+                  `).get(userCatId, provChannelId)?.id || 0);
+                if (!assignmentId) throw new Error('Unable to resolve synchronized user-channel assignment');
 
                 // Update in-memory state
                 existingAssignments.set(assignmentKey, {
-                  id: Number(assignmentInfo.lastInsertRowid),
+                  id: assignmentId,
                   user_category_id: userCatId,
                   provider_channel_id: Number(provChannelId),
                   mapping_id: mappingId,
@@ -688,20 +813,29 @@ export async function performSync(providerId, userId, options = {}) {
         }
       }
 
-      // Remove provider entries that were confirmed absent from a complete
-      // stream-type response. Explicitly remove assignments first because
-      // legacy databases do not enforce a foreign key on user_channels.
+      const cleanupTypes = new Set();
       for (const streamType of completeStreamTypes) {
-        const seenIds = [...(seenRemoteIdsByType.get(streamType) || [])];
-        const notInSeen = seenIds.length ? ` AND remote_stream_id NOT IN (${Array(seenIds.length).fill('?').join(',')})` : '';
-        const staleRows = db.prepare(`
-          SELECT id FROM provider_channels
-          WHERE provider_id = ? AND COALESCE(stream_type, 'live') = ?${notInSeen}
-        `).all(providerId, streamType, ...seenIds);
-        for (const stale of staleRows) {
-          db.prepare('DELETE FROM user_channels WHERE provider_channel_id = ?').run(stale.id);
-          db.prepare('DELETE FROM provider_channels WHERE id = ? AND provider_id = ?').run(stale.id, providerId);
+        const snapshot = snapshotStates.get(streamType);
+        if (!snapshot) continue;
+        const localCount = existingChannels.reduce(
+          (count, row) => count + ((row.stream_type || 'live') === streamType ? 1 : 0),
+          0
+        );
+        if (updateProviderSyncState(db, providerId, streamType, snapshot.count, localCount, startTime)) {
+          cleanupTypes.add(streamType);
         }
+      }
+
+      // Calculate stale rows from the already loaded catalog and in-memory
+      // Sets. This avoids SQLite's bound-variable limit for large providers.
+      const staleRows = selectStaleProviderChannels(
+        existingChannels,
+        seenRemoteIdsByType,
+        cleanupTypes,
+        currentTypeByRemoteId
+      );
+      for (const stale of staleRows) {
+        deleteProviderChannelCascade(db, providerId, stale.id);
       }
     })();
 

--- a/tests/controllers/channelController.test.js
+++ b/tests/controllers/channelController.test.js
@@ -709,4 +709,140 @@ describe('Channel Controller - createUserCategory', () => {
         expect(db.prepare('SELECT id FROM user_categories WHERE id IN (?, ?) ORDER BY id').all(own.categoryId, foreign.categoryId))
           .toEqual([{ id: own.categoryId }, { id: foreign.categoryId }]);
     });
+
+    it('retargets mapping-owned assignments and rebinds series aliases', () => {
+        const provider = db.prepare("INSERT INTO providers (name, url, username, password, user_id) VALUES ('Mapping Provider', 'http://provider.test', 'u', 'p', 2)").run().lastInsertRowid;
+        const source = db.prepare("INSERT INTO user_categories (user_id, name, type) VALUES (2, 'Source', 'live')").run().lastInsertRowid;
+        const target = db.prepare("INSERT INTO user_categories (user_id, name, type) VALUES (2, 'Target', 'live')").run().lastInsertRowid;
+        const mapping = db.prepare(`
+          INSERT INTO category_mappings
+            (provider_id, user_id, provider_category_id, provider_category_name, user_category_id, category_type)
+          VALUES (?, 2, 77, 'Provider', ?, 'live')
+        `).run(provider, source).lastInsertRowid;
+        const channel = db.prepare("INSERT INTO provider_channels (provider_id, remote_stream_id, name, stream_type) VALUES (?, 77, 'Series', 'live')").run(provider).lastInsertRowid;
+        const assignment = db.prepare(`
+          INSERT INTO user_channels
+            (user_category_id, provider_channel_id, sort_order, custom_name, is_hidden, mapping_id)
+          VALUES (?, ?, 4, 'Custom', 1, ?)
+        `).run(source, channel, mapping).lastInsertRowid;
+        const alias = db.prepare(`
+          INSERT INTO series_episode_aliases
+            (user_channel_id, source_key, series_remote_id, remote_episode_id)
+          VALUES (?, 'mapping-source', 77, 1)
+        `).run(assignment).lastInsertRowid;
+        const res = response();
+
+        channelController.updateCategoryMapping({
+            params: { id: String(mapping) }, body: { user_category_id: String(target) },
+            user: { id: 2, is_admin: false }
+        }, res);
+
+        expect(res.json).toHaveBeenCalledWith({
+            success: true, assignments_removed: 0, assignments_moved: 1, duplicates_merged: 0
+        });
+        expect(db.prepare('SELECT user_category_id, mapping_id, is_hidden, custom_name FROM user_channels WHERE id = ?').get(assignment))
+          .toEqual({ user_category_id: target, mapping_id: mapping, is_hidden: 1, custom_name: 'Custom' });
+        expect(db.prepare('SELECT id, user_channel_id FROM series_episode_aliases WHERE id = ?').get(alias))
+          .toEqual({ id: alias, user_channel_id: assignment });
+    });
+
+    it('merges a retargeted assignment into a manual target and preserves aliases', () => {
+        const provider = db.prepare("INSERT INTO providers (name, url, username, password, user_id) VALUES ('Merge Provider', 'http://provider.test', 'u', 'p', 2)").run().lastInsertRowid;
+        const source = db.prepare("INSERT INTO user_categories (user_id, name, type) VALUES (2, 'Mapped Source', 'live')").run().lastInsertRowid;
+        const target = db.prepare("INSERT INTO user_categories (user_id, name, type) VALUES (2, 'Manual Target', 'live')").run().lastInsertRowid;
+        const mapping = db.prepare(`
+          INSERT INTO category_mappings
+            (provider_id, user_id, provider_category_id, provider_category_name, user_category_id, category_type)
+          VALUES (?, 2, 88, 'Provider', ?, 'live')
+        `).run(provider, source).lastInsertRowid;
+        const channel = db.prepare("INSERT INTO provider_channels (provider_id, remote_stream_id, name, stream_type) VALUES (?, 88, 'Channel', 'live')").run(provider).lastInsertRowid;
+        const manual = db.prepare(`
+          INSERT INTO user_channels
+            (user_category_id, provider_channel_id, sort_order, custom_name, is_hidden)
+          VALUES (?, ?, 2, 'Manual name', 1)
+        `).run(target, channel).lastInsertRowid;
+        const mapped = db.prepare(`
+          INSERT INTO user_channels
+            (user_category_id, provider_channel_id, sort_order, custom_name, mapping_id)
+          VALUES (?, ?, 9, 'Mapped name', ?)
+        `).run(source, channel, mapping).lastInsertRowid;
+        const alias = db.prepare(`
+          INSERT INTO series_episode_aliases
+            (user_channel_id, source_key, series_remote_id, remote_episode_id)
+          VALUES (?, 'merge-source', 88, 1)
+        `).run(mapped).lastInsertRowid;
+        const res = response();
+
+        channelController.updateCategoryMapping({
+            params: { id: String(mapping) }, body: { user_category_id: String(target) },
+            user: { id: 2, is_admin: false }
+        }, res);
+
+        expect(res.json).toHaveBeenCalledWith({
+            success: true, assignments_removed: 0, assignments_moved: 0, duplicates_merged: 1
+        });
+        expect(db.prepare('SELECT id, mapping_id, is_hidden, custom_name FROM user_channels WHERE user_category_id = ? AND provider_channel_id = ?').get(target, channel))
+          .toEqual({ id: manual, mapping_id: null, is_hidden: 1, custom_name: 'Manual name' });
+        expect(db.prepare('SELECT id, user_channel_id FROM series_episode_aliases WHERE id = ?').get(alias))
+          .toEqual({ id: alias, user_channel_id: manual });
+        expect(db.prepare('SELECT id FROM user_channels WHERE id = ?').get(mapped)).toBeUndefined();
+    });
+
+    it('removes mapping-owned cross-owner assignments on unmapping but keeps manual rows', () => {
+        const provider = db.prepare("INSERT INTO providers (name, url, username, password, user_id) VALUES ('Cross Owner', 'http://provider.test', 'u', 'p', 3)").run().lastInsertRowid;
+        const category = db.prepare("INSERT INTO user_categories (user_id, name, type) VALUES (2, 'Shared', 'live')").run().lastInsertRowid;
+        const manualCategory = db.prepare("INSERT INTO user_categories (user_id, name, type) VALUES (2, 'Manual', 'live')").run().lastInsertRowid;
+        const mapping = db.prepare(`
+          INSERT INTO category_mappings
+            (provider_id, user_id, provider_category_id, provider_category_name, user_category_id, category_type)
+          VALUES (?, 2, 99, 'Provider', ?, 'live')
+        `).run(provider, category).lastInsertRowid;
+        const channel = db.prepare("INSERT INTO provider_channels (provider_id, remote_stream_id, name, stream_type) VALUES (?, 99, 'Channel', 'live')").run(provider).lastInsertRowid;
+        const owned = db.prepare(`
+          INSERT INTO user_channels
+            (user_category_id, provider_channel_id, mapping_id, granted_by_admin, authorization_revoked)
+          VALUES (?, ?, ?, 1, 0)
+        `).run(category, channel, mapping).lastInsertRowid;
+        const manual = db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id) VALUES (?, ?)').run(manualCategory, channel).lastInsertRowid;
+        const res = response();
+
+        channelController.updateCategoryMapping({
+            params: { id: String(mapping) }, body: { user_category_id: null },
+            user: { id: 2, is_admin: false }
+        }, res);
+
+        expect(res.json).toHaveBeenCalledWith({
+            success: true, assignments_removed: 1, assignments_moved: 0, duplicates_merged: 0
+        });
+        expect(db.prepare('SELECT id FROM user_channels WHERE id = ?').get(owned)).toBeUndefined();
+        expect(db.prepare('SELECT id, mapping_id FROM user_channels WHERE id = ?').get(manual))
+          .toEqual({ id: manual, mapping_id: null });
+        expect(db.prepare('SELECT user_category_id FROM category_mappings WHERE id = ?').get(mapping))
+          .toEqual({ user_category_id: null });
+    });
+
+    it('accepts exactly 5000 bulk category IDs and rejects larger requests before writing', () => {
+        const insert = db.prepare("INSERT INTO user_categories (user_id, name, type) VALUES (2, ?, 'live')");
+        const ids = [];
+        const create = db.transaction(() => {
+            for (let i = 0; i < 5000; i++) ids.push(Number(insert.run(`bulk-${i}`).lastInsertRowid));
+        });
+        create();
+        const accepted = response();
+        channelController.bulkDeleteUserCategories({
+            body: { ids }, user: { id: 1, is_admin: true, username: 'admin' }, ip: '127.0.0.1'
+        }, accepted);
+        expect(accepted.json).toHaveBeenCalledWith({ success: true, deleted: 5000 });
+
+        const own = addAssignment(2);
+        channelsJsonCache.set('user_2_live', ['cached']);
+        const rejected = response();
+        channelController.bulkDeleteUserChannels({
+            body: { ids: [own.assignmentId, ...Array.from({ length: 5000 }, (_, i) => i + 100000)] },
+            user: { id: 2, is_admin: false, username: 'user' }, ip: '127.0.0.1'
+        }, rejected);
+        expect(rejected.status).toHaveBeenCalledWith(400);
+        expect(db.prepare('SELECT is_hidden FROM user_channels WHERE id = ?').get(own.assignmentId)).toEqual({ is_hidden: 0 });
+        expect(channelsJsonCache.has('user_2_live')).toBe(true);
+    });
 });

--- a/tests/controllers/delete_cleanup.test.js
+++ b/tests/controllers/delete_cleanup.test.js
@@ -48,7 +48,8 @@ vi.mock('../../src/utils/helpers.js', () => ({
 
 vi.mock('../../src/services/syncService.js', () => ({
   performSync: vi.fn(),
-  checkProviderExpiry: vi.fn()
+  checkProviderExpiry: vi.fn(),
+  deleteProviderChannelCascade: vi.fn()
 }));
 
 vi.mock('../../src/services/epgService.js', () => ({

--- a/tests/migration_regression.test.js
+++ b/tests/migration_regression.test.js
@@ -7,6 +7,9 @@ import {
     migrateOtpSecrets,
     migrateSeriesEpisodes,
     migrateUserChannelMappingId,
+    migrateProviderSyncState,
+    migrateUserChannelMappingBackfillV1,
+    migrateUserChannelDeduplicationV1,
     migrateUserChannelAdminGrants,
     migrateSyncConfigAdminGrants
 } from '../src/database/migrations.js';
@@ -67,6 +70,122 @@ describe('Migration Bug Regression', () => {
               .toContain('mapping_id');
             expect(legacyDb.prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_user_channels_mapping'").get())
               .toEqual({ name: 'idx_user_channels_mapping' });
+        } finally {
+            legacyDb.close();
+        }
+    });
+
+    it('creates persistent provider snapshot state idempotently', () => {
+        const legacyDb = new Database(':memory:');
+        try {
+            legacyDb.exec('CREATE TABLE providers (id INTEGER PRIMARY KEY)');
+            migrateProviderSyncState(legacyDb);
+            migrateProviderSyncState(legacyDb);
+            expect(legacyDb.prepare('PRAGMA table_info(provider_sync_state)').all().map(column => column.name))
+              .toEqual(['provider_id', 'stream_type', 'empty_snapshot_count', 'last_nonempty_count', 'last_snapshot_at']);
+        } finally {
+            legacyDb.close();
+        }
+    });
+
+    it('backfills only unambiguous legacy mapping ownership and records a marker', () => {
+        const legacyDb = new Database(':memory:');
+        try {
+            legacyDb.exec(`
+              CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT);
+              CREATE TABLE providers (id INTEGER PRIMARY KEY, user_id INTEGER);
+              CREATE TABLE provider_channels (id INTEGER PRIMARY KEY, provider_id INTEGER, original_category_id INTEGER, stream_type TEXT);
+              CREATE TABLE user_categories (id INTEGER PRIMARY KEY, user_id INTEGER, type TEXT);
+              CREATE TABLE category_mappings (
+                id INTEGER PRIMARY KEY, provider_id INTEGER, user_id INTEGER,
+                provider_category_id INTEGER, provider_category_name TEXT,
+                user_category_id INTEGER, category_type TEXT
+              );
+              CREATE TABLE user_channels (
+                id INTEGER PRIMARY KEY, user_category_id INTEGER, provider_channel_id INTEGER,
+                mapping_id INTEGER
+              );
+              INSERT INTO providers VALUES (1, 1), (2, 9);
+              INSERT INTO provider_channels VALUES
+                (10, 1, 100, 'live'), (11, 1, 200, 'live'), (12, 2, 100, 'live'),
+                (13, 1, 300, 'live'), (14, 1, 400, 'live'), (15, 1, 500, 'live');
+              INSERT INTO user_categories VALUES
+                (20, 2, 'live'), (21, 2, 'radio'), (22, 2, 'movie'), (23, 2, 'live');
+              INSERT INTO category_mappings VALUES
+                (100, 1, 2, 100, 'Live', 20, 'live'),
+                (101, 1, 2, 200, 'Radio', 21, 'radio'),
+                (102, 1, 2, 300, 'Ambiguous A', 20, 'live'),
+                (103, 1, 2, 300, 'Ambiguous B', 20, 'live'),
+                (105, 1, 2, 400, 'Wrong type', 22, 'movie'),
+                (106, 1, 2, 500, 'Unmatched', 23, 'live'),
+                (107, 1, 2, 600, 'Cross owner', 23, 'live');
+              INSERT INTO user_channels (id, user_category_id, provider_channel_id, mapping_id) VALUES
+                (201, 20, 10, NULL), (202, 21, 11, NULL), (203, 20, 13, NULL),
+                (204, 20, 12, NULL), (205, 22, 14, NULL), (206, 23, 15, NULL);
+            `);
+
+            const result = migrateUserChannelMappingBackfillV1(legacyDb);
+            expect(result).toEqual({ assigned: 3, ambiguous: 1, unmatched: 2, skipped: false });
+            expect(legacyDb.prepare('SELECT id, mapping_id FROM user_channels ORDER BY id').all()).toEqual([
+              { id: 201, mapping_id: 100 },
+              { id: 202, mapping_id: 101 },
+              { id: 203, mapping_id: null },
+              { id: 204, mapping_id: null },
+              { id: 205, mapping_id: null },
+              { id: 206, mapping_id: 106 }
+            ]);
+            expect(legacyDb.prepare("SELECT value FROM settings WHERE key = 'user_channel_mapping_backfill_v1'").get()).toBeTruthy();
+            expect(migrateUserChannelMappingBackfillV1(legacyDb)).toEqual({ assigned: 0, ambiguous: 0, unmatched: 0, skipped: true });
+        } finally {
+            legacyDb.close();
+        }
+    });
+
+    it('deduplicates assignments, rebinds aliases, and creates a unique index idempotently', () => {
+        const legacyDb = new Database(':memory:');
+        try {
+            legacyDb.pragma('foreign_keys = ON');
+            legacyDb.exec(`
+              CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT);
+              CREATE TABLE user_channels (
+                id INTEGER PRIMARY KEY, user_category_id INTEGER, provider_channel_id INTEGER,
+                sort_order INTEGER DEFAULT 0, custom_name TEXT DEFAULT '', is_hidden INTEGER DEFAULT 0,
+                mapping_id INTEGER, granted_by_admin INTEGER DEFAULT 0, authorization_revoked INTEGER DEFAULT 0
+              );
+              CREATE TABLE series_episode_aliases (
+                id INTEGER PRIMARY KEY,
+                user_channel_id INTEGER NOT NULL,
+                source_key TEXT NOT NULL,
+                series_remote_id INTEGER NOT NULL,
+                remote_episode_id INTEGER NOT NULL,
+                UNIQUE(user_channel_id, source_key, series_remote_id, remote_episode_id),
+                FOREIGN KEY (user_channel_id) REFERENCES user_channels(id) ON DELETE CASCADE
+              );
+              INSERT INTO user_channels VALUES
+                (1, 10, 20, 8, '', 0, 7, 1, 0),
+                (2, 10, 20, 2, 'Manual', 1, NULL, 0, 0),
+                (3, 11, 21, 9, 'Mapped', 0, 8, 0, 1),
+                (4, 11, 21, 3, '', 0, 9, 0, 0);
+              INSERT INTO series_episode_aliases (id, user_channel_id, source_key, series_remote_id, remote_episode_id) VALUES
+                (900000005, 2, 'source', 20, 1),
+                (900000006, 1, 'source', 20, 1),
+                (900000007, 1, 'source', 20, 2),
+                (900000008, 3, 'source', 21, 1);
+            `);
+
+            expect(migrateUserChannelDeduplicationV1(legacyDb)).toEqual({ merged: 2, skipped: false });
+            expect(legacyDb.prepare('SELECT id, mapping_id, is_hidden, custom_name, sort_order FROM user_channels ORDER BY id').all()).toEqual([
+              { id: 2, mapping_id: null, is_hidden: 1, custom_name: 'Manual', sort_order: 2 },
+              { id: 3, mapping_id: 8, is_hidden: 0, custom_name: 'Mapped', sort_order: 3 }
+            ]);
+            expect(legacyDb.prepare('SELECT id, user_channel_id, remote_episode_id FROM series_episode_aliases ORDER BY id').all()).toEqual([
+              { id: 900000005, user_channel_id: 2, remote_episode_id: 1 },
+              { id: 900000007, user_channel_id: 2, remote_episode_id: 2 },
+              { id: 900000008, user_channel_id: 3, remote_episode_id: 1 }
+            ]);
+            expect(legacyDb.prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'uq_user_channels_category_provider'").get())
+              .toEqual({ name: 'uq_user_channels_category_provider' });
+            expect(migrateUserChannelDeduplicationV1(legacyDb)).toEqual({ merged: 0, skipped: true });
         } finally {
             legacyDb.close();
         }

--- a/tests/sync_service_regression.test.js
+++ b/tests/sync_service_regression.test.js
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import Database from 'better-sqlite3';
+import { performance } from 'node:perf_hooks';
 
 const { fetchSafe, xtreamState } = vi.hoisted(() => ({
   fetchSafe: vi.fn(),
@@ -20,9 +21,12 @@ vi.mock('../src/services/logoResolver.js', () => ({ prePopulateProviderIconCache
 
 describe('sync authorization regression', () => {
   let performSync;
+  let selectStaleProviderChannels;
+  let deleteProviderChannelCascade;
 
   beforeAll(async () => {
-    ({ performSync } = await import('../src/services/syncService.js'));
+    ({ performSync, selectStaleProviderChannels, deleteProviderChannelCascade } = await import('../src/services/syncService.js'));
+    memDb.pragma('foreign_keys = ON');
     memDb.exec(`
       CREATE TABLE providers (
         id INTEGER PRIMARY KEY, name TEXT, url TEXT, username TEXT, password TEXT,
@@ -42,6 +46,21 @@ describe('sync authorization regression', () => {
         plot TEXT, "cast" TEXT, director TEXT, genre TEXT, releaseDate TEXT,
         youtube_trailer TEXT, episode_run_time TEXT,
         UNIQUE(provider_id, remote_stream_id)
+      );
+      CREATE TABLE epg_channel_mappings (
+        id INTEGER PRIMARY KEY, provider_channel_id INTEGER,
+        FOREIGN KEY (provider_channel_id) REFERENCES provider_channels(id)
+      );
+      CREATE TABLE stream_stats (
+        id INTEGER PRIMARY KEY, channel_id INTEGER,
+        FOREIGN KEY (channel_id) REFERENCES provider_channels(id)
+      );
+      CREATE TABLE provider_sync_state (
+        provider_id INTEGER, stream_type TEXT,
+        empty_snapshot_count INTEGER NOT NULL DEFAULT 0,
+        last_nonempty_count INTEGER NOT NULL DEFAULT 0,
+        last_snapshot_at INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY(provider_id, stream_type)
       );
       CREATE TABLE sync_logs (
         id INTEGER PRIMARY KEY, provider_id INTEGER, user_id INTEGER, sync_time INTEGER,
@@ -63,6 +82,15 @@ describe('sync authorization regression', () => {
         granted_by_admin INTEGER NOT NULL DEFAULT 0,
         authorization_revoked INTEGER NOT NULL DEFAULT 0
       );
+      CREATE TABLE series_episode_aliases (
+        id INTEGER PRIMARY KEY,
+        user_channel_id INTEGER NOT NULL,
+        source_key TEXT NOT NULL,
+        series_remote_id INTEGER NOT NULL,
+        remote_episode_id INTEGER NOT NULL,
+        UNIQUE(user_channel_id, source_key, series_remote_id, remote_episode_id),
+        FOREIGN KEY (user_channel_id) REFERENCES user_channels(id) ON DELETE CASCADE
+      );
       CREATE TABLE user_categories (
         id INTEGER PRIMARY KEY, user_id INTEGER, name TEXT, is_adult INTEGER,
         sort_order INTEGER, type TEXT
@@ -72,7 +100,8 @@ describe('sync authorization regression', () => {
 
   beforeEach(() => {
     for (const table of [
-      'security_logs', 'sync_logs', 'user_channels', 'provider_channels',
+      'security_logs', 'sync_logs', 'series_episode_aliases',
+      'epg_channel_mappings', 'stream_stats', 'user_channels', 'provider_channels', 'provider_sync_state',
       'category_mappings', 'user_categories', 'sync_configs', 'providers',
     ]) {
       memDb.prepare(`DELETE FROM ${table}`).run();
@@ -343,9 +372,157 @@ describe('sync authorization regression', () => {
 
     xtreamState.channels = [];
     await performSync(1, 1, { mode: 'scheduled' });
+    expect(memDb.prepare('SELECT COUNT(*) AS count FROM provider_channels').get().count).toBe(1);
+    await performSync(1, 1, { mode: 'scheduled' });
     expect(memDb.prepare('SELECT COUNT(*) AS count FROM provider_channels').get().count).toBe(0);
     expect(memDb.prepare('SELECT COUNT(*) AS count FROM user_channels').get().count).toBe(0);
   });
+
+  it('removes stale channels with EPG, stream-stat, assignment, and alias dependencies', async () => {
+    configure();
+    await performSync(1, 1, { mode: 'scheduled' });
+    const channel = memDb.prepare('SELECT id FROM provider_channels WHERE remote_stream_id = 101').get();
+    const assignment = memDb.prepare('SELECT id FROM user_channels WHERE provider_channel_id = ?').get(channel.id);
+    memDb.prepare('INSERT INTO epg_channel_mappings (id, provider_channel_id) VALUES (1, ?)').run(channel.id);
+    memDb.prepare('INSERT INTO stream_stats (id, channel_id) VALUES (1, ?)').run(channel.id);
+    memDb.prepare(`
+      INSERT INTO series_episode_aliases
+        (id, user_channel_id, source_key, series_remote_id, remote_episode_id)
+      VALUES (1, ?, 'source', 101, 1)
+    `).run(assignment.id);
+
+    xtreamState.channels = [];
+    await performSync(1, 1, { mode: 'scheduled' });
+    expect(memDb.prepare('SELECT COUNT(*) AS count FROM provider_channels').get().count).toBe(1);
+    await performSync(1, 1, { mode: 'scheduled' });
+
+    expect(memDb.prepare('SELECT COUNT(*) AS count FROM provider_channels').get().count).toBe(0);
+    expect(memDb.prepare('SELECT COUNT(*) AS count FROM epg_channel_mappings').get().count).toBe(0);
+    expect(memDb.prepare('SELECT COUNT(*) AS count FROM stream_stats').get().count).toBe(0);
+    expect(memDb.prepare('SELECT COUNT(*) AS count FROM user_channels').get().count).toBe(0);
+    expect(memDb.prepare('SELECT COUNT(*) AS count FROM series_episode_aliases').get().count).toBe(0);
+  });
+
+  it('does not delete a channel belonging to another provider', () => {
+    memDb.prepare("INSERT INTO providers (id, name, url, username, password, user_id) VALUES (2, 'Other', 'http://other.test', 'u', 'p', 2)").run();
+    const channel = memDb.prepare("INSERT INTO provider_channels (provider_id, remote_stream_id, name, stream_type) VALUES (2, 202, 'Other', 'live')").run().lastInsertRowid;
+    expect(deleteProviderChannelCascade(memDb, 1, channel)).toBe(0);
+    expect(memDb.prepare('SELECT id FROM provider_channels WHERE id = ?').get(channel)).toEqual({ id: channel });
+  });
+
+  it('rolls back the full synchronization when a dependent cleanup fails', async () => {
+    configure();
+    await performSync(1, 1, { mode: 'scheduled' });
+    const channel = memDb.prepare('SELECT id FROM provider_channels WHERE remote_stream_id = 101').get();
+    memDb.prepare('INSERT INTO stream_stats (id, channel_id) VALUES (1, ?)').run(channel.id);
+    memDb.exec(`
+      CREATE TRIGGER fail_stream_stat_delete
+      BEFORE DELETE ON stream_stats
+      BEGIN SELECT RAISE(FAIL, 'dependent cleanup failure'); END;
+    `);
+    xtreamState.channels = [];
+    await performSync(1, 1, { mode: 'scheduled' });
+    const failed = await performSync(1, 1, { mode: 'scheduled' });
+    expect(failed.errorMessage).toMatch(/dependent cleanup failure/);
+    expect(memDb.prepare('SELECT id FROM provider_channels WHERE id = ?').get(channel.id)).toEqual({ id: channel.id });
+    expect(memDb.prepare('SELECT COUNT(*) AS count FROM user_channels').get().count).toBe(1);
+    memDb.exec('DROP TRIGGER fail_stream_stat_delete');
+  });
+
+  it('confirms empty VOD snapshots independently from live and ignores failed or invalid responses', async () => {
+    configure();
+    await performSync(1, 1, { mode: 'scheduled' });
+    const movie = memDb.prepare(`
+      INSERT INTO provider_channels
+        (provider_id, remote_stream_id, name, stream_type)
+      VALUES (1, 900, 'Movie', 'movie')
+    `).run().lastInsertRowid;
+
+    await performSync(1, 1, { mode: 'scheduled' });
+    expect(memDb.prepare('SELECT id FROM provider_channels WHERE id = ?').get(movie)).toEqual({ id: movie });
+    expect(memDb.prepare("SELECT empty_snapshot_count FROM provider_sync_state WHERE provider_id = 1 AND stream_type = 'movie'").get())
+      .toEqual({ empty_snapshot_count: 1 });
+    await performSync(1, 1, { mode: 'scheduled' });
+    expect(memDb.prepare('SELECT id FROM provider_channels WHERE id = ?').get(movie)).toBeUndefined();
+
+    const secondMovie = memDb.prepare(`
+      INSERT INTO provider_channels
+        (provider_id, remote_stream_id, name, stream_type)
+      VALUES (1, 901, 'Movie 2', 'movie')
+    `).run().lastInsertRowid;
+    fetchSafe.mockImplementation(async url => {
+      if (url.includes('action=get_vod_streams')) return { ok: false, status: 503, json: async () => [] };
+      return { ok: true, status: 200, headers: { get: () => 'application/json' }, json: async () => [] };
+    });
+    await performSync(1, 1, { mode: 'scheduled' });
+    expect(memDb.prepare('SELECT id FROM provider_channels WHERE id = ?').get(secondMovie)).toEqual({ id: secondMovie });
+    expect(memDb.prepare("SELECT empty_snapshot_count FROM provider_sync_state WHERE provider_id = 1 AND stream_type = 'movie'").get())
+      .toEqual({ empty_snapshot_count: 2 });
+
+    fetchSafe.mockImplementation(async url => {
+      if (url.includes('action=get_vod_streams')) return { ok: true, status: 200, json: async () => ({ error: 'auth' }) };
+      return { ok: true, status: 200, headers: { get: () => 'application/json' }, json: async () => [] };
+    });
+    await performSync(1, 1, { mode: 'scheduled' });
+    expect(memDb.prepare('SELECT id FROM provider_channels WHERE id = ?').get(secondMovie)).toEqual({ id: secondMovie });
+    expect(memDb.prepare("SELECT empty_snapshot_count FROM provider_sync_state WHERE provider_id = 1 AND stream_type = 'movie'").get())
+      .toEqual({ empty_snapshot_count: 2 });
+  });
+
+  it('accepts an initially empty provider without creating destructive cleanup state', async () => {
+    configure();
+    xtreamState.channels = [];
+    const result = await performSync(1, 1, { mode: 'scheduled' });
+    expect(result.errorMessage).toBe(null);
+    expect(memDb.prepare('SELECT COUNT(*) AS count FROM provider_channels').get().count).toBe(0);
+    expect(memDb.prepare("SELECT empty_snapshot_count FROM provider_sync_state WHERE provider_id = 1 AND stream_type = 'live'").get())
+      .toEqual({ empty_snapshot_count: 0 });
+  });
+
+  it('selects 40k live, VOD, and series catalogs deterministically without SQL placeholders', () => {
+    const existing = [];
+    const seen = new Map([
+      ['live', new Set()], ['movie', new Set()], ['series', new Set()]
+    ]);
+    for (const type of ['live', 'movie', 'series']) {
+      for (let id = 1; id <= 40000; id++) {
+        existing.push({ id: existing.length + 1, remote_stream_id: id, stream_type: type });
+        seen.get(type).add(id);
+      }
+    }
+    existing.push({ id: existing.length + 1, remote_stream_id: 40001, stream_type: 'live' });
+    const started = performance.now();
+    const stale = selectStaleProviderChannels(existing, seen, new Set(['live', 'movie', 'series']));
+    const elapsed = performance.now() - started;
+    expect(stale).toEqual([{ id: 120001, remote_stream_id: 40001, stream_type: 'live' }]);
+    console.info(`[Sync catalog benchmark] processed=${existing.length} stale=${stale.length} elapsed_ms=${elapsed.toFixed(1)} heap_delta_mib=${((process.memoryUsage().heapUsed) / 1024 / 1024).toFixed(1)} rss_mib=${(process.memoryUsage().rss / 1024 / 1024).toFixed(1)}`);
+  });
+
+  it('synchronizes a 100,000-channel live catalog and removes one stale item', async () => {
+    configure();
+    memDb.prepare('UPDATE sync_configs SET auto_add_channels = 0').run();
+    const catalog = Array.from({ length: 100000 }, (_, index) => ({
+      name: `Channel ${index + 1}`,
+      stream_id: index + 1,
+      category_id: 10,
+      stream_type: 'live'
+    }));
+    xtreamState.channels = catalog;
+    const started = performance.now();
+    const before = process.memoryUsage();
+    const first = await performSync(1, 1, { mode: 'scheduled' });
+    const elapsed = performance.now() - started;
+    const after = process.memoryUsage();
+    expect(first.errorMessage).toBe(null);
+    expect(first.channelsAdded).toBe(100000);
+    expect(memDb.prepare('SELECT COUNT(*) AS count FROM provider_channels').get().count).toBe(100000);
+    console.info(`[Sync catalog benchmark] processed=100000 stale=0 elapsed_ms=${elapsed.toFixed(1)} heap_delta_mib=${((after.heapUsed - before.heapUsed) / 1024 / 1024).toFixed(1)} rss_delta_mib=${((after.rss - before.rss) / 1024 / 1024).toFixed(1)}`);
+
+    xtreamState.channels = catalog.slice(1);
+    const second = await performSync(1, 1, { mode: 'scheduled' });
+    expect(second.errorMessage).toBe(null);
+    expect(memDb.prepare('SELECT COUNT(*) AS count FROM provider_channels').get().count).toBe(99999);
+  }, 120000);
 
   afterAll(() => memDb.close());
 });


### PR DESCRIPTION
## Summary

This hotfix addresses the post-PR611 provider-sync cleanup and category-mapping lifecycle regressions.

### Root causes and fixes

- Stale provider-channel cleanup now uses one transactional `deleteProviderChannelCascade` helper. It removes EPG mappings, stream statistics, user assignments (and cascading series aliases) before deleting the provider channel, verifies exactly one final delete, and is reused by provider deletion.
- Stale selection is computed from the already-loaded catalog and per-stream `Set` values. No provider-channel `NOT IN` placeholder list is generated, so large catalogs avoid SQLite variable limits and retain deterministic ordering.
- Persistent `provider_sync_state` tracks live, movie, and series snapshots independently. A first complete empty snapshot with local rows is preserved; only the second consecutive authoritative empty snapshot permits cleanup. Failed, invalid, and incomplete responses do not advance state.
- Mapping retarget and explicit unmap reconcile only `mapping_id`-owned assignments in the same transaction. Retargets move or merge rows, prefer manual survivors, preserve hidden/custom-name/authorization/sort data, and rebind series aliases. Manual assignments remain untouched; unmapping removes owned rows immediately.
- `user_channel_mapping_backfill_v1` assigns legacy ownership only for exactly one valid provider/category/owner/type match, including live-to-radio matching. Ambiguous, unmatched, and manual rows remain unowned.
- `user_channel_deduplication_v1` merges duplicate assignments deterministically, preserves conservative fields and aliases, and creates `uq_user_channels_category_provider`. All relevant import, restore, clone, sync, and bulk insert paths tolerate the unique index.
- Bulk category/channel requests reject more than 5,000 IDs before any write or cache invalidation.

### Compatibility

No Stalker/MAG, Xtream, M3U, HDHomeRun, VOD, series, radio, EPG, catch-up, stream URL, or public channel-ID contract was changed. User-facing localization was not changed.

### Validation

- Focused regression matrix: 17 files, 161 tests passed.
- Isolated full suite: 92 files, 589 tests passed (`DATA_DIR` temporary directory).
- Lint: 0 errors (146 pre-existing warnings).
- `npm audit --audit-level=high`: 0 vulnerabilities.
- `npm audit --omit=dev --audit-level=high`: 0 vulnerabilities.
- `npm run build`: passed (project has no compile step).
- `npm ci` and `npm ci --dry-run`: passed.
- Docker build: `iptv-manager-sync-hotfix` built successfully with Colima.
- Large-catalog regression includes deterministic 40k live/movie/series selection and a 100,000-channel synchronization/removal benchmark with elapsed, heap-delta, RSS-delta, processed, and stale counts logged by the test.

Real IPTVnator/OTT Navigator binaries are not present in this checkout/runtime (`/private/tmp/pr610-e2e` is unavailable), so a real-client smoke pass is not claimed. The existing automated Stalker contract suite remains green; the client-environment blocker is explicit and does not affect the server-side validation above.

No release, tag, GitHub Release, container publication, or deployment is included.