### PR TITLE
fix: preserve manual assignment provenance in legacy data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,13 @@ All notable changes to this project are documented here.
   existing content catalog.
 - Reconcile mapping-owned assignments when mappings are retargeted or removed,
   while preserving manual assignments and hidden state.
-- Backfill legacy `mapping_id` values only for unambiguous matches and merge
-  duplicate user-channel assignments before enforcing uniqueness.
+- Added explicit `assignment_origin` provenance (`manual`, `mapping`, `legacy`,
+  or `imported`) and restricted mapping reconciliation to trusted mapping rows.
+- Replaced unsafe V1 mapping inference with a conservative V2 repair that
+  clears uncertain ownership while preserving assignment IDs and fields.
+- Deterministically merge duplicate assignments during legacy backup restore,
+  full-system import, cloning, and category import, including alias rebinding.
+- Treat manual re-add as an explicit transfer from mapping ownership to manual
+  ownership.
 - Validated the experimental portal with real software clients.
 - Hardware-specific MAG UI and favorites remain unsupported.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -94,13 +94,18 @@ Category mappings accept `null` for an explicit unmap, or a category owned by
 the mapping user with the same content type. Invalid, foreign, and mixed-type
 targets are rejected without changing the mapping.
 
-Assignments created by category synchronization are owned through
-`user_channels.mapping_id`. Retargeting a mapping moves or merges only those
-owned assignments into the validated target category; explicitly unmapping a
-mapping removes its owned assignments. Manual assignments (`mapping_id IS NULL`)
-remain unchanged. Each user category can contain at most one assignment for a
-given provider channel. Bulk category and channel requests accept at most 5,000
-IDs per request.
+Assignments carry an explicit `user_channels.assignment_origin` constrained to
+`manual`, `mapping`, `legacy`, or `imported`. Manual assignments are user-owned
+and are never moved or removed by category mapping reconciliation. Mapping
+assignments are owned by one `category_mappings.id` and may be moved, merged,
+or removed. Legacy and imported assignments remain unmanaged until explicitly
+adopted. A manual re-add of an existing assignment adopts it as `manual` and
+clears `mapping_id`.
+
+Mapping reconciliation requires both `assignment_origin = 'mapping'` and a
+matching `mapping_id`; a non-null ID alone is not trusted. Each user category
+can contain at most one assignment for a given provider channel. Bulk category
+and channel requests accept at most 5,000 IDs per request.
 
 ## EPG and Mapping
 
@@ -148,6 +153,16 @@ cross-owner grant only by sending `allow_cross_owner: true`; omitted or false
 values keep those rows revoked with grant `0`. The restore response
 includes non-sensitive `channels_restored`, `channels_hidden`, and
 `channels_skipped` counters.
+
+New backups use `format_version: 2` and
+`assignment_provenance_version: 1`. Only a mapping present in the backup,
+belonging to the restored user, and targeting the restored category/provider
+relationship may retain mapping ownership. Legacy or unversioned backups treat
+all assignments as imported and unowned. Duplicate assignments are merged by
+category/provider-channel identity: manual wins over legacy/imported, which
+wins over mapping; hidden state wins; custom names and lowest valid sort order
+are deterministic; authorization is recalculated fail-closed. The optional
+`channels_merged` counter reports merged rows without inflating restored rows.
 
 ## System, Security, and Statistics
 
@@ -200,6 +215,14 @@ rebuilt ownership relationships. Imported cross-owner administrator grants are
 restored only when the admin import request also includes
 `allow_cross_owner: true`; otherwise their sync configs remain disabled and
 their channel assignments remain authorization-revoked.
+
+New full-system exports use `version: 2` with
+`assignment_provenance_version: 1`. Modern mapping provenance is retained only
+when the mapping was recreated for the imported user/category/provider. Older
+or unversioned exports restore assignments as imported and unowned. Duplicate
+assignments are merged with the same deterministic policy as backup restore;
+`stats.channels` counts unique inserted assignments and `channels_merged` and
+`channels_skipped` report the corresponding outcomes.
 
 Radio categories are user-facing mappings of live provider channels. A live
 provider category may be mapped to both live and radio user categories, and

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -131,20 +131,28 @@ their authorization revocation, while an administrator must explicitly restore
 a selected channel to clear its hidden state. Re-running the migration is
 idempotent and does not infer administrator grants.
 
-Automatic category synchronization records ownership of new assignments in the
-nullable `user_channels.mapping_id` column. Legacy or manually curated rows
-remain unowned (`NULL`) so a category move cannot delete them; only assignments
-created by an active mapping are reconciled. The migration adds the column and
-an index without changing public IDs.
+Automatic category synchronization records ownership of new assignments with
+`assignment_origin = 'mapping'` and the active `mapping_id`. Explicit channel
+adds and re-adds use `assignment_origin = 'manual'` and clear `mapping_id`.
+Rows created before trustworthy provenance, or by an old import, use
+`legacy`/`imported`; mapping lifecycle code never moves or deletes those rows.
+The origin column has a SQLite CHECK constraint and an origin/mapping index.
 
-The versioned `user_channel_mapping_backfill_v1` migration assigns ownership to
-legacy rows only when exactly one mapping matches the provider, source
-category, category owner, and content type (including the live-to-radio rule).
-Ambiguous, unmatched, and manual rows remain unowned. The
-`user_channel_deduplication_v1` migration deterministically merges duplicate
-category/provider-channel assignments, rebinds series aliases, and then creates
-the `uq_user_channels_category_provider` unique index. Both markers make the
-migrations idempotent.
+`user_channel_mapping_backfill_v1` is now a marker-only compatibility migration;
+it never infers ownership from matching provider/category fields. The versioned
+`user_channel_assignment_provenance_v2` migration runs after the origin column
+exists and before deduplication. It converts all uncertain pre-V2 rows to
+`legacy` with `mapping_id = NULL`, preserving IDs, visibility, names, grants,
+sort order, and series aliases. Its marker makes the repair idempotent.
+
+`user_channel_deduplication_v1`, backup restore, full-system import, cloning,
+category import, and mapping retargeting share one deterministic merge helper.
+The helper merges by category/provider-channel identity, prefers
+manual > legacy/imported > mapping, keeps hidden state, selects a deterministic
+custom name and lowest valid sort order, recalculates authorization, and
+rebinds/de-duplicates series aliases before removing losers. Modern backup and
+system formats may retain mapping ownership only after relationship validation;
+legacy formats are imported as unowned.
 
 Provider sync state is persisted per provider and stream type in
 `provider_sync_state`. A first complete empty snapshot with local rows is

--- a/src/controllers/backupController.js
+++ b/src/controllers/backupController.js
@@ -108,12 +108,14 @@ export const restoreBackup = (req, res) => {
       // Insert backup data
       const insertCategory = db.prepare('INSERT INTO user_categories (id, user_id, name, sort_order, is_adult, type) VALUES (?, ?, ?, ?, ?, ?)');
       const getMapping = db.prepare(`
-        SELECT id, provider_id, COALESCE(category_type, 'live') AS category_type
+        SELECT id, provider_id, provider_category_id,
+               COALESCE(category_type, 'live') AS category_type
         FROM category_mappings
         WHERE id = ? AND user_id = ?
       `);
       const getProviderOwner = db.prepare(`
-        SELECT p.id AS provider_id, p.user_id AS provider_owner_id, COALESCE(pc.stream_type, 'live') AS stream_type
+        SELECT p.id AS provider_id, p.user_id AS provider_owner_id,
+               pc.original_category_id, COALESCE(pc.stream_type, 'live') AS stream_type
         FROM provider_channels pc
         JOIN providers p ON p.id = pc.provider_id
         WHERE pc.id = ?
@@ -146,7 +148,8 @@ export const restoreBackup = (req, res) => {
           allowExplicitAdminGrant: req.body?.allow_cross_owner === true
         });
         const isHidden = Number(chan.is_hidden) === 1 ? 1 : 0;
-        const authorizationRevoked = grant === null ? 1 : 0;
+        const authorizationRevoked = grant === null ||
+          (Number(chan.authorization_revoked) === 1 && grant !== 1) ? 1 : 0;
         const sourceOrigin = trustedFormat
           ? normalizeAssignmentOrigin(chan.assignment_origin, 'legacy')
           : 'imported';
@@ -177,10 +180,15 @@ export const restoreBackup = (req, res) => {
             const mapType = String(map?.category_type || 'live');
             const categoryType = String(category?.type || 'live');
             const streamType = String(provider.stream_type || 'live');
+            const providerCategoryId = Number(provider.original_category_id);
+            const mappingCategoryId = Number(current?.provider_category_id);
+            const sourceCategoryId = Number(sourceMapping?.provider_category_id);
             const typeValid = mapType === categoryType &&
               (streamType === mapType || (streamType === 'live' && mapType === 'radio'));
             return Boolean(map && current && Number(map.user_category_id) === categoryId &&
-              Number(current.provider_id) === Number(provider.provider_id) && typeValid);
+              Number(current.provider_id) === Number(provider.provider_id) &&
+              Number.isFinite(providerCategoryId) && providerCategoryId === mappingCategoryId &&
+              providerCategoryId === sourceCategoryId && typeValid);
           }
         });
         if (result.skipped) {

--- a/src/controllers/backupController.js
+++ b/src/controllers/backupController.js
@@ -1,6 +1,10 @@
 import db from '../database/db.js';
 import { clearChannelsCache } from '../services/cacheService.js';
 import { resolveAssignmentGrant } from '../utils/helpers.js';
+import {
+  normalizeAssignmentOrigin,
+  upsertMergedUserChannelAssignment
+} from '../services/userChannelAssignmentService.js';
 
 export const getBackups = (req, res) => {
   try {
@@ -43,6 +47,8 @@ export const createBackup = (req, res) => {
     }
 
     const backupData = JSON.stringify({
+      format_version: 2,
+      assignment_provenance_version: 1,
       userCategories,
       userChannels,
       categoryMappings
@@ -80,8 +86,9 @@ export const restoreBackup = (req, res) => {
     const backupMappingTargets = new Map(
       data.categoryMappings
         .filter(map => Number.isInteger(Number(map.id)) && Number(map.id) > 0)
-        .map(map => [Number(map.id), Number(map.user_category_id)])
+        .map(map => [Number(map.id), map])
     );
+    const trustedFormat = Number(data.format_version) === 2 && Number(data.assignment_provenance_version) === 1;
 
     const stats = { channels_restored: 0, channels_hidden: 0, channels_skipped: 0 };
 
@@ -100,20 +107,18 @@ export const restoreBackup = (req, res) => {
 
       // Insert backup data
       const insertCategory = db.prepare('INSERT INTO user_categories (id, user_id, name, sort_order, is_adult, type) VALUES (?, ?, ?, ?, ?, ?)');
-      const insertChannel = db.prepare(`
-        INSERT INTO user_channels
-          (id, user_category_id, provider_channel_id, sort_order, custom_name, is_hidden,
-           mapping_id, granted_by_admin, authorization_revoked)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-        ON CONFLICT DO NOTHING
+      const getMapping = db.prepare(`
+        SELECT id, provider_id, COALESCE(category_type, 'live') AS category_type
+        FROM category_mappings
+        WHERE id = ? AND user_id = ?
       `);
-      const getMapping = db.prepare('SELECT id FROM category_mappings WHERE id = ? AND user_id = ?');
       const getProviderOwner = db.prepare(`
-        SELECT p.user_id AS provider_owner_id
+        SELECT p.id AS provider_id, p.user_id AS provider_owner_id, COALESCE(pc.stream_type, 'live') AS stream_type
         FROM provider_channels pc
         JOIN providers p ON p.id = pc.provider_id
         WHERE pc.id = ?
       `);
+      const getCategoryType = db.prepare("SELECT COALESCE(type, 'live') AS type FROM user_categories WHERE id = ? AND user_id = ?");
       const updateMapping = db.prepare('UPDATE category_mappings SET user_category_id = ?, auto_created = ? WHERE id = ? AND user_id = ?');
 
       for (const cat of data.userCategories) {
@@ -142,25 +147,47 @@ export const restoreBackup = (req, res) => {
         });
         const isHidden = Number(chan.is_hidden) === 1 ? 1 : 0;
         const authorizationRevoked = grant === null ? 1 : 0;
-        const mappingId = Number(chan.mapping_id);
-        const restoredMappingId = Number.isInteger(mappingId) && mappingId > 0 &&
-          backupMappingTargets.get(mappingId) === categoryId && getMapping.get(mappingId, userId)
-          ? mappingId
+        const sourceOrigin = trustedFormat
+          ? normalizeAssignmentOrigin(chan.assignment_origin, 'legacy')
+          : 'imported';
+        const sourceMappingId = Number(chan.mapping_id);
+        const sourceMapping = backupMappingTargets.get(sourceMappingId);
+        const restoredMappingId = sourceOrigin === 'mapping' && Number.isInteger(sourceMappingId) && sourceMappingId > 0 &&
+          sourceMapping && Number(sourceMapping.user_category_id) === categoryId && getMapping.get(sourceMappingId, userId)
+          ? sourceMappingId
           : null;
-
-        insertChannel.run(
-          chan.id,
-          categoryId,
-          providerChannelId,
-          chan.sort_order,
-          chan.custom_name || '',
-          isHidden,
-          restoredMappingId,
-          grant === 1 ? 1 : 0,
-          authorizationRevoked
-        );
-        if (isHidden || authorizationRevoked) stats.channels_hidden++;
-        else stats.channels_restored++;
+        const result = upsertMergedUserChannelAssignment(db, {
+          id: chan.id,
+          user_category_id: categoryId,
+          provider_channel_id: providerChannelId,
+          sort_order: chan.sort_order,
+          custom_name: chan.custom_name || '',
+          is_hidden: isHidden,
+          assignment_origin: sourceOrigin,
+          mapping_id: restoredMappingId,
+          granted_by_admin: grant === 1 ? 1 : 0,
+          authorization_revoked: authorizationRevoked,
+          grant_valid: grant === 1
+        }, {
+          preserveId: true,
+          mappingValidator: mappingId => {
+            const map = backupMappingTargets.get(Number(mappingId));
+            const current = getMapping.get(Number(mappingId), userId);
+            const category = getCategoryType.get(categoryId, userId);
+            const mapType = String(map?.category_type || 'live');
+            const categoryType = String(category?.type || 'live');
+            const streamType = String(provider.stream_type || 'live');
+            const typeValid = mapType === categoryType &&
+              (streamType === mapType || (streamType === 'live' && mapType === 'radio'));
+            return Boolean(map && current && Number(map.user_category_id) === categoryId &&
+              Number(current.provider_id) === Number(provider.provider_id) && typeValid);
+          }
+        });
+        if (result.skipped) {
+          stats.channels_skipped++;
+          continue;
+        }
+        if (result.merged) stats.channels_merged = (stats.channels_merged || 0) + result.merged;
       }
 
       for (const map of data.categoryMappings) {
@@ -169,9 +196,23 @@ export const restoreBackup = (req, res) => {
           updateMapping.run(categoryId, map.auto_created ? 1 : 0, map.id, userId);
         }
       }
+
+      const categoryPlaceholders = [...restoredCategoryIds].map(() => '?').join(',');
+      if (categoryPlaceholders) {
+        const finalCounts = db.prepare(`
+          SELECT
+            SUM(CASE WHEN is_hidden = 0 AND authorization_revoked = 0 THEN 1 ELSE 0 END) AS restored,
+            SUM(CASE WHEN is_hidden = 1 OR authorization_revoked = 1 THEN 1 ELSE 0 END) AS hidden
+          FROM user_channels
+          WHERE user_category_id IN (${categoryPlaceholders})
+        `).get(...restoredCategoryIds);
+        stats.channels_restored = Number(finalCounts?.restored || 0);
+        stats.channels_hidden = Number(finalCounts?.hidden || 0);
+      }
     })();
 
     clearChannelsCache(userId);
+    if (!stats.channels_merged) delete stats.channels_merged;
     res.json({ success: true, ...stats });
   } catch (error) {
     console.error('Restore backup error:', error);

--- a/src/controllers/channelController.js
+++ b/src/controllers/channelController.js
@@ -2,6 +2,10 @@ import { clearChannelsCache } from '../services/cacheService.js';
 import db from '../database/db.js';
 import { isAdultCategory, resolveAssignmentGrant } from '../utils/helpers.js';
 import { getEpgLogo, loadEpgLogosCache } from '../services/logoResolver.js';
+import {
+  mergeAssignmentCandidates,
+  rebindSeriesEpisodeAliases
+} from '../services/userChannelAssignmentService.js';
 
 const MAX_BULK_IDS = 5000;
 
@@ -24,78 +28,19 @@ function bulkOperationError(status, message) {
   return error;
 }
 
-function rebindSeriesAliases(survivorId, loserId) {
-  const aliasTable = db.prepare(`
-    SELECT name FROM sqlite_master
-    WHERE type = 'table' AND name = 'series_episode_aliases'
-  `).get();
-  if (!aliasTable) return;
-
-  const aliases = db.prepare(`
-    SELECT id, source_key, series_remote_id, remote_episode_id
-    FROM series_episode_aliases
-    WHERE user_channel_id = ?
-    ORDER BY id
-  `).all(loserId);
-  const findAlias = db.prepare(`
-    SELECT id FROM series_episode_aliases
-    WHERE user_channel_id = ? AND source_key = ?
-      AND series_remote_id = ? AND remote_episode_id = ?
-  `);
-  const updateAlias = db.prepare('UPDATE series_episode_aliases SET user_channel_id = ? WHERE id = ?');
-  const deleteAlias = db.prepare('DELETE FROM series_episode_aliases WHERE id = ?');
-  for (const alias of aliases) {
-    const existing = findAlias.get(
-      survivorId,
-      alias.source_key,
-      alias.series_remote_id,
-      alias.remote_episode_id
-    );
-    if (existing) deleteAlias.run(alias.id);
-    else updateAlias.run(survivorId, alias.id);
-  }
-}
-
-function mergeUserChannelAssignments(survivor, duplicate) {
-  rebindSeriesAliases(survivor.id, duplicate.id);
-  const hasValidGrant = [survivor, duplicate].some(
-    row => Number(row.granted_by_admin) === 1 && Number(row.authorization_revoked) !== 1
-  );
-  const hasGrant = [survivor, duplicate].some(row => Number(row.granted_by_admin) === 1);
-  const customName = String(survivor.custom_name || '').trim()
-    ? survivor.custom_name
-    : (String(duplicate.custom_name || '').trim() ? duplicate.custom_name : '');
-  db.prepare(`
-    UPDATE user_channels
-    SET is_hidden = ?,
-        custom_name = ?,
-        granted_by_admin = ?,
-        authorization_revoked = ?,
-        sort_order = ?
-    WHERE id = ?
-  `).run(
-    Number(survivor.is_hidden) === 1 || Number(duplicate.is_hidden) === 1 ? 1 : 0,
-    customName,
-    hasValidGrant || hasGrant ? 1 : 0,
-    hasValidGrant ? 0 : (
-      Number(survivor.authorization_revoked) === 1 || Number(duplicate.authorization_revoked) === 1 ? 1 : 0
-    ),
-    Math.min(Number(survivor.sort_order) || 0, Number(duplicate.sort_order) || 0),
-    survivor.id
-  );
-  db.prepare('DELETE FROM user_channels WHERE id = ?').run(duplicate.id);
-}
-
 function reconcileMappingAssignments(mapping, targetId) {
   const ownedAssignments = db.prepare(`
     SELECT uc.*
     FROM user_channels uc
-    WHERE uc.mapping_id = ?
+    WHERE uc.mapping_id = ? AND uc.assignment_origin = 'mapping'
     ORDER BY uc.id
   `).all(mapping.id);
   if (targetId === null) {
     for (const assignment of ownedAssignments) {
-      db.prepare('DELETE FROM user_channels WHERE id = ? AND mapping_id = ?').run(assignment.id, mapping.id);
+      db.prepare(`
+        DELETE FROM user_channels
+        WHERE id = ? AND mapping_id = ? AND assignment_origin = 'mapping'
+      `).run(assignment.id, mapping.id);
     }
     return { assignments_removed: ownedAssignments.length, assignments_moved: 0, duplicates_merged: 0 };
   }
@@ -108,26 +53,89 @@ function reconcileMappingAssignments(mapping, targetId) {
     WHERE user_category_id = ? AND provider_channel_id = ?
     ORDER BY id
   `);
-  const move = db.prepare('UPDATE user_channels SET user_category_id = ? WHERE id = ? AND mapping_id = ?');
+  const update = db.prepare(`
+    UPDATE user_channels
+    SET user_category_id = ?, sort_order = ?, custom_name = ?, is_hidden = ?,
+        assignment_origin = ?, mapping_id = ?, granted_by_admin = ?, authorization_revoked = ?
+    WHERE id = ?
+  `);
+  const deleteAssignment = db.prepare('DELETE FROM user_channels WHERE id = ?');
 
   for (const assignment of ownedAssignments) {
     if (Number(assignment.user_category_id) === Number(targetId)) continue;
     const targetRows = findTarget.all(targetId, assignment.provider_channel_id);
     if (targetRows.length === 0) {
-      if (move.run(targetId, assignment.id, mapping.id).changes === 1) assignmentsMoved++;
+      if (update.run(
+        targetId,
+        assignment.sort_order,
+        assignment.custom_name || '',
+        Number(assignment.is_hidden) === 1 ? 1 : 0,
+        'mapping',
+        mapping.id,
+        Number(assignment.granted_by_admin) === 1 ? 1 : 0,
+        Number(assignment.authorization_revoked) === 1 ? 1 : 0,
+        assignment.id
+      ).changes === 1) assignmentsMoved++;
       continue;
     }
 
-    const target = targetRows.find(row => row.mapping_id === null || row.mapping_id === undefined) || targetRows[0];
-    if (target.id === assignment.id) continue;
-    const survivor = [target, assignment]
-      .filter(row => row.mapping_id === null || row.mapping_id === undefined)[0]
-      || ([target, assignment].sort((a, b) => Number(a.id) - Number(b.id))[0]);
-    const duplicate = survivor.id === assignment.id ? target : assignment;
-    mergeUserChannelAssignments(survivor, duplicate);
-    if (survivor.id === assignment.id) {
-      move.run(targetId, assignment.id, mapping.id);
+    const merged = mergeAssignmentCandidates(
+      [...targetRows, { ...assignment, user_category_id: targetId }],
+      {
+        mappingValidator: mappingId => {
+          if (Number(mappingId) === Number(mapping.id)) return true;
+          const row = db.prepare(`
+            SELECT user_id, provider_id, user_category_id, COALESCE(category_type, 'live') AS category_type
+            FROM category_mappings
+            WHERE id = ?
+          `).get(mappingId);
+          return row && Number(row.user_id) === Number(mapping.user_id) &&
+            Number(row.provider_id) === Number(mapping.provider_id) &&
+            String(row.category_type) === String(mapping.category_type) &&
+            Number(row.user_category_id) === Number(targetId);
+        }
+      }
+    );
+    const survivorId = Number(merged.id);
+    const survivorIsSource = survivorId === Number(assignment.id);
+    const survivor = survivorIsSource ? assignment : targetRows.find(row => Number(row.id) === survivorId) || targetRows[0];
+    const losers = targetRows.filter(row => Number(row.id) !== Number(survivor.id));
+
+    if (survivorIsSource) {
+      for (const loser of targetRows) {
+        rebindSeriesEpisodeAliases(db, assignment.id, loser.id);
+        deleteAssignment.run(loser.id);
+      }
+      update.run(
+        targetId,
+        merged.sort_order,
+        merged.custom_name || '',
+        merged.is_hidden,
+        merged.assignment_origin,
+        merged.mapping_id,
+        merged.granted_by_admin,
+        merged.authorization_revoked,
+        assignment.id
+      );
       assignmentsMoved++;
+    } else {
+      update.run(
+        targetId,
+        merged.sort_order,
+        merged.custom_name || '',
+        merged.is_hidden,
+        merged.assignment_origin,
+        merged.mapping_id,
+        merged.granted_by_admin,
+        merged.authorization_revoked,
+        survivor.id
+      );
+      for (const loser of losers) {
+        rebindSeriesEpisodeAliases(db, survivor.id, loser.id);
+        deleteAssignment.run(loser.id);
+      }
+      rebindSeriesEpisodeAliases(db, survivor.id, assignment.id);
+      deleteAssignment.run(assignment.id);
     }
     duplicatesMerged++;
   }
@@ -396,15 +404,17 @@ export const addUserChannel = (req, res) => {
     if (existing) {
         db.prepare(`
           UPDATE user_channels
-          SET is_hidden = 0, sort_order = ?, granted_by_admin = ?, authorization_revoked = 0
+          SET is_hidden = 0, sort_order = ?, assignment_origin = 'manual', mapping_id = NULL,
+              granted_by_admin = ?, authorization_revoked = 0
           WHERE id = ?
         `).run(newSortOrder, grantedByAdmin, existing.id);
         insertId = existing.id;
     } else {
         const info = db.prepare(`
           INSERT INTO user_channels
-            (user_category_id, provider_channel_id, sort_order, granted_by_admin, authorization_revoked)
-          VALUES (?, ?, ?, ?, 0)
+            (user_category_id, provider_channel_id, sort_order, assignment_origin, mapping_id,
+             granted_by_admin, authorization_revoked)
+          VALUES (?, ?, ?, 'manual', NULL, ?, 0)
         `).run(catId, Number(provider_channel_id), newSortOrder, grantedByAdmin);
         insertId = info.lastInsertRowid;
     }

--- a/src/controllers/providerController.js
+++ b/src/controllers/providerController.js
@@ -6,6 +6,7 @@ import { performSync, checkProviderExpiry, deleteProviderChannelCascade } from '
 import { updateProviderEpg } from '../services/epgService.js';
 import { clearChannelsCache } from '../services/cacheService.js';
 import { parseTimeshiftTimezone } from '../utils/timezone.js';
+import { upsertMergedUserChannelAssignment } from '../services/userChannelAssignmentService.js';
 
 const normalizeProviderBaseUrl = (url) => String(url || '').trim().replace(/\/+$/, '');
 const isHttpUrl = (url) => /^https?:\/\//i.test(url);
@@ -753,26 +754,36 @@ export const importCategory = async (req, res) => {
         ORDER BY original_sort_order ASC, name ASC
       `);
 
-      const insertChannel = db.prepare(`
-        INSERT INTO user_channels
-          (user_category_id, provider_channel_id, sort_order, mapping_id, granted_by_admin, authorization_revoked)
-        VALUES (?, ?, ?, ?, ?, 0)
-        ON CONFLICT DO NOTHING
-      `);
       const channels = stmt.all(providerId, Number(category_id), streamType);
-      const importedCount = channels.length;
+      let importedCount = 0;
+      let mergedCount = 0;
       db.transaction(() => {
         channels.forEach((ch, idx) => {
-          insertChannel.run(newCategoryId, ch.id, idx, mapping?.id || null, grantedByAdmin);
+          const result = upsertMergedUserChannelAssignment(db, {
+            user_category_id: newCategoryId,
+            provider_channel_id: ch.id,
+            sort_order: idx,
+            assignment_origin: 'mapping',
+            mapping_id: mapping?.id || null,
+            granted_by_admin: grantedByAdmin,
+            authorization_revoked: 0,
+            grant_valid: grantedByAdmin === 1
+          }, {
+            mappingValidator: mappingId => Number(mappingId) === Number(mapping?.id) && Boolean(mapping?.id)
+          });
+          importedCount += result.inserted;
+          mergedCount += result.merged;
         });
       })();
 
-      res.json({
+      const response = {
         success: true,
         category_id: newCategoryId,
         channels_imported: importedCount,
         is_adult: isAdult
-      });
+      };
+      if (mergedCount) response.channels_merged = mergedCount;
+      res.json(response);
     } else {
       res.json({
         success: true,
@@ -816,15 +827,10 @@ export const importCategories = async (req, res) => {
 
     const results = [];
     let totalChannels = 0;
+    let totalMerged = 0;
     let totalCategories = 0;
 
     const insertUserCategory = db.prepare('INSERT INTO user_categories (user_id, name, is_adult, sort_order, type) VALUES (?, ?, ?, ?, ?)');
-    const insertChannel = db.prepare(`
-      INSERT INTO user_channels
-        (user_category_id, provider_channel_id, sort_order, mapping_id, granted_by_admin, authorization_revoked)
-      VALUES (?, ?, ?, ?, ?, 0)
-      ON CONFLICT DO NOTHING
-    `);
     const getMaxSort = db.prepare('SELECT COALESCE(MAX(sort_order), -1) as max_sort FROM user_categories WHERE user_id = ?');
 
     // Pre-fetch channels for all categories being imported to avoid N+1 queries
@@ -888,10 +894,22 @@ export const importCategories = async (req, res) => {
           const channels = channelsMap.get(`${Number(cat.id)}_${streamType}`) || [];
 
           channels.forEach((ch, idx) => {
-            insertChannel.run(newCategoryId, ch.id, idx, mapping?.id || null, grantedByAdmin);
+            const result = upsertMergedUserChannelAssignment(db, {
+              user_category_id: newCategoryId,
+              provider_channel_id: ch.id,
+              sort_order: idx,
+              assignment_origin: 'mapping',
+              mapping_id: mapping?.id || null,
+              granted_by_admin: grantedByAdmin,
+              authorization_revoked: 0,
+              grant_valid: grantedByAdmin === 1
+            }, {
+              mappingValidator: mappingId => Number(mappingId) === Number(mapping?.id) && Boolean(mapping?.id)
+            });
+            channelsImported += result.inserted;
+            totalChannels += result.inserted;
+            totalMerged += result.merged;
           });
-          channelsImported = channels.length;
-          totalChannels += channelsImported;
         }
 
         results.push({
@@ -903,12 +921,14 @@ export const importCategories = async (req, res) => {
       }
     })();
 
-    res.json({
+    const response = {
       success: true,
       categories_imported: totalCategories,
       channels_imported: totalChannels,
       results
-    });
+    };
+    if (totalMerged) response.channels_merged = totalMerged;
+    res.json(response);
   } catch (e) {
     console.error(e);
     res.status(500).json({error: e.message});

--- a/src/controllers/systemController.js
+++ b/src/controllers/systemController.js
@@ -13,6 +13,10 @@ import geoip from 'geoip-lite';
 import { getEpgLogo, loadEpgLogosCache } from '../services/logoResolver.js';
 import { getGeoIpUpdatePlan, reloadGeoIpData, runGeoIpUpdateProcess } from '../services/geoIpUpdateService.js';
 import { parseTimeshiftTimezone } from '../utils/timezone.js';
+import {
+  normalizeAssignmentOrigin,
+  upsertMergedUserChannelAssignment
+} from '../services/userChannelAssignmentService.js';
 
 let initialNetStats = null;
 si.networkStats().then(stats => {
@@ -228,7 +232,8 @@ export const exportData = (req, res) => {
     }
 
     const exportData = {
-      version: 1,
+      version: 2,
+      assignment_provenance_version: 1,
       timestamp: Date.now(),
       users: [],
       providers: [],
@@ -394,9 +399,11 @@ export const importData = async (req, res) => {
 
     const importData = JSON.parse(jsonStr);
 
-    if (!importData.version || !importData.users) {
+    if (!Array.isArray(importData.users)) {
       return res.status(400).json({error: 'Invalid export file format'});
     }
+    const trustedModernFormat = Number(importData.version) === 2 &&
+      Number(importData.assignment_provenance_version) === 1;
 
     // Security validation for URLs
     for (const p of importData.providers || []) {
@@ -438,7 +445,9 @@ export const importData = async (req, res) => {
       users_skipped: 0,
       providers: 0,
       categories: 0,
-      channels: 0
+      channels: 0,
+      channels_merged: 0,
+      channels_skipped: 0
     };
 
     db.transaction(() => {
@@ -503,7 +512,7 @@ export const importData = async (req, res) => {
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `);
 
-      for (const p of importData.providers) {
+      for (const p of importData.providers || []) {
         const newUserId = userIdMap.get(p.user_id);
         if (!newUserId) continue;
 
@@ -530,7 +539,7 @@ export const importData = async (req, res) => {
         stats.providers++;
       }
 
-      const provChannels = importData.channels.filter(c => !c.type && providerIdMap.has(c.provider_id));
+      const provChannels = (importData.channels || []).filter(c => !c.type && providerIdMap.has(c.provider_id));
 
       const insertProvChannel = db.prepare(`
         INSERT INTO provider_channels (
@@ -573,7 +582,7 @@ export const importData = async (req, res) => {
 
       const insertCategoryStmt = db.prepare('INSERT INTO user_categories (user_id, name, is_adult, sort_order, type) VALUES (?, ?, ?, ?, ?)');
 
-      for (const cat of importData.categories) {
+      for (const cat of importData.categories || []) {
         const newUserId = userIdMap.get(cat.user_id);
         if (!newUserId) continue;
 
@@ -589,8 +598,9 @@ export const importData = async (req, res) => {
         VALUES (?, ?, ?, ?, ?, ?, ?)
       `);
       const mappingIdMap = new Map();
+      const mappingSourceMap = new Map();
 
-      for (const m of importData.mappings) {
+      for (const m of importData.mappings || []) {
         const newProvId = providerIdMap.get(m.provider_id);
         const newUserId = userIdMap.get(m.user_id);
         const newUserCatId = m.user_category_id ? categoryIdMap.get(m.user_category_id) : null;
@@ -598,6 +608,13 @@ export const importData = async (req, res) => {
         if (newProvId && newUserId) {
            const info = insertMappingStmt.run(newProvId, newUserId, m.provider_category_id, m.provider_category_name, newUserCatId, m.auto_created, m.category_type || 'live');
            mappingIdMap.set(Number(m.id), info.lastInsertRowid);
+           mappingSourceMap.set(Number(m.id), {
+             ...m,
+             new_id: Number(info.lastInsertRowid),
+             new_provider_id: Number(newProvId),
+             new_user_id: Number(newUserId),
+             new_user_category_id: newUserCatId ? Number(newUserCatId) : null
+           });
         }
       }
 
@@ -606,7 +623,7 @@ export const importData = async (req, res) => {
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `);
 
-      for (const s of importData.sync_configs) {
+      for (const s of importData.sync_configs || []) {
         const newProvId = providerIdMap.get(s.provider_id);
         const newUserId = userIdMap.get(s.user_id);
 
@@ -633,43 +650,80 @@ export const importData = async (req, res) => {
         }
       }
 
-      const userAssignments = importData.channels.filter(c => c.type === 'user_assignment');
-      const insertUserChannel = db.prepare(`
-        INSERT INTO user_channels
-          (user_category_id, provider_channel_id, sort_order, custom_name, is_hidden,
-           mapping_id, granted_by_admin, authorization_revoked)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-        ON CONFLICT DO NOTHING
+      const userAssignments = (importData.channels || []).filter(c => c.type === 'user_assignment');
+      const getProviderChannel = db.prepare("SELECT provider_id, COALESCE(stream_type, 'live') AS stream_type FROM provider_channels WHERE id = ?");
+      const getMapping = db.prepare(`
+        SELECT id, provider_id, user_id, user_category_id, COALESCE(category_type, 'live') AS category_type
+        FROM category_mappings
+        WHERE id = ?
       `);
+      const getCategoryType = db.prepare("SELECT COALESCE(type, 'live') AS type FROM user_categories WHERE id = ?");
 
       for (const ua of userAssignments) {
         const newUserCatId = categoryIdMap.get(ua.user_category_id);
         const newProvChannelId = providerChannelIdMap.get(ua.provider_channel_id);
 
-        if (newUserCatId && newProvChannelId) {
-          const grant = resolveAssignmentGrant({
-            categoryOwnerId: categoryOwnerMap.get(newUserCatId),
-            providerOwnerId: providerChannelOwnerMap.get(newProvChannelId),
-            isAdmin: true,
-            allowExplicitAdminGrant: allowCrossOwner &&
-              Number(ua.granted_by_admin) === 1
-          });
-          insertUserChannel.run(
-            newUserCatId,
-            newProvChannelId,
-            ua.sort_order,
-            ua.custom_name || '',
-            Number(ua.is_hidden) === 1 ? 1 : 0,
-            Number(ua.mapping_id) > 0 ? (mappingIdMap.get(Number(ua.mapping_id)) || null) : null,
-            grant === 1 ? 1 : 0,
-            grant === null ? 1 : 0
-          );
-          stats.channels++;
+        if (!newUserCatId || !newProvChannelId) {
+          stats.channels_skipped++;
+          continue;
+        }
+
+        const grant = resolveAssignmentGrant({
+          categoryOwnerId: categoryOwnerMap.get(newUserCatId),
+          providerOwnerId: providerChannelOwnerMap.get(newProvChannelId),
+          isAdmin: true,
+          allowExplicitAdminGrant: allowCrossOwner && Number(ua.granted_by_admin) === 1
+        });
+        const requestedOrigin = trustedModernFormat
+          ? normalizeAssignmentOrigin(ua.assignment_origin, 'legacy')
+          : 'imported';
+        const sourceMappingId = Number(ua.mapping_id);
+        const sourceMapping = mappingSourceMap.get(sourceMappingId);
+        const remappedMappingId = requestedOrigin === 'mapping' ? mappingIdMap.get(sourceMappingId) : null;
+        const restoredChannel = getProviderChannel.get(newProvChannelId);
+        const restoredProviderId = restoredChannel?.provider_id;
+        const restoredCategoryType = getCategoryType.get(newUserCatId)?.type || 'live';
+        const sourceMappingType = sourceMapping?.category_type || 'live';
+        const typeValid = sourceMappingType === restoredCategoryType &&
+          (String(restoredChannel?.stream_type || 'live') === sourceMappingType ||
+            (String(restoredChannel?.stream_type || 'live') === 'live' && sourceMappingType === 'radio'));
+        const validMapping = requestedOrigin === 'mapping' && sourceMapping && remappedMappingId &&
+          Number(sourceMapping.new_user_category_id) === Number(newUserCatId) &&
+          Number(sourceMapping.new_provider_id) === Number(restoredProviderId) && typeValid;
+        const authorizationRevoked = grant === null ||
+          (Number(ua.authorization_revoked) === 1 && grant !== 1) ? 1 : 0;
+        const result = upsertMergedUserChannelAssignment(db, {
+          id: ua.id,
+          user_category_id: Number(newUserCatId),
+          provider_channel_id: Number(newProvChannelId),
+          sort_order: ua.sort_order,
+          custom_name: ua.custom_name || '',
+          is_hidden: Number(ua.is_hidden) === 1 ? 1 : 0,
+          assignment_origin: validMapping ? 'mapping' : (requestedOrigin === 'mapping' ? 'legacy' : requestedOrigin),
+          mapping_id: validMapping ? Number(remappedMappingId) : null,
+          granted_by_admin: grant === 1 ? 1 : 0,
+          authorization_revoked: authorizationRevoked,
+          grant_valid: grant === 1
+        }, {
+          preserveId: false,
+          mappingValidator: mappingId => {
+            const mapping = getMapping.get(Number(mappingId));
+            return Boolean(mapping && Number(mapping.user_category_id) === Number(newUserCatId) &&
+              Number(mapping.provider_id) === Number(restoredProviderId) &&
+              Number(mapping.user_id) === Number(categoryOwnerMap.get(newUserCatId)) &&
+              String(mapping.category_type || 'live') === String(restoredCategoryType));
+          }
+        });
+        if (result.skipped) stats.channels_skipped++;
+        else {
+          stats.channels += result.inserted;
+          stats.channels_merged += result.merged;
         }
       }
 
     })();
 
+    if (stats.channels_merged === 0) delete stats.channels_merged;
     res.json({success: true, stats});
 
   } catch (e) {

--- a/src/controllers/systemController.js
+++ b/src/controllers/systemController.js
@@ -651,7 +651,7 @@ export const importData = async (req, res) => {
       }
 
       const userAssignments = (importData.channels || []).filter(c => c.type === 'user_assignment');
-      const getProviderChannel = db.prepare("SELECT provider_id, COALESCE(stream_type, 'live') AS stream_type FROM provider_channels WHERE id = ?");
+      const getProviderChannel = db.prepare("SELECT provider_id, original_category_id, COALESCE(stream_type, 'live') AS stream_type FROM provider_channels WHERE id = ?");
       const getMapping = db.prepare(`
         SELECT id, provider_id, user_id, user_category_id, COALESCE(category_type, 'live') AS category_type
         FROM category_mappings
@@ -684,12 +684,15 @@ export const importData = async (req, res) => {
         const restoredProviderId = restoredChannel?.provider_id;
         const restoredCategoryType = getCategoryType.get(newUserCatId)?.type || 'live';
         const sourceMappingType = sourceMapping?.category_type || 'live';
+        const providerCategoryId = Number(restoredChannel?.original_category_id);
+        const mappingCategoryId = Number(sourceMapping?.provider_category_id);
         const typeValid = sourceMappingType === restoredCategoryType &&
           (String(restoredChannel?.stream_type || 'live') === sourceMappingType ||
             (String(restoredChannel?.stream_type || 'live') === 'live' && sourceMappingType === 'radio'));
         const validMapping = requestedOrigin === 'mapping' && sourceMapping && remappedMappingId &&
           Number(sourceMapping.new_user_category_id) === Number(newUserCatId) &&
-          Number(sourceMapping.new_provider_id) === Number(restoredProviderId) && typeValid;
+          Number(sourceMapping.new_provider_id) === Number(restoredProviderId) &&
+          Number.isFinite(providerCategoryId) && providerCategoryId === mappingCategoryId && typeValid;
         const authorizationRevoked = grant === null ||
           (Number(ua.authorization_revoked) === 1 && grant !== 1) ? 1 : 0;
         const result = upsertMergedUserChannelAssignment(db, {
@@ -711,6 +714,7 @@ export const importData = async (req, res) => {
             return Boolean(mapping && Number(mapping.user_category_id) === Number(newUserCatId) &&
               Number(mapping.provider_id) === Number(restoredProviderId) &&
               Number(mapping.user_id) === Number(categoryOwnerMap.get(newUserCatId)) &&
+              Number(mapping.provider_category_id) === providerCategoryId &&
               String(mapping.category_type || 'live') === String(restoredCategoryType));
           }
         });

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -351,11 +351,13 @@ export const createUser = async (req, res) => {
                     WHERE cat.user_id = ?
                 `).all(sourceUserId);
                 const getClonedMapping = db.prepare(`
-                    SELECT id, provider_id, user_id, user_category_id
+                    SELECT id, provider_id, user_id, user_category_id, provider_category_id,
+                           COALESCE(category_type, 'live') AS category_type
                     FROM category_mappings
                     WHERE id = ? AND user_id = ?
                 `);
-                const getClonedProvider = db.prepare('SELECT provider_id FROM provider_channels WHERE id = ?');
+                const getClonedProvider = db.prepare("SELECT provider_id, original_category_id, COALESCE(stream_type, 'live') AS stream_type FROM provider_channels WHERE id = ?");
+                const getClonedCategory = db.prepare("SELECT COALESCE(type, 'live') AS type FROM user_categories WHERE id = ? AND user_id = ?");
 
                 for (const uc of sourceUserChans) {
                     const newCatId = categoryMap[uc.user_category_id];
@@ -366,7 +368,9 @@ export const createUser = async (req, res) => {
                         const remappedMappingId = sourceOrigin === 'mapping'
                           ? mappingIdMap.get(Number(uc.mapping_id)) || null
                           : null;
-                        const providerId = getClonedProvider.get(newProvChanId)?.provider_id;
+                        const provider = getClonedProvider.get(newProvChanId);
+                        const providerId = provider?.provider_id;
+                        const categoryType = String(getClonedCategory.get(newCatId, newUserId)?.type || 'live');
                         upsertMergedUserChannelAssignment(db, {
                             user_category_id: Number(newCatId),
                             provider_channel_id: Number(newProvChanId),
@@ -382,7 +386,11 @@ export const createUser = async (req, res) => {
                             mappingValidator: mappingId => {
                                 const mapping = getClonedMapping.get(Number(mappingId), newUserId);
                                 return Boolean(mapping && Number(mapping.user_category_id) === Number(newCatId) &&
-                                    Number(mapping.provider_id) === Number(providerId));
+                                    Number(mapping.provider_id) === Number(providerId) &&
+                                    Number(mapping.provider_category_id) === Number(provider?.original_category_id) &&
+                                    String(mapping.category_type || 'live') === categoryType &&
+                                    (String(provider?.stream_type || 'live') === String(mapping.category_type || 'live') ||
+                                      String(provider?.stream_type || 'live') === 'live' && String(mapping.category_type || 'live') === 'radio'));
                             }
                         });
                     }

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -8,6 +8,10 @@ import crypto from 'crypto';
 import { BCRYPT_ROUNDS } from '../config/constants.js';
 import { providerSourceKey } from '../utils/helpers.js';
 import { normalizeContainerExtension } from '../utils/containerExtension.js';
+import {
+  normalizeAssignmentOrigin,
+  upsertMergedUserChannelAssignment
+} from '../services/userChannelAssignmentService.js';
 
 const getClonedProviderChannelName = (channel) => {
   if (typeof channel.name === 'string' && channel.name.trim()) return channel.name;
@@ -308,48 +312,79 @@ export const createUser = async (req, res) => {
                     INSERT OR IGNORE INTO category_mappings (provider_id, user_id, provider_category_id, provider_category_name, user_category_id, auto_created, category_type)
                     VALUES (?, ?, ?, ?, ?, ?, ?)
                 `);
+                const findMapping = db.prepare(`
+                    SELECT id FROM category_mappings
+                    WHERE provider_id = ? AND user_id = ? AND provider_category_id = ?
+                      AND COALESCE(category_type, 'live') = ?
+                    ORDER BY id DESC LIMIT 1
+                `);
                 const mappingIdMap = new Map();
 
                 for (const m of sourceMappings) {
                     if (providerMap[m.provider_id]) {
-                        const mappingInfo = insertMapping.run(
+                        const categoryId = m.user_category_id ? categoryMap[m.user_category_id] : null;
+                        const categoryType = m.category_type || 'live';
+                        insertMapping.run(
                             providerMap[m.provider_id],
                             newUserId,
                             m.provider_category_id,
                             m.provider_category_name,
-                            m.user_category_id ? categoryMap[m.user_category_id] : null,
+                            categoryId,
                             m.auto_created,
-                            m.category_type || 'live'
+                            categoryType
                         );
-                        mappingIdMap.set(Number(m.id), Number(mappingInfo.lastInsertRowid));
+                        const mapping = findMapping.get(
+                            providerMap[m.provider_id], newUserId, m.provider_category_id, categoryType
+                        );
+                        if (mapping) mappingIdMap.set(Number(m.id), Number(mapping.id));
                     }
                 }
 
                 // 6. Copy User Channels
-                // We need to iterate over source user's categories to find channels
-                // Or simply select all user_channels linked to source user's categories
-                const insertUserChan = db.prepare(`
-                    INSERT INTO user_channels
-                      (user_category_id, provider_channel_id, sort_order, custom_name, is_hidden,
-                       mapping_id, granted_by_admin, authorization_revoked)
-                    VALUES (?, ?, ?, ?, ?, ?, 0, 0)
-                    ON CONFLICT DO NOTHING
-                `);
-
                 // Fetch all user channels for source user categories
                 const sourceUserChans = db.prepare(`
-                    SELECT uc.user_category_id, uc.provider_channel_id, uc.sort_order, uc.custom_name, uc.is_hidden, uc.mapping_id
+                    SELECT uc.user_category_id, uc.provider_channel_id, uc.sort_order, uc.custom_name,
+                           uc.is_hidden, uc.mapping_id, uc.assignment_origin,
+                           uc.granted_by_admin, uc.authorization_revoked
                     FROM user_channels uc
                     JOIN user_categories cat ON uc.user_category_id = cat.id
                     WHERE cat.user_id = ?
                 `).all(sourceUserId);
+                const getClonedMapping = db.prepare(`
+                    SELECT id, provider_id, user_id, user_category_id
+                    FROM category_mappings
+                    WHERE id = ? AND user_id = ?
+                `);
+                const getClonedProvider = db.prepare('SELECT provider_id FROM provider_channels WHERE id = ?');
 
                 for (const uc of sourceUserChans) {
                     const newCatId = categoryMap[uc.user_category_id];
                     const newProvChanId = channelMap[uc.provider_channel_id];
 
                     if (newCatId && newProvChanId) {
-                        insertUserChan.run(newCatId, newProvChanId, uc.sort_order, uc.custom_name || '', uc.is_hidden || 0, mappingIdMap.get(Number(uc.mapping_id)) || null);
+                        const sourceOrigin = normalizeAssignmentOrigin(uc.assignment_origin, 'legacy');
+                        const remappedMappingId = sourceOrigin === 'mapping'
+                          ? mappingIdMap.get(Number(uc.mapping_id)) || null
+                          : null;
+                        const providerId = getClonedProvider.get(newProvChanId)?.provider_id;
+                        upsertMergedUserChannelAssignment(db, {
+                            user_category_id: Number(newCatId),
+                            provider_channel_id: Number(newProvChanId),
+                            sort_order: uc.sort_order,
+                            custom_name: uc.custom_name || '',
+                            is_hidden: Number(uc.is_hidden) === 1 ? 1 : 0,
+                            assignment_origin: remappedMappingId ? 'mapping' : (sourceOrigin === 'mapping' ? 'legacy' : sourceOrigin),
+                            mapping_id: remappedMappingId,
+                            granted_by_admin: 0,
+                            authorization_revoked: Number(uc.authorization_revoked) === 1 ? 1 : 0,
+                            grant_valid: false
+                        }, {
+                            mappingValidator: mappingId => {
+                                const mapping = getClonedMapping.get(Number(mappingId), newUserId);
+                                return Boolean(mapping && Number(mapping.user_category_id) === Number(newCatId) &&
+                                    Number(mapping.provider_id) === Number(providerId));
+                            }
+                        });
                     }
                 }
             }

--- a/src/database/db.js
+++ b/src/database/db.js
@@ -119,6 +119,8 @@ export function initDb(isPrimary) {
       sort_order INTEGER DEFAULT 0,
       custom_name TEXT DEFAULT '',
       is_hidden INTEGER DEFAULT 0,
+      assignment_origin TEXT NOT NULL DEFAULT 'legacy'
+        CHECK (assignment_origin IN ('legacy', 'manual', 'mapping', 'imported')),
       granted_by_admin INTEGER NOT NULL DEFAULT 0,
       authorization_revoked INTEGER NOT NULL DEFAULT 0,
       mapping_id INTEGER
@@ -321,6 +323,7 @@ export function initDb(isPrimary) {
             migrations.migrateUserChannelsCustomName(db);
             migrations.migrateUserChannelsIsHidden(db);
             migrations.migrateUserChannelMappingId(db);
+            migrations.migrateUserChannelAssignmentOrigin(db);
             migrations.migrateUserChannelAdminGrants(db);
             migrations.migrateSyncConfigAdminGrants(db);
             migrations.migrateUserNotes(db);
@@ -338,6 +341,9 @@ export function initDb(isPrimary) {
             }
             if (typeof migrations.migrateUserChannelMappingBackfillV1 === 'function') {
                 migrations.migrateUserChannelMappingBackfillV1(db);
+            }
+            if (typeof migrations.migrateUserChannelAssignmentProvenanceV2 === 'function') {
+                migrations.migrateUserChannelAssignmentProvenanceV2(db);
             }
             if (typeof migrations.migrateUserChannelDeduplicationV1 === 'function') {
                 migrations.migrateUserChannelDeduplicationV1(db);

--- a/src/database/migrations.js
+++ b/src/database/migrations.js
@@ -2,6 +2,7 @@ import { encrypt, decrypt } from '../utils/crypto.js';
 import bcrypt from 'bcrypt';
 import { BCRYPT_ROUNDS } from '../config/constants.js';
 import { clearSettingsCache } from '../utils/helpers.js';
+import { mergeAssignmentCandidates, rebindSeriesEpisodeAliases } from '../services/userChannelAssignmentService.js';
 
 export function migrateProvidersSchema(db) {
   try {
@@ -811,71 +812,61 @@ export function migrateUserChannelMappingId(db) {
   }
 }
 
+export function migrateUserChannelAssignmentOrigin(db) {
+  try {
+    const columns = db.prepare('PRAGMA table_info(user_channels)').all().map(column => column.name);
+    if (!columns.includes('assignment_origin')) {
+      db.exec(`
+        ALTER TABLE user_channels
+        ADD COLUMN assignment_origin TEXT NOT NULL DEFAULT 'legacy'
+          CHECK (assignment_origin IN ('legacy', 'manual', 'mapping', 'imported'))
+      `);
+      console.log('✅ DB Migration: assignment_origin column added to user_channels');
+    }
+    db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_user_channels_origin_mapping
+      ON user_channels(assignment_origin, mapping_id)
+    `);
+  } catch (e) {
+    console.error('User channel assignment origin migration error:', e);
+    throw e;
+  }
+}
+
 export function migrateUserChannelMappingBackfillV1(db) {
   const markerKey = 'user_channel_mapping_backfill_v1';
   const migrate = db.transaction(() => {
     if (db.prepare('SELECT value FROM settings WHERE key = ?').get(markerKey)?.value) {
       return { assigned: 0, ambiguous: 0, unmatched: 0, skipped: true };
     }
-
-    db.exec(`
-      CREATE INDEX IF NOT EXISTS idx_category_mappings_backfill
-        ON category_mappings(provider_id, user_id, user_category_id, provider_category_id, category_type);
-    `);
-
-    const rows = db.prepare(`
-      SELECT uc.id AS user_channel_id,
-             cm.id AS mapping_id
-      FROM user_channels uc
-      JOIN user_categories cat ON cat.id = uc.user_category_id
-      JOIN provider_channels pc ON pc.id = uc.provider_channel_id
-      LEFT JOIN category_mappings cm
-        ON cm.provider_id = pc.provider_id
-       AND cm.user_id = cat.user_id
-       AND cm.user_category_id = uc.user_category_id
-       AND cm.provider_category_id = pc.original_category_id
-       AND COALESCE(cm.category_type, 'live') = COALESCE(cat.type, 'live')
-       AND (
-         COALESCE(pc.stream_type, 'live') = COALESCE(cm.category_type, 'live')
-         OR (
-           COALESCE(pc.stream_type, 'live') = 'live'
-           AND COALESCE(cat.type, 'live') = 'radio'
-           AND COALESCE(cm.category_type, 'live') = 'radio'
-         )
-       )
-      WHERE uc.mapping_id IS NULL
-      ORDER BY uc.id, cm.id
-    `).all();
-
-    const candidates = new Map();
-    for (const row of rows) {
-      if (!candidates.has(row.user_channel_id)) candidates.set(row.user_channel_id, []);
-      if (row.mapping_id !== null && row.mapping_id !== undefined) {
-        candidates.get(row.user_channel_id).push(Number(row.mapping_id));
-      }
-    }
-
-    const assign = db.prepare('UPDATE user_channels SET mapping_id = ? WHERE id = ? AND mapping_id IS NULL');
-    let assigned = 0;
-    let ambiguous = 0;
-    let unmatched = 0;
-    for (const [userChannelId, mappingIds] of candidates) {
-      const uniqueIds = [...new Set(mappingIds)];
-      if (uniqueIds.length === 1) {
-        assigned += assign.run(uniqueIds[0], userChannelId).changes;
-      } else if (uniqueIds.length > 1) {
-        ambiguous++;
-      } else {
-        unmatched++;
-      }
-    }
-
     db.prepare('INSERT INTO settings (key, value) VALUES (?, ?)').run(
       markerKey,
-      JSON.stringify({ assigned, ambiguous, unmatched })
+      JSON.stringify({ assigned: 0, ambiguous: 0, unmatched: 0, mode: 'marker-only' })
     );
-    console.info(`✅ Mapping backfill: ${assigned} assigned, ${ambiguous} ambiguous, ${unmatched} unmatched`);
-    return { assigned, ambiguous, unmatched, skipped: false };
+    console.info('✅ Mapping backfill V1 recorded without inferring assignment ownership');
+    return { assigned: 0, ambiguous: 0, unmatched: 0, skipped: false };
+  });
+
+  return migrate();
+}
+
+export function migrateUserChannelAssignmentProvenanceV2(db) {
+  const markerKey = 'user_channel_assignment_provenance_v2';
+  const migrate = db.transaction(() => {
+    const marker = db.prepare('SELECT value FROM settings WHERE key = ?').get(markerKey);
+    if (marker?.value) return { repaired: 0, skipped: true };
+
+    const repaired = db.prepare(`
+      UPDATE user_channels
+      SET assignment_origin = 'legacy', mapping_id = NULL
+      WHERE assignment_origin != 'legacy' OR mapping_id IS NOT NULL
+    `).run().changes;
+    db.prepare('INSERT INTO settings (key, value) VALUES (?, ?)').run(
+      markerKey,
+      JSON.stringify({ repaired, mode: 'fail-safe-legacy' })
+    );
+    console.info(`✅ Assignment provenance V2: ${repaired} uncertain row(s) reset to legacy`);
+    return { repaired, skipped: false };
   });
 
   return migrate();
@@ -897,6 +888,8 @@ export function migrateUserChannelDeduplicationV1(db) {
       SELECT name FROM sqlite_master
       WHERE type = 'table' AND name = 'series_episode_aliases'
     `).get();
+    const hasOrigin = db.prepare('PRAGMA table_info(user_channels)').all()
+      .some(column => column.name === 'assignment_origin');
     const duplicateGroups = db.prepare(`
       SELECT user_category_id, provider_channel_id
       FROM user_channels
@@ -908,6 +901,7 @@ export function migrateUserChannelDeduplicationV1(db) {
     const selectRows = db.prepare(`
       SELECT id, user_category_id, provider_channel_id, sort_order, custom_name,
              is_hidden, mapping_id, granted_by_admin, authorization_revoked
+             ${hasOrigin ? ', assignment_origin' : ''}
       FROM user_channels
       WHERE user_category_id = ? AND provider_channel_id = ?
       ORDER BY id
@@ -918,63 +912,37 @@ export function migrateUserChannelDeduplicationV1(db) {
           custom_name = ?,
           granted_by_admin = ?,
           authorization_revoked = ?,
-          sort_order = ?
+          sort_order = ?${hasOrigin ? ', assignment_origin = ?, mapping_id = ?' : ''}
       WHERE id = ?
     `);
     const deleteAssignment = db.prepare('DELETE FROM user_channels WHERE id = ?');
-    let merged = 0;
+    let mergedCount = 0;
 
     for (const group of duplicateGroups) {
       const rows = selectRows.all(group.user_category_id, group.provider_channel_id);
-      const survivor = rows
-        .filter(row => row.mapping_id === null || row.mapping_id === undefined)
-        .sort((a, b) => Number(a.id) - Number(b.id))[0] || rows[0];
-      const losers = rows.filter(row => row.id !== survivor.id);
-      const customName = rows.find(row => String(row.custom_name || '').trim())?.custom_name || '';
-      const hasValidGrant = rows.some(row => Number(row.granted_by_admin) === 1 && Number(row.authorization_revoked) !== 1);
-      const hasGrant = rows.some(row => Number(row.granted_by_admin) === 1);
-      const revoked = hasValidGrant ? 0 : (rows.some(row => Number(row.authorization_revoked) === 1) ? 1 : 0);
-      const sortOrder = Math.min(...rows.map(row => Number(row.sort_order) || 0));
-
-      if (aliasTable) {
-        const selectAliases = db.prepare(`
-          SELECT id, source_key, series_remote_id, remote_episode_id
-          FROM series_episode_aliases
-          WHERE user_channel_id = ?
-          ORDER BY id
-        `);
-        const findAlias = db.prepare(`
-          SELECT id FROM series_episode_aliases
-          WHERE user_channel_id = ? AND source_key = ?
-            AND series_remote_id = ? AND remote_episode_id = ?
-        `);
-        const rebindAlias = db.prepare('UPDATE series_episode_aliases SET user_channel_id = ? WHERE id = ?');
-        const removeAlias = db.prepare('DELETE FROM series_episode_aliases WHERE id = ?');
-        for (const loser of losers) {
-          for (const alias of selectAliases.all(loser.id)) {
-            const existing = findAlias.get(
-              survivor.id,
-              alias.source_key,
-              alias.series_remote_id,
-              alias.remote_episode_id
-            );
-            if (existing) removeAlias.run(alias.id);
-            else rebindAlias.run(survivor.id, alias.id);
-          }
-        }
-      }
+      const normalized = rows.map(row => ({
+        ...row,
+        assignment_origin: hasOrigin
+          ? row.assignment_origin
+          : (row.mapping_id === null || row.mapping_id === undefined ? 'legacy' : 'mapping')
+      }));
+      const mergedRow = mergeAssignmentCandidates(normalized);
+      const survivor = normalized.find(row => Number(row.id) === Number(mergedRow.id)) || normalized[0];
+      const losers = normalized.filter(row => Number(row.id) !== Number(survivor.id));
 
       updateSurvivor.run(
-        rows.some(row => Number(row.is_hidden) === 1) ? 1 : 0,
-        customName,
-        hasValidGrant || hasGrant ? 1 : 0,
-        revoked,
-        sortOrder,
+        mergedRow.is_hidden,
+        mergedRow.custom_name || '',
+        mergedRow.granted_by_admin,
+        mergedRow.authorization_revoked,
+        mergedRow.sort_order,
+        ...(hasOrigin ? [mergedRow.assignment_origin, mergedRow.mapping_id] : []),
         survivor.id
       );
       for (const loser of losers) {
+        if (aliasTable) rebindSeriesEpisodeAliases(db, survivor.id, loser.id);
         deleteAssignment.run(loser.id);
-        merged++;
+        mergedCount++;
       }
     }
 
@@ -984,10 +952,10 @@ export function migrateUserChannelDeduplicationV1(db) {
     `);
     db.prepare('INSERT INTO settings (key, value) VALUES (?, ?)').run(
       markerKey,
-      JSON.stringify({ merged })
+      JSON.stringify({ merged: mergedCount })
     );
-    console.info(`✅ User channel deduplication: ${merged} duplicate assignment(s) merged`);
-    return { merged, skipped: false };
+    console.info(`✅ User channel deduplication: ${mergedCount} duplicate assignment(s) merged`);
+    return { merged: mergedCount, skipped: false };
   });
 
   return migrate();

--- a/src/database/migrations.js
+++ b/src/database/migrations.js
@@ -912,7 +912,7 @@ export function migrateUserChannelDeduplicationV1(db) {
           custom_name = ?,
           granted_by_admin = ?,
           authorization_revoked = ?,
-          sort_order = ?${hasOrigin ? ', assignment_origin = ?, mapping_id = ?' : ''}
+          sort_order = ?${hasOrigin ? ', assignment_origin = ?, mapping_id = ?' : ', mapping_id = NULL'}
       WHERE id = ?
     `);
     const deleteAssignment = db.prepare('DELETE FROM user_channels WHERE id = ?');
@@ -922,9 +922,7 @@ export function migrateUserChannelDeduplicationV1(db) {
       const rows = selectRows.all(group.user_category_id, group.provider_channel_id);
       const normalized = rows.map(row => ({
         ...row,
-        assignment_origin: hasOrigin
-          ? row.assignment_origin
-          : (row.mapping_id === null || row.mapping_id === undefined ? 'legacy' : 'mapping')
+        assignment_origin: hasOrigin ? row.assignment_origin : 'legacy'
       }));
       const mergedRow = mergeAssignmentCandidates(normalized);
       const survivor = normalized.find(row => Number(row.id) === Number(mergedRow.id)) || normalized[0];

--- a/src/services/syncService.js
+++ b/src/services/syncService.js
@@ -7,6 +7,7 @@ import { isAdultCategory, providerSourceKey } from '../utils/helpers.js';
 import { normalizeContainerExtension } from '../utils/containerExtension.js';
 import { parseM3uStream } from '../utils/playlistParser.js';
 import { prePopulateProviderIconCache } from './logoResolver.js';
+import { isTrustedMappingAssignment } from './userChannelAssignmentService.js';
 
 /**
  * Delete one provider channel without violating the dependent foreign keys.
@@ -443,8 +444,8 @@ export async function performSync(providerId, userId, options = {}) {
     // Prepare statement unconditionally to avoid potential undefined issues
     const insertUserChannel = db.prepare(`
       INSERT INTO user_channels
-        (user_category_id, provider_channel_id, sort_order, mapping_id, granted_by_admin, authorization_revoked)
-      VALUES (?, ?, ?, ?, ?, 0)
+        (user_category_id, provider_channel_id, sort_order, assignment_origin, mapping_id, granted_by_admin, authorization_revoked)
+      VALUES (?, ?, ?, 'mapping', ?, ?, 0)
       ON CONFLICT DO NOTHING
     `);
     const authorizeExistingAssignment = db.prepare(`
@@ -452,13 +453,20 @@ export async function performSync(providerId, userId, options = {}) {
       SET granted_by_admin = ?, authorization_revoked = 0
       WHERE id = ?
     `);
-    const updateAssignmentMapping = db.prepare('UPDATE user_channels SET mapping_id = ? WHERE id = ?');
-    const deleteMappedAssignment = db.prepare('DELETE FROM user_channels WHERE id = ? AND mapping_id = ?');
+    const updateAssignmentMapping = db.prepare(`
+      UPDATE user_channels
+      SET mapping_id = ?, assignment_origin = 'mapping'
+      WHERE id = ? AND assignment_origin = 'mapping'
+    `);
+    const deleteMappedAssignment = db.prepare(`
+      DELETE FROM user_channels
+      WHERE id = ? AND mapping_id = ? AND assignment_origin = 'mapping'
+    `);
 
     if (config && config.auto_add_channels) {
       const existingAssignmentsRows = db.prepare(`
         SELECT uc.id, uc.user_category_id, uc.provider_channel_id,
-               uc.mapping_id, uc.granted_by_admin, uc.authorization_revoked
+               uc.mapping_id, uc.assignment_origin, uc.granted_by_admin, uc.authorization_revoked
         FROM user_channels uc
         JOIN provider_channels pc ON pc.id = uc.provider_channel_id
         WHERE pc.provider_id = ?
@@ -698,7 +706,9 @@ export async function performSync(providerId, userId, options = {}) {
                   .map(Number));
 
                 for (const [assignmentKey, assignment] of existingAssignments) {
-                  if (Number(assignment.provider_channel_id) !== Number(existingId) || !oldMappingIds.has(Number(assignment.mapping_id))) continue;
+                  if (Number(assignment.provider_channel_id) !== Number(existingId) ||
+                      !oldMappingIds.has(Number(assignment.mapping_id)) ||
+                      !isTrustedMappingAssignment(assignment, assignment.mapping_id)) continue;
                   deleteMappedAssignment.run(assignment.id, assignment.mapping_id);
                   existingAssignments.delete(assignmentKey);
                   console.debug(`  🗑️ Removed mapped assignment for moved channel "${newName}"`);
@@ -779,26 +789,21 @@ export async function performSync(providerId, userId, options = {}) {
                 const newSortOrder = currentMax + 1;
 
                 const assignmentInfo = insertUserChannel.run(userCatId, provChannelId, newSortOrder, mappingId, assignmentGrant);
-                const assignmentId = assignmentInfo.changes === 1
-                  ? Number(assignmentInfo.lastInsertRowid)
-                  : Number(db.prepare(`
-                    SELECT id FROM user_channels
-                    WHERE user_category_id = ? AND provider_channel_id = ?
-                  `).get(userCatId, provChannelId)?.id || 0);
+                const resolvedAssignment = db.prepare(`
+                  SELECT id, user_category_id, provider_channel_id, mapping_id,
+                         assignment_origin, granted_by_admin, authorization_revoked
+                  FROM user_channels
+                  WHERE user_category_id = ? AND provider_channel_id = ?
+                `).get(userCatId, provChannelId);
+                const assignmentId = Number(resolvedAssignment?.id || 0);
                 if (!assignmentId) throw new Error('Unable to resolve synchronized user-channel assignment');
 
                 // Update in-memory state
-                existingAssignments.set(assignmentKey, {
-                  id: assignmentId,
-                  user_category_id: userCatId,
-                  provider_channel_id: Number(provChannelId),
-                  mapping_id: mappingId,
-                  granted_by_admin: assignmentGrant,
-                  authorization_revoked: 0
-                });
-                maxSortMap.set(userCatId, newSortOrder);
+                existingAssignments.set(assignmentKey, resolvedAssignment);
+                if (assignmentInfo.changes === 1) maxSortMap.set(userCatId, newSortOrder);
               } else {
-                if (existingAssignment.mapping_id && Number(existingAssignment.mapping_id) !== mappingId) {
+                if (isTrustedMappingAssignment(existingAssignment, existingAssignment.mapping_id) &&
+                    Number(existingAssignment.mapping_id) !== mappingId) {
                   updateAssignmentMapping.run(mappingId, existingAssignment.id);
                   existingAssignment.mapping_id = mappingId;
                 }

--- a/src/services/userChannelAssignmentService.js
+++ b/src/services/userChannelAssignmentService.js
@@ -28,14 +28,23 @@ export function mergeAssignmentCandidates(candidates, { mappingValidator } = {})
     if (Number.isInteger(aId) && Number.isInteger(bId) && aId !== bId) return aId - bId;
     return a._source_index - b._source_index;
   });
-  const preferred = ordered[0];
+  let preferred = ordered[0];
   let assignmentOrigin = preferred.assignment_origin;
   let mappingId = assignmentOrigin === 'mapping' ? Number(preferred.mapping_id) || null : null;
-  if (assignmentOrigin === 'mapping' && (
-    !mappingId || preferred.mapping_valid === false || mappingValidator && !mappingValidator(mappingId, preferred)
-  )) {
-    assignmentOrigin = 'legacy';
-    mappingId = null;
+  if (assignmentOrigin === 'mapping') {
+    const validMapping = ordered.find(row => {
+      if (row.assignment_origin !== 'mapping') return false;
+      const candidateMappingId = Number(row.mapping_id) || null;
+      return candidateMappingId && row.mapping_valid !== false &&
+        (!mappingValidator || mappingValidator(candidateMappingId, row));
+    });
+    if (validMapping) {
+      preferred = validMapping;
+      mappingId = Number(validMapping.mapping_id) || null;
+    } else {
+      assignmentOrigin = 'legacy';
+      mappingId = null;
+    }
   }
 
   const customName = ordered.find(row => String(row.custom_name || '').trim())?.custom_name || '';

--- a/src/services/userChannelAssignmentService.js
+++ b/src/services/userChannelAssignmentService.js
@@ -1,0 +1,200 @@
+export const ASSIGNMENT_ORIGINS = Object.freeze(['legacy', 'manual', 'mapping', 'imported']);
+
+const ORIGIN_PRIORITY = Object.freeze({ manual: 0, legacy: 1, imported: 1, mapping: 2 });
+
+export function normalizeAssignmentOrigin(value, fallback = 'legacy') {
+  const origin = String(value || '').toLowerCase();
+  return ASSIGNMENT_ORIGINS.includes(origin) ? origin : fallback;
+}
+
+export function isTrustedMappingAssignment(row, mappingId) {
+  return normalizeAssignmentOrigin(row?.assignment_origin) === 'mapping' &&
+    Number(row?.mapping_id) === Number(mappingId) && Number(mappingId) > 0;
+}
+
+export function mergeAssignmentCandidates(candidates, { mappingValidator } = {}) {
+  const rows = candidates.map((candidate, index) => ({
+    ...candidate,
+    assignment_origin: normalizeAssignmentOrigin(candidate.assignment_origin),
+    _source_index: index
+  }));
+  if (rows.length === 0) return null;
+
+  const ordered = [...rows].sort((a, b) => {
+    const priority = ORIGIN_PRIORITY[a.assignment_origin] - ORIGIN_PRIORITY[b.assignment_origin];
+    if (priority !== 0) return priority;
+    const aId = Number(a.id);
+    const bId = Number(b.id);
+    if (Number.isInteger(aId) && Number.isInteger(bId) && aId !== bId) return aId - bId;
+    return a._source_index - b._source_index;
+  });
+  const preferred = ordered[0];
+  let assignmentOrigin = preferred.assignment_origin;
+  let mappingId = assignmentOrigin === 'mapping' ? Number(preferred.mapping_id) || null : null;
+  if (assignmentOrigin === 'mapping' && (
+    !mappingId || preferred.mapping_valid === false || mappingValidator && !mappingValidator(mappingId, preferred)
+  )) {
+    assignmentOrigin = 'legacy';
+    mappingId = null;
+  }
+
+  const customName = ordered.find(row => String(row.custom_name || '').trim())?.custom_name || '';
+  const sortOrders = rows
+    .map(row => Number(row.sort_order))
+    .filter(Number.isFinite);
+  const validGrant = rows.some(row => (
+    row.grant_valid === true ||
+    row.grant_valid === undefined && Number(row.granted_by_admin) === 1 && Number(row.authorization_revoked) !== 1
+  ));
+  const requestedGrant = rows.some(row => Number(row.granted_by_admin) === 1);
+
+  return {
+    ...preferred,
+    assignment_origin: assignmentOrigin,
+    mapping_id: mappingId,
+    is_hidden: rows.some(row => Number(row.is_hidden) === 1) ? 1 : 0,
+    custom_name: customName,
+    sort_order: sortOrders.length ? Math.min(...sortOrders) : 0,
+    granted_by_admin: validGrant ? 1 : (requestedGrant ? 1 : 0),
+    authorization_revoked: validGrant ? 0 : (rows.some(row => Number(row.authorization_revoked) === 1) ? 1 : 0)
+  };
+}
+
+export function rebindSeriesEpisodeAliases(database, survivorId, loserId) {
+  const aliasTable = database.prepare(`
+    SELECT name FROM sqlite_master
+    WHERE type = 'table' AND name = 'series_episode_aliases'
+  `).get();
+  if (!aliasTable) return 0;
+
+  const aliases = database.prepare(`
+    SELECT id, source_key, series_remote_id, remote_episode_id
+    FROM series_episode_aliases
+    WHERE user_channel_id = ?
+    ORDER BY id
+  `).all(loserId);
+  const findAlias = database.prepare(`
+    SELECT id FROM series_episode_aliases
+    WHERE user_channel_id = ? AND source_key = ?
+      AND series_remote_id = ? AND remote_episode_id = ?
+  `);
+  const updateAlias = database.prepare('UPDATE series_episode_aliases SET user_channel_id = ? WHERE id = ?');
+  const deleteAlias = database.prepare('DELETE FROM series_episode_aliases WHERE id = ?');
+  let removed = 0;
+  for (const alias of aliases) {
+    const existing = findAlias.get(
+      survivorId,
+      alias.source_key,
+      alias.series_remote_id,
+      alias.remote_episode_id
+    );
+    if (existing) {
+      deleteAlias.run(alias.id);
+      removed++;
+    } else {
+      updateAlias.run(survivorId, alias.id);
+    }
+  }
+  return removed;
+}
+
+function assignmentValues(row) {
+  return [
+    row.user_category_id,
+    row.provider_channel_id,
+    row.sort_order,
+    row.custom_name || '',
+    Number(row.is_hidden) === 1 ? 1 : 0,
+    row.assignment_origin,
+    row.mapping_id,
+    Number(row.granted_by_admin) === 1 ? 1 : 0,
+    Number(row.authorization_revoked) === 1 ? 1 : 0
+  ];
+}
+
+export function upsertMergedUserChannelAssignment(database, candidate, {
+  preserveId = false,
+  mappingValidator
+} = {}) {
+  const categoryId = Number(candidate?.user_category_id);
+  const providerChannelId = Number(candidate?.provider_channel_id);
+  if (!Number.isInteger(categoryId) || categoryId <= 0 ||
+      !Number.isInteger(providerChannelId) || providerChannelId <= 0) {
+    return { inserted: 0, merged: 0, skipped: 1, hidden: 0, authorization_revoked: 0 };
+  }
+
+  const existing = database.prepare(`
+    SELECT * FROM user_channels
+    WHERE user_category_id = ? AND provider_channel_id = ?
+    ORDER BY id
+  `).all(categoryId, providerChannelId);
+  const merged = mergeAssignmentCandidates([...existing, candidate], { mappingValidator });
+  const candidateId = Number(candidate.id);
+  const candidateAlreadyExists = existing.some(row => Number(row.id) === candidateId && candidateId > 0);
+
+  if (existing.length === 0) {
+    const idIsAvailable = preserveId && Number.isInteger(candidateId) && candidateId > 0 &&
+      !database.prepare('SELECT id FROM user_channels WHERE id = ?').get(candidateId);
+    const statement = idIsAvailable
+      ? database.prepare(`
+          INSERT INTO user_channels
+            (id, user_category_id, provider_channel_id, sort_order, custom_name, is_hidden,
+             assignment_origin, mapping_id, granted_by_admin, authorization_revoked)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `)
+      : database.prepare(`
+          INSERT INTO user_channels
+            (user_category_id, provider_channel_id, sort_order, custom_name, is_hidden,
+             assignment_origin, mapping_id, granted_by_admin, authorization_revoked)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `);
+    const info = idIsAvailable
+      ? statement.run(candidateId, ...assignmentValues(merged))
+      : statement.run(...assignmentValues(merged));
+    return {
+      inserted: 1,
+      merged: 0,
+      skipped: 0,
+      hidden: merged.is_hidden,
+      authorization_revoked: merged.authorization_revoked,
+      id: Number(idIsAvailable ? candidateId : info.lastInsertRowid),
+      assignment_origin: merged.assignment_origin,
+      mapping_id: merged.mapping_id
+    };
+  }
+
+  const survivorId = Number(merged.id);
+  const survivor = existing.find(row => Number(row.id) === survivorId) || existing[0];
+  const loserRows = existing.filter(row => Number(row.id) !== Number(survivor.id));
+  const update = database.prepare(`
+    UPDATE user_channels
+    SET sort_order = ?, custom_name = ?, is_hidden = ?, assignment_origin = ?,
+        mapping_id = ?, granted_by_admin = ?, authorization_revoked = ?
+    WHERE id = ?
+  `);
+  update.run(
+    merged.sort_order,
+    merged.custom_name || '',
+    merged.is_hidden,
+    merged.assignment_origin,
+    merged.mapping_id,
+    merged.granted_by_admin,
+    merged.authorization_revoked,
+    survivor.id
+  );
+  for (const loser of loserRows) {
+    rebindSeriesEpisodeAliases(database, survivor.id, loser.id);
+    database.prepare('DELETE FROM user_channels WHERE id = ?').run(loser.id);
+  }
+
+  return {
+    inserted: 0,
+    merged: loserRows.length + (candidateAlreadyExists ? 0 : 1),
+    skipped: 0,
+    hidden: merged.is_hidden,
+    authorization_revoked: merged.authorization_revoked,
+    id: survivor.id,
+    assignment_origin: merged.assignment_origin,
+    mapping_id: merged.mapping_id
+  };
+}

--- a/tests/controllers/backup_restore_authorization.test.js
+++ b/tests/controllers/backup_restore_authorization.test.js
@@ -52,9 +52,9 @@ describe('user backup restore authorization', () => {
     fs.rmSync(TEST_DB_DIR, { recursive: true, force: true });
   });
 
-  const addProviderChannel = (ownerId) => {
+  const addProviderChannel = (ownerId, originalCategoryId = 0) => {
     const providerId = db.prepare("INSERT INTO providers (name, url, username, password, user_id) VALUES ('P', 'http://provider.example', 'u', 'p', ?)").run(ownerId).lastInsertRowid;
-    return db.prepare("INSERT INTO provider_channels (provider_id, remote_stream_id, name, stream_type) VALUES (?, 10, 'Show', 'series')").run(providerId).lastInsertRowid;
+    return db.prepare("INSERT INTO provider_channels (provider_id, remote_stream_id, name, original_category_id, stream_type) VALUES (?, 10, 'Show', ?, 'series')").run(providerId, originalCategoryId).lastInsertRowid;
   };
 
   const addBackup = (data) => db.prepare(`
@@ -119,6 +119,22 @@ describe('user backup restore authorization', () => {
     });
     expect(db.prepare('SELECT id FROM authorized_user_channels WHERE id = 200').get()).toBeUndefined();
     expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ channels_hidden: 1 }));
+  });
+
+  it('keeps a source revocation for a same-owner restore without a valid admin grant', () => {
+    const providerChannelId = addProviderChannel(1);
+    const backupId = addBackup(backupData(1, {
+      provider_channel_id: providerChannelId,
+      granted_by_admin: 0,
+      authorization_revoked: 1,
+    }));
+
+    restore(backupId);
+
+    expect(db.prepare('SELECT granted_by_admin, authorization_revoked FROM user_channels WHERE id = 200').get()).toEqual({
+      granted_by_admin: 0,
+      authorization_revoked: 1,
+    });
   });
 
   it('cannot turn crafted cross-owner backup data into an admin grant', () => {
@@ -231,7 +247,7 @@ describe('user backup restore authorization', () => {
   });
 
   it('retains a validated modern mapping assignment', () => {
-    const providerChannelId = addProviderChannel(1);
+    const providerChannelId = addProviderChannel(1, 10);
     db.prepare("INSERT INTO user_categories (id, user_id, name, type) VALUES (100, 1, 'Series', 'series')").run();
     const mappingId = db.prepare(`
       INSERT INTO category_mappings
@@ -247,7 +263,7 @@ describe('user backup restore authorization', () => {
         provider_channel_id: providerChannelId,
         assignment_origin: 'mapping', mapping_id: mappingId,
       }),
-      categoryMappings: [{ id: mappingId, user_category_id: 100, category_type: 'series' }],
+      categoryMappings: [{ id: mappingId, user_category_id: 100, provider_category_id: 10, category_type: 'series' }],
     };
     const backupId = addBackup(data);
 

--- a/tests/controllers/backup_restore_authorization.test.js
+++ b/tests/controllers/backup_restore_authorization.test.js
@@ -82,6 +82,19 @@ describe('user backup restore authorization', () => {
     expect(clearChannelsCache).toHaveBeenCalledWith(1);
   });
 
+  it('writes a versioned provenance-aware backup payload', () => {
+    db.prepare("INSERT INTO user_categories (id, user_id, name, type) VALUES (100, 1, 'Series', 'series')").run();
+    const result = response();
+    createBackup(
+      { params: { userId: '1' }, user: { id: 1, is_admin: false }, body: { name: 'versioned' } },
+      result
+    );
+    const backupId = result.json.mock.calls[0][0].id;
+    const payload = JSON.parse(db.prepare('SELECT data FROM user_backups WHERE id = ?').get(backupId).data);
+    expect(payload.format_version).toBe(2);
+    expect(payload.assignment_provenance_version).toBe(1);
+  });
+
   it('does not resurrect a revoked historical admin grant for a normal user', () => {
     const providerChannelId = addProviderChannel(2);
     db.prepare("INSERT INTO user_categories (id, user_id, name, type) VALUES (100, 1, 'Series', 'series')").run();
@@ -162,6 +175,86 @@ describe('user backup restore authorization', () => {
       is_hidden: 0,
       granted_by_admin: 0,
       authorization_revoked: 0,
+    });
+  });
+
+  it('merges duplicate modern assignments without losing hidden state or names', () => {
+    const providerChannelId = addProviderChannel(1);
+    db.prepare("INSERT INTO user_categories (id, user_id, name, type) VALUES (100, 1, 'Series', 'series')").run();
+    const mappingId = db.prepare(`
+      INSERT INTO category_mappings
+        (provider_id, user_id, provider_category_id, provider_category_name, user_category_id, category_type)
+      SELECT p.id, 1, 10, 'Series', 100, 'series'
+      FROM provider_channels pc JOIN providers p ON p.id = pc.provider_id
+      WHERE pc.id = ?
+    `).run(providerChannelId).lastInsertRowid;
+    const data = {
+      format_version: 2,
+      assignment_provenance_version: 1,
+      ...backupData(1, {
+        provider_channel_id: providerChannelId,
+        assignment_origin: 'manual',
+        mapping_id: null,
+        sort_order: 9,
+        custom_name: '',
+        is_hidden: 0,
+      }),
+    };
+    data.categoryMappings = [{
+      id: mappingId, user_category_id: 100, provider_category_id: 10,
+      category_type: 'series',
+    }];
+    data.userChannels.push({
+      id: 201, user_category_id: 100, provider_channel_id: providerChannelId,
+      assignment_origin: 'mapping', mapping_id: mappingId,
+      sort_order: 2, custom_name: 'Mapped name', is_hidden: 1,
+    });
+    const backupId = addBackup(data);
+
+    const res = restore(backupId);
+
+    expect(db.prepare(`
+      SELECT id, assignment_origin, mapping_id, sort_order, custom_name, is_hidden
+      FROM user_channels
+    `).all()).toEqual([{
+      id: 200,
+      assignment_origin: 'manual',
+      mapping_id: null,
+      sort_order: 2,
+      custom_name: 'Mapped name',
+      is_hidden: 1,
+    }]);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true, channels_restored: 0, channels_hidden: 1, channels_skipped: 0,
+      channels_merged: 1,
+    });
+  });
+
+  it('retains a validated modern mapping assignment', () => {
+    const providerChannelId = addProviderChannel(1);
+    db.prepare("INSERT INTO user_categories (id, user_id, name, type) VALUES (100, 1, 'Series', 'series')").run();
+    const mappingId = db.prepare(`
+      INSERT INTO category_mappings
+        (provider_id, user_id, provider_category_id, provider_category_name, user_category_id, category_type)
+      SELECT p.id, 1, 10, 'Series', 100, 'series'
+      FROM provider_channels pc JOIN providers p ON p.id = pc.provider_id
+      WHERE pc.id = ?
+    `).run(providerChannelId).lastInsertRowid;
+    const data = {
+      format_version: 2,
+      assignment_provenance_version: 1,
+      ...backupData(1, {
+        provider_channel_id: providerChannelId,
+        assignment_origin: 'mapping', mapping_id: mappingId,
+      }),
+      categoryMappings: [{ id: mappingId, user_category_id: 100, category_type: 'series' }],
+    };
+    const backupId = addBackup(data);
+
+    restore(backupId);
+
+    expect(db.prepare('SELECT assignment_origin, mapping_id FROM user_channels').get()).toEqual({
+      assignment_origin: 'mapping', mapping_id: mappingId,
     });
   });
 

--- a/tests/controllers/channelController.test.js
+++ b/tests/controllers/channelController.test.js
@@ -270,6 +270,42 @@ describe('Channel Controller - createUserCategory', () => {
         expect(db.prepare('SELECT id FROM authorized_user_channels WHERE id = ?').get(created.id).id).toBe(created.id);
     });
 
+    it('transfers a mapped assignment to manual ownership when re-added', () => {
+        const categoryId = db.prepare("INSERT INTO user_categories (user_id, name, type) VALUES (2, 'Mapped', 'live')").run().lastInsertRowid;
+        const providerId = db.prepare("INSERT INTO providers (name, url, username, password, user_id) VALUES ('Mapped Provider', 'http://provider.test', 'u', 'p', 2)").run().lastInsertRowid;
+        const channelId = db.prepare("INSERT INTO provider_channels (provider_id, remote_stream_id, name, stream_type) VALUES (?, 100, 'Mapped Channel', 'live')").run(providerId).lastInsertRowid;
+        const mappingId = db.prepare(`
+          INSERT INTO category_mappings
+            (provider_id, user_id, provider_category_id, provider_category_name, user_category_id, category_type)
+          VALUES (?, 2, 100, 'Mapped', ?, 'live')
+        `).run(providerId, categoryId).lastInsertRowid;
+        const assignmentId = db.prepare(`
+          INSERT INTO user_channels
+            (user_category_id, provider_channel_id, is_hidden, assignment_origin, mapping_id)
+          VALUES (?, ?, 1, 'mapping', ?)
+        `).run(categoryId, channelId, mappingId).lastInsertRowid;
+
+        const addRes = { json: vi.fn(), status: vi.fn().mockReturnThis() };
+        channelController.addUserChannel({
+            params: { catId: String(categoryId) },
+            body: { provider_channel_id: channelId },
+            user: { id: 2, is_admin: false }
+        }, addRes);
+
+        expect(addRes.json).toHaveBeenCalledWith({ id: assignmentId });
+        expect(db.prepare('SELECT assignment_origin, mapping_id, is_hidden FROM user_channels WHERE id = ?').get(assignmentId))
+          .toEqual({ assignment_origin: 'manual', mapping_id: null, is_hidden: 0 });
+
+        const unmapRes = { json: vi.fn(), status: vi.fn().mockReturnThis() };
+        channelController.updateCategoryMapping({
+            params: { id: String(mappingId) }, body: { user_category_id: null },
+            user: { id: 2, is_admin: false }
+        }, unmapRes);
+
+        expect(db.prepare('SELECT id, assignment_origin, mapping_id FROM user_channels WHERE id = ?').get(assignmentId))
+          .toEqual({ id: assignmentId, assignment_origin: 'manual', mapping_id: null });
+    });
+
     it('should return 404 for an unknown provider channel', () => {
         const categoryId = db.prepare("INSERT INTO user_categories (user_id, name) VALUES (2, 'My Category')").run().lastInsertRowid;
         const req = {
@@ -722,8 +758,8 @@ describe('Channel Controller - createUserCategory', () => {
         const channel = db.prepare("INSERT INTO provider_channels (provider_id, remote_stream_id, name, stream_type) VALUES (?, 77, 'Series', 'live')").run(provider).lastInsertRowid;
         const assignment = db.prepare(`
           INSERT INTO user_channels
-            (user_category_id, provider_channel_id, sort_order, custom_name, is_hidden, mapping_id)
-          VALUES (?, ?, 4, 'Custom', 1, ?)
+            (user_category_id, provider_channel_id, sort_order, custom_name, is_hidden, assignment_origin, mapping_id)
+          VALUES (?, ?, 4, 'Custom', 1, 'mapping', ?)
         `).run(source, channel, mapping).lastInsertRowid;
         const alias = db.prepare(`
           INSERT INTO series_episode_aliases
@@ -763,8 +799,8 @@ describe('Channel Controller - createUserCategory', () => {
         `).run(target, channel).lastInsertRowid;
         const mapped = db.prepare(`
           INSERT INTO user_channels
-            (user_category_id, provider_channel_id, sort_order, custom_name, mapping_id)
-          VALUES (?, ?, 9, 'Mapped name', ?)
+            (user_category_id, provider_channel_id, sort_order, custom_name, assignment_origin, mapping_id)
+          VALUES (?, ?, 9, 'Mapped name', 'mapping', ?)
         `).run(source, channel, mapping).lastInsertRowid;
         const alias = db.prepare(`
           INSERT INTO series_episode_aliases
@@ -800,8 +836,8 @@ describe('Channel Controller - createUserCategory', () => {
         const channel = db.prepare("INSERT INTO provider_channels (provider_id, remote_stream_id, name, stream_type) VALUES (?, 99, 'Channel', 'live')").run(provider).lastInsertRowid;
         const owned = db.prepare(`
           INSERT INTO user_channels
-            (user_category_id, provider_channel_id, mapping_id, granted_by_admin, authorization_revoked)
-          VALUES (?, ?, ?, 1, 0)
+            (user_category_id, provider_channel_id, assignment_origin, mapping_id, granted_by_admin, authorization_revoked)
+          VALUES (?, ?, 'mapping', ?, 1, 0)
         `).run(category, channel, mapping).lastInsertRowid;
         const manual = db.prepare('INSERT INTO user_channels (user_category_id, provider_channel_id) VALUES (?, ?)').run(manualCategory, channel).lastInsertRowid;
         const res = response();

--- a/tests/export_regression.test.js
+++ b/tests/export_regression.test.js
@@ -89,6 +89,9 @@ describe('Export/Import Regression Tests', () => {
 
         expect(exportedBuffer).not.toBeNull();
         fs.writeFileSync(tempFilePath, exportedBuffer);
+        const exportedFormat = JSON.parse(zlib.gunzipSync(decryptWithPassword(exportedBuffer, TEST_EXPORT_PASSWORD)).toString('utf8'));
+        expect(exportedFormat.version).toBe(2);
+        expect(exportedFormat.assignment_provenance_version).toBe(1);
 
         // 4. Import Data (Clear DB first)
         db.prepare('PRAGMA foreign_keys = OFF').run();
@@ -290,5 +293,71 @@ describe('Export/Import Regression Tests', () => {
             { name: 'Owner Provider', enabled: 1, granted_by_admin: 0 },
             { name: 'Shared Provider', enabled: 1, granted_by_admin: 1 },
         ]);
+    });
+
+    it('merges duplicate assignments during system import and reports unique counts', async () => {
+        db.prepare('PRAGMA foreign_keys = OFF').run();
+        for (const table of ['user_channels', 'category_mappings', 'sync_configs', 'provider_channels', 'providers', 'user_categories', 'users']) {
+            db.prepare(`DELETE FROM ${table}`).run();
+        }
+        db.prepare('PRAGMA foreign_keys = ON').run();
+
+        const userId = db.prepare("INSERT INTO users (username, password) VALUES ('duplicate_import', 'pass')").run().lastInsertRowid;
+        const providerId = db.prepare(`
+            INSERT INTO providers (name, url, username, password, user_id)
+            VALUES ('Duplicate Provider', 'http://duplicate.example', 'u', ?, ?)
+        `).run(encrypt('provider-pass'), userId).lastInsertRowid;
+        const channelId = db.prepare(`
+            INSERT INTO provider_channels (provider_id, remote_stream_id, name, stream_type)
+            VALUES (?, 501, 'Duplicate Channel', 'series')
+        `).run(providerId).lastInsertRowid;
+        const categoryId = db.prepare("INSERT INTO user_categories (user_id, name, type) VALUES (?, 'Duplicate', 'series')").run(userId).lastInsertRowid;
+        db.prepare(`
+            INSERT INTO user_channels
+              (user_category_id, provider_channel_id, sort_order, assignment_origin, custom_name, is_hidden)
+            VALUES (?, ?, 4, 'legacy', '', 0)
+        `).run(categoryId, channelId);
+
+        let exportedBuffer;
+        systemController.exportData(
+            { user: { is_admin: true }, body: { password: TEST_EXPORT_PASSWORD, user_id: 'all' }, query: {} },
+            { setHeader: vi.fn(), status: vi.fn().mockReturnThis(), json: vi.fn(), send: vi.fn(buffer => { exportedBuffer = buffer; }) }
+        );
+        const exportedData = JSON.parse(zlib.gunzipSync(decryptWithPassword(exportedBuffer, TEST_EXPORT_PASSWORD)).toString('utf8'));
+        const sourceAssignment = exportedData.channels.find(channel => channel.type === 'user_assignment');
+        exportedData.channels.push({
+            ...sourceAssignment,
+            id: 9999,
+            assignment_origin: 'mapping',
+            mapping_id: 123456,
+            sort_order: 0,
+            custom_name: 'Imported name',
+            is_hidden: 1,
+        });
+        fs.writeFileSync(tempFilePath, encryptWithPassword(zlib.gzipSync(JSON.stringify(exportedData)), TEST_EXPORT_PASSWORD));
+
+        db.prepare('PRAGMA foreign_keys = OFF').run();
+        for (const table of ['user_channels', 'category_mappings', 'sync_configs', 'provider_channels', 'providers', 'user_categories', 'users']) {
+            db.prepare(`DELETE FROM ${table}`).run();
+        }
+        db.prepare('PRAGMA foreign_keys = ON').run();
+
+        const resImport = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+        await systemController.importData(
+            { user: { is_admin: true }, body: { password: TEST_EXPORT_PASSWORD }, file: { path: tempFilePath } },
+            resImport
+        );
+
+        expect(resImport.json).toHaveBeenCalledWith({
+            success: true,
+            stats: expect.objectContaining({ channels: 1, channels_merged: 1, channels_skipped: 0 })
+        });
+        expect(db.prepare(`
+            SELECT assignment_origin, mapping_id, sort_order, custom_name, is_hidden
+            FROM user_channels
+        `).get()).toEqual({
+            assignment_origin: 'legacy', mapping_id: null, sort_order: 0,
+            custom_name: 'Imported name', is_hidden: 1
+        });
     });
 });

--- a/tests/migration_regression.test.js
+++ b/tests/migration_regression.test.js
@@ -256,6 +256,27 @@ describe('Migration Bug Regression', () => {
         });
     });
 
+    it('does not infer mapping ownership while deduplicating a legacy schema', () => {
+        const legacyDb = new Database(':memory:');
+        try {
+            legacyDb.exec(`
+              CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT);
+              CREATE TABLE user_channels (
+                id INTEGER PRIMARY KEY, user_category_id INTEGER, provider_channel_id INTEGER,
+                sort_order INTEGER DEFAULT 0, custom_name TEXT DEFAULT '', is_hidden INTEGER DEFAULT 0,
+                mapping_id INTEGER, granted_by_admin INTEGER DEFAULT 0, authorization_revoked INTEGER DEFAULT 0
+              );
+              INSERT INTO user_channels (id, user_category_id, provider_channel_id, mapping_id)
+              VALUES (1, 10, 20, 900), (2, 10, 20, NULL);
+            `);
+
+            expect(migrateUserChannelDeduplicationV1(legacyDb)).toEqual({ merged: 1, skipped: false });
+            expect(legacyDb.prepare('SELECT mapping_id FROM user_channels').get()).toEqual({ mapping_id: null });
+        } finally {
+            legacyDb.close();
+        }
+    });
+
     it('should revoke legacy ownership mismatches idempotently without changing IDs', () => {
         const legacyDb = new Database(':memory:');
         try {

--- a/tests/migration_regression.test.js
+++ b/tests/migration_regression.test.js
@@ -7,6 +7,8 @@ import {
     migrateOtpSecrets,
     migrateSeriesEpisodes,
     migrateUserChannelMappingId,
+    migrateUserChannelAssignmentOrigin,
+    migrateUserChannelAssignmentProvenanceV2,
     migrateProviderSyncState,
     migrateUserChannelMappingBackfillV1,
     migrateUserChannelDeduplicationV1,
@@ -88,7 +90,7 @@ describe('Migration Bug Regression', () => {
         }
     });
 
-    it('backfills only unambiguous legacy mapping ownership and records a marker', () => {
+    it('records the legacy V1 marker without inferring mapping ownership', () => {
         const legacyDb = new Database(':memory:');
         try {
             legacyDb.exec(`
@@ -125,17 +127,65 @@ describe('Migration Bug Regression', () => {
             `);
 
             const result = migrateUserChannelMappingBackfillV1(legacyDb);
-            expect(result).toEqual({ assigned: 3, ambiguous: 1, unmatched: 2, skipped: false });
+            expect(result).toEqual({ assigned: 0, ambiguous: 0, unmatched: 0, skipped: false });
             expect(legacyDb.prepare('SELECT id, mapping_id FROM user_channels ORDER BY id').all()).toEqual([
-              { id: 201, mapping_id: 100 },
-              { id: 202, mapping_id: 101 },
+              { id: 201, mapping_id: null },
+              { id: 202, mapping_id: null },
               { id: 203, mapping_id: null },
               { id: 204, mapping_id: null },
               { id: 205, mapping_id: null },
-              { id: 206, mapping_id: 106 }
+              { id: 206, mapping_id: null }
             ]);
             expect(legacyDb.prepare("SELECT value FROM settings WHERE key = 'user_channel_mapping_backfill_v1'").get()).toBeTruthy();
             expect(migrateUserChannelMappingBackfillV1(legacyDb)).toEqual({ assigned: 0, ambiguous: 0, unmatched: 0, skipped: true });
+        } finally {
+            legacyDb.close();
+        }
+    });
+
+    it('repairs uncertain V1 ownership conservatively and is idempotent', () => {
+        const legacyDb = new Database(':memory:');
+        try {
+            legacyDb.exec(`
+              CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT);
+              CREATE TABLE user_channels (
+                id INTEGER PRIMARY KEY, user_category_id INTEGER, provider_channel_id INTEGER,
+                sort_order INTEGER DEFAULT 0, custom_name TEXT DEFAULT '', is_hidden INTEGER DEFAULT 0,
+                assignment_origin TEXT NOT NULL DEFAULT 'legacy',
+                mapping_id INTEGER, granted_by_admin INTEGER DEFAULT 0, authorization_revoked INTEGER DEFAULT 0
+              );
+              CREATE TABLE series_episode_aliases (
+                id INTEGER PRIMARY KEY, user_channel_id INTEGER, source_key TEXT,
+                series_remote_id INTEGER, remote_episode_id INTEGER
+              );
+              INSERT INTO user_channels
+                (id, user_category_id, provider_channel_id, sort_order, custom_name, is_hidden,
+                 mapping_id, granted_by_admin, authorization_revoked)
+              VALUES (42, 7, 9, 3, 'Keep', 1, 100, 1, 1);
+              INSERT INTO series_episode_aliases VALUES (99, 42, 'source', 9, 1);
+            `);
+            migrateUserChannelMappingId(legacyDb);
+            migrateUserChannelAssignmentOrigin(legacyDb);
+            expect(migrateUserChannelAssignmentProvenanceV2(legacyDb)).toEqual({ repaired: 1, skipped: false });
+            expect(legacyDb.prepare(`
+              SELECT id, user_category_id, provider_channel_id, sort_order, custom_name, is_hidden,
+                     assignment_origin, mapping_id, granted_by_admin, authorization_revoked
+              FROM user_channels
+            `).get()).toEqual({
+              id: 42, user_category_id: 7, provider_channel_id: 9, sort_order: 3,
+              custom_name: 'Keep', is_hidden: 1, assignment_origin: 'legacy', mapping_id: null,
+              granted_by_admin: 1, authorization_revoked: 1
+            });
+            expect(legacyDb.prepare('SELECT id, user_channel_id FROM series_episode_aliases').get())
+              .toEqual({ id: 99, user_channel_id: 42 });
+            legacyDb.prepare(`
+              INSERT INTO user_channels
+                (id, user_category_id, provider_channel_id, assignment_origin, mapping_id)
+              VALUES (43, 7, 10, 'mapping', 101)
+            `).run();
+            expect(migrateUserChannelAssignmentProvenanceV2(legacyDb)).toEqual({ repaired: 0, skipped: true });
+            expect(legacyDb.prepare('SELECT assignment_origin, mapping_id FROM user_channels WHERE id = 43').get())
+              .toEqual({ assignment_origin: 'mapping', mapping_id: 101 });
         } finally {
             legacyDb.close();
         }
@@ -150,6 +200,7 @@ describe('Migration Bug Regression', () => {
               CREATE TABLE user_channels (
                 id INTEGER PRIMARY KEY, user_category_id INTEGER, provider_channel_id INTEGER,
                 sort_order INTEGER DEFAULT 0, custom_name TEXT DEFAULT '', is_hidden INTEGER DEFAULT 0,
+                assignment_origin TEXT NOT NULL DEFAULT 'legacy',
                 mapping_id INTEGER, granted_by_admin INTEGER DEFAULT 0, authorization_revoked INTEGER DEFAULT 0
               );
               CREATE TABLE series_episode_aliases (
@@ -162,10 +213,10 @@ describe('Migration Bug Regression', () => {
                 FOREIGN KEY (user_channel_id) REFERENCES user_channels(id) ON DELETE CASCADE
               );
               INSERT INTO user_channels VALUES
-                (1, 10, 20, 8, '', 0, 7, 1, 0),
-                (2, 10, 20, 2, 'Manual', 1, NULL, 0, 0),
-                (3, 11, 21, 9, 'Mapped', 0, 8, 0, 1),
-                (4, 11, 21, 3, '', 0, 9, 0, 0);
+                (1, 10, 20, 8, '', 0, 'mapping', 7, 1, 0),
+                (2, 10, 20, 2, 'Manual', 1, 'manual', NULL, 0, 0),
+                (3, 11, 21, 9, 'Mapped', 0, 'mapping', 8, 0, 1),
+                (4, 11, 21, 3, '', 0, 'mapping', 9, 0, 0);
               INSERT INTO series_episode_aliases (id, user_channel_id, source_key, series_remote_id, remote_episode_id) VALUES
                 (900000005, 2, 'source', 20, 1),
                 (900000006, 1, 'source', 20, 1),
@@ -174,9 +225,9 @@ describe('Migration Bug Regression', () => {
             `);
 
             expect(migrateUserChannelDeduplicationV1(legacyDb)).toEqual({ merged: 2, skipped: false });
-            expect(legacyDb.prepare('SELECT id, mapping_id, is_hidden, custom_name, sort_order FROM user_channels ORDER BY id').all()).toEqual([
-              { id: 2, mapping_id: null, is_hidden: 1, custom_name: 'Manual', sort_order: 2 },
-              { id: 3, mapping_id: 8, is_hidden: 0, custom_name: 'Mapped', sort_order: 3 }
+            expect(legacyDb.prepare('SELECT id, assignment_origin, mapping_id, is_hidden, custom_name, sort_order FROM user_channels ORDER BY id').all()).toEqual([
+              { id: 2, assignment_origin: 'manual', mapping_id: null, is_hidden: 1, custom_name: 'Manual', sort_order: 2 },
+              { id: 3, assignment_origin: 'mapping', mapping_id: 8, is_hidden: 0, custom_name: 'Mapped', sort_order: 3 }
             ]);
             expect(legacyDb.prepare('SELECT id, user_channel_id, remote_episode_id FROM series_episode_aliases ORDER BY id').all()).toEqual([
               { id: 900000005, user_channel_id: 2, remote_episode_id: 1 },

--- a/tests/migration_regression.test.js
+++ b/tests/migration_regression.test.js
@@ -15,6 +15,7 @@ import {
     migrateUserChannelAdminGrants,
     migrateSyncConfigAdminGrants
 } from '../src/database/migrations.js';
+import { mergeAssignmentCandidates } from '../src/services/userChannelAssignmentService.js';
 
 describe('Migration Bug Regression', () => {
     beforeAll(() => {
@@ -240,6 +241,19 @@ describe('Migration Bug Regression', () => {
         } finally {
             legacyDb.close();
         }
+    });
+
+    it('keeps a valid mapping when a lower-id duplicate mapping is stale', () => {
+        const merged = mergeAssignmentCandidates([
+            { id: 10, user_category_id: 1, provider_channel_id: 2, assignment_origin: 'mapping', mapping_id: 900 },
+            { id: 11, user_category_id: 1, provider_channel_id: 2, assignment_origin: 'mapping', mapping_id: 901 }
+        ], { mappingValidator: mappingId => mappingId === 901 });
+
+        expect(merged).toMatchObject({
+            id: 11,
+            assignment_origin: 'mapping',
+            mapping_id: 901
+        });
     });
 
     it('should revoke legacy ownership mismatches idempotently without changing IDs', () => {

--- a/tests/sync_service_regression.test.js
+++ b/tests/sync_service_regression.test.js
@@ -78,6 +78,8 @@ describe('sync authorization regression', () => {
       CREATE TABLE user_channels (
         id INTEGER PRIMARY KEY, user_category_id INTEGER, provider_channel_id INTEGER,
         sort_order INTEGER, is_hidden INTEGER DEFAULT 0,
+        assignment_origin TEXT NOT NULL DEFAULT 'legacy'
+          CHECK (assignment_origin IN ('legacy', 'manual', 'mapping', 'imported')),
         mapping_id INTEGER,
         granted_by_admin INTEGER NOT NULL DEFAULT 0,
         authorization_revoked INTEGER NOT NULL DEFAULT 0

--- a/tests/user_clone_regression.test.js
+++ b/tests/user_clone_regression.test.js
@@ -56,6 +56,7 @@ describe('User clone regression', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     insertProviderRun.mockReturnValue({ lastInsertRowid: 20 });
+    insertUserChannelRun.mockReturnValue({ lastInsertRowid: 40 });
     insertChannelRun.mockImplementation((providerId, remoteStreamId, name) => {
       if (name == null) {
         throw new Error('NOT NULL constraint failed: provider_channels.name');
@@ -212,7 +213,7 @@ describe('User clone regression', () => {
     expect(insertProviderRun.mock.calls[0][12]).toBe(1);
     expect(insertProviderRun.mock.calls[0][13]).toBe('Europe/Berlin');
     expect(insertSyncRun).toHaveBeenCalledWith(20, 200, 1, 'daily', 1, 1, 1);
-    expect(insertUserChannelRun).toHaveBeenCalledWith(40, 30, 0, '', 0, null);
-    expect(mockPrepare).toHaveBeenCalledWith(expect.stringContaining('VALUES (?, ?, ?, ?, ?, ?, 0, 0)'));
+    expect(insertUserChannelRun).toHaveBeenCalledWith(40, 30, 0, '', 0, 'legacy', null, 0, 0);
+    expect(mockPrepare).toHaveBeenCalledWith(expect.stringContaining('assignment_origin'));
   });
 });


### PR DESCRIPTION
## Summary
- Add explicit `assignment_origin` provenance with conservative V1/V2 migration behavior.
- Route mapping lifecycle through trusted `mapping` ownership only; manual add/re-add always adopts `manual` ownership.
- Use one deterministic merge/alias-rebind helper for migration, mapping retarget, backup restore, system import, clone, and category import.
- Preserve legacy/unversioned imports as unowned `imported` assignments and retain modern mapping provenance only after relationship validation.
- Add regression coverage and update API/development documentation.

## Duplicate semantics
- Identity is user category plus provider channel.
- Priority is manual > legacy/imported > mapping.
- Lowest valid ID is stable; hidden state wins; custom name and lowest valid sort are deterministic.
- Mapping IDs are retained only when the mapping/category/provider/content relationship is validated.
- Authorization is recalculated fail-closed and merge counters do not inflate inserted/restored counts.
- Series episode aliases are rebound and de-duplicated before loser rows are removed.

## Validation
- `npm ci`
- `npm run lint -- --no-fix` (0 errors; existing warnings only)
- Three isolated full test-suite runs: 593/593 passed each
- Final isolated full suite: passed
- `npm audit --audit-level=high` and production-only audit: 0 vulnerabilities
- `npm run build`
- `npm ci --dry-run`
- Docker build: `iptv-manager-provenance-hotfix` succeeded
- Automated Stalker protocol/VOD/series/radio/catch-up coverage passes. No IPTVnator or OTT Navigator binary/client was available in this environment, so a real-client matrix remains the explicit external blocker.

No release, tag, publication, or deployment is included.