### PR TITLE
fix: preserve mapping lifecycle across imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@ All notable changes to this project are documented here.
   clears uncertain ownership while preserving assignment IDs and fields.
 - Deterministically merge duplicate assignments during legacy backup restore,
   full-system import, cloning, and category import, including alias rebinding.
+- Preserve trusted mapping provenance during version-2 system imports only after
+  validating user, category, provider, provider-category, type, and stream
+  relationships.
+- Reuse and transactionally reconcile existing mapping targets during repeated
+  category imports instead of stranding mapping-owned assignments.
+- Group backup and system-import duplicate assignments before insertion so
+  merged state and the lowest available assignment ID are independent of input
+  order.
 - Treat manual re-add as an explicit transfer from mapping ownership to manual
   ownership.
 - Validated the experimental portal with real software clients.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -107,6 +107,14 @@ matching `mapping_id`; a non-null ID alone is not trusted. Each user category
 can contain at most one assignment for a given provider channel. Bulk category
 and channel requests accept at most 5,000 IDs per request.
 
+Repeated provider-category imports reuse an existing valid mapping target and
+merge missing mapping-owned assignments into it. Mapping ownership is retained
+only when the user, target category, provider, provider category, content type,
+and provider stream are compatible; invalid provenance remains unowned instead
+of retaining a stale mapping reference. Backup and full-system import payloads
+are grouped before insertion, so merged state and the lowest available
+assignment ID do not depend on source row order.
+
 ## EPG and Mapping
 
 - `GET /api/epg/now`

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -154,6 +154,14 @@ rebinds/de-duplicates series aliases before removing losers. Modern backup and
 system formats may retain mapping ownership only after relationship validation;
 legacy formats are imported as unowned.
 
+The shared mapping validator checks mapping ownership, target category, provider
+category, content type, and stream compatibility (including live-provider radio
+categories). Reimporting a mapped provider category reuses its valid target and
+reconciles mapping-owned assignments in one transaction; manual, legacy, and
+imported rows are not moved or deleted. Backup and system-import assignments are
+grouped before writes, preserving hidden state, aliases, merged fields, and the
+lowest available source ID independently of payload order.
+
 Provider sync state is persisted per provider and stream type in
 `provider_sync_state`. A first complete empty snapshot with local rows is
 recorded but is not destructive; cleanup requires a second consecutive empty

--- a/src/controllers/backupController.js
+++ b/src/controllers/backupController.js
@@ -3,8 +3,16 @@ import { clearChannelsCache } from '../services/cacheService.js';
 import { resolveAssignmentGrant } from '../utils/helpers.js';
 import {
   normalizeAssignmentOrigin,
+  mergeAssignmentGroups,
   upsertMergedUserChannelAssignment
 } from '../services/userChannelAssignmentService.js';
+import {
+  getCategoryMapping,
+  retargetCategoryMapping,
+  validateMappingTarget,
+  validateMappingAssignmentRelationship,
+  validateStoredMappingAssignment
+} from '../services/categoryMappingService.js';
 
 export const getBackups = (req, res) => {
   try {
@@ -108,7 +116,7 @@ export const restoreBackup = (req, res) => {
       // Insert backup data
       const insertCategory = db.prepare('INSERT INTO user_categories (id, user_id, name, sort_order, is_adult, type) VALUES (?, ?, ?, ?, ?, ?)');
       const getMapping = db.prepare(`
-        SELECT id, provider_id, provider_category_id,
+        SELECT id, provider_id, user_id, user_category_id, provider_category_id,
                COALESCE(category_type, 'live') AS category_type
         FROM category_mappings
         WHERE id = ? AND user_id = ?
@@ -121,12 +129,30 @@ export const restoreBackup = (req, res) => {
         WHERE pc.id = ?
       `);
       const getCategoryType = db.prepare("SELECT COALESCE(type, 'live') AS type FROM user_categories WHERE id = ? AND user_id = ?");
-      const updateMapping = db.prepare('UPDATE category_mappings SET user_category_id = ?, auto_created = ? WHERE id = ? AND user_id = ?');
+      const updateMappingMetadata = db.prepare('UPDATE category_mappings SET auto_created = ? WHERE id = ? AND user_id = ?');
 
       for (const cat of data.userCategories) {
         insertCategory.run(cat.id, userId, cat.name, cat.sort_order, cat.is_adult, cat.type);
       }
 
+      // Reconnect mappings before validating assignment provenance. This keeps the
+      // relationship validator from observing a temporarily detached target.
+      for (const map of data.categoryMappings) {
+        const categoryId = Number(map.user_category_id);
+        if (restoredCategoryIds.has(categoryId)) {
+          const currentMapping = getCategoryMapping(db, map.id);
+          if (currentMapping && Number(currentMapping.user_id) === userId) {
+            if (validateMappingTarget(db, currentMapping, categoryId)) {
+              if (!retargetCategoryMapping(db, currentMapping, categoryId)) {
+                throw new Error('Mapping retarget failed');
+              }
+              updateMappingMetadata.run(map.auto_created ? 1 : 0, map.id, userId);
+            }
+          }
+        }
+      }
+
+      const candidates = [];
       for (const chan of data.userChannels) {
         const categoryId = Number(chan.user_category_id);
         const providerChannelId = Number(chan.provider_channel_id);
@@ -155,54 +181,64 @@ export const restoreBackup = (req, res) => {
           : 'imported';
         const sourceMappingId = Number(chan.mapping_id);
         const sourceMapping = backupMappingTargets.get(sourceMappingId);
-        const restoredMappingId = sourceOrigin === 'mapping' && Number.isInteger(sourceMappingId) && sourceMappingId > 0 &&
-          sourceMapping && Number(sourceMapping.user_category_id) === categoryId && getMapping.get(sourceMappingId, userId)
-          ? sourceMappingId
+        const currentMapping = sourceOrigin === 'mapping' ? getMapping.get(sourceMappingId, userId) : null;
+        const category = getCategoryType.get(categoryId, userId);
+        const sourceValidationMapping = currentMapping && sourceMapping
+          ? { ...currentMapping, ...sourceMapping,
+              provider_id: sourceMapping.provider_id ?? currentMapping.provider_id,
+              user_id: sourceMapping.user_id ?? currentMapping.user_id,
+              id: sourceMapping.id ?? currentMapping.id }
           : null;
-        const result = upsertMergedUserChannelAssignment(db, {
+        const sourceValid = sourceOrigin === 'mapping' && sourceMapping && currentMapping &&
+          Number(sourceMapping.user_category_id) === categoryId &&
+          validateMappingAssignmentRelationship({
+            mapping: sourceValidationMapping,
+            userId,
+            userCategoryId: categoryId,
+            userCategoryType: category?.type,
+            providerId: provider.provider_id,
+            providerCategoryId: provider.original_category_id,
+            providerStreamType: provider.stream_type
+          });
+        const restoredMappingId = sourceValid && validateStoredMappingAssignment(db, {
+          mappingId: sourceMappingId,
+          userId,
+          userCategoryId: categoryId,
+          providerChannelId
+        }) ? sourceMappingId : null;
+        const validMapping = Boolean(restoredMappingId);
+        candidates.push({
           id: chan.id,
           user_category_id: categoryId,
           provider_channel_id: providerChannelId,
           sort_order: chan.sort_order,
           custom_name: chan.custom_name || '',
           is_hidden: isHidden,
-          assignment_origin: sourceOrigin,
+          assignment_origin: validMapping ? 'mapping' : (sourceOrigin === 'mapping' ? 'legacy' : sourceOrigin),
           mapping_id: restoredMappingId,
           granted_by_admin: grant === 1 ? 1 : 0,
           authorization_revoked: authorizationRevoked,
-          grant_valid: grant === 1
-        }, {
-          preserveId: true,
-          mappingValidator: mappingId => {
-            const map = backupMappingTargets.get(Number(mappingId));
-            const current = getMapping.get(Number(mappingId), userId);
-            const category = getCategoryType.get(categoryId, userId);
-            const mapType = String(map?.category_type || 'live');
-            const categoryType = String(category?.type || 'live');
-            const streamType = String(provider.stream_type || 'live');
-            const providerCategoryId = Number(provider.original_category_id);
-            const mappingCategoryId = Number(current?.provider_category_id);
-            const sourceCategoryId = Number(sourceMapping?.provider_category_id);
-            const typeValid = mapType === categoryType &&
-              (streamType === mapType || (streamType === 'live' && mapType === 'radio'));
-            return Boolean(map && current && Number(map.user_category_id) === categoryId &&
-              Number(current.provider_id) === Number(provider.provider_id) &&
-              Number.isFinite(providerCategoryId) && providerCategoryId === mappingCategoryId &&
-              providerCategoryId === sourceCategoryId && typeValid);
-          }
+          grant_valid: grant === 1,
+          mapping_valid: validMapping
         });
-        if (result.skipped) {
-          stats.channels_skipped++;
-          continue;
-        }
-        if (result.merged) stats.channels_merged = (stats.channels_merged || 0) + result.merged;
       }
 
-      for (const map of data.categoryMappings) {
-        const categoryId = Number(map.user_category_id);
-        if (restoredCategoryIds.has(categoryId)) {
-          updateMapping.run(categoryId, map.auto_created ? 1 : 0, map.id, userId);
-        }
+      const grouped = mergeAssignmentGroups(candidates, { preserveLowestId: true });
+      const getAssignmentById = db.prepare('SELECT id FROM user_channels WHERE id = ?');
+      for (const group of grouped.groups) {
+        const candidate = { ...group.candidate };
+        candidate.id = group.validIds.find(id => !getAssignmentById.get(id)) || null;
+        const result = upsertMergedUserChannelAssignment(db, candidate, {
+          preserveId: true,
+          mappingValidator: mappingId => validateStoredMappingAssignment(db, {
+            mappingId,
+            userId,
+            userCategoryId: candidate.user_category_id,
+            providerChannelId: candidate.provider_channel_id
+          })
+        });
+        if (result.skipped) stats.channels_skipped++;
+        else stats.channels_merged = (stats.channels_merged || 0) + group.duplicateCount + result.merged;
       }
 
       const categoryPlaceholders = [...restoredCategoryIds].map(() => '?').join(',');

--- a/src/controllers/backupController.js
+++ b/src/controllers/backupController.js
@@ -185,12 +185,15 @@ export const restoreBackup = (req, res) => {
         const category = getCategoryType.get(categoryId, userId);
         const sourceValidationMapping = currentMapping && sourceMapping
           ? { ...currentMapping, ...sourceMapping,
-              provider_id: sourceMapping.provider_id ?? currentMapping.provider_id,
-              user_id: sourceMapping.user_id ?? currentMapping.user_id,
-              id: sourceMapping.id ?? currentMapping.id }
+              id: sourceMapping.id === undefined ? currentMapping.id : sourceMapping.id,
+              provider_id: sourceMapping.provider_id === undefined ? currentMapping.provider_id : sourceMapping.provider_id,
+              user_id: sourceMapping.user_id === undefined ? currentMapping.user_id : sourceMapping.user_id,
+              user_category_id: sourceMapping.user_category_id === undefined ? currentMapping.user_category_id : sourceMapping.user_category_id,
+              provider_category_id: sourceMapping.provider_category_id === undefined ? currentMapping.provider_category_id : sourceMapping.provider_category_id,
+              category_type: sourceMapping.category_type === undefined ? currentMapping.category_type : sourceMapping.category_type }
           : null;
         const sourceValid = sourceOrigin === 'mapping' && sourceMapping && currentMapping &&
-          Number(sourceMapping.user_category_id) === categoryId &&
+          Number(sourceValidationMapping.user_category_id) === categoryId &&
           validateMappingAssignmentRelationship({
             mapping: sourceValidationMapping,
             userId,

--- a/src/controllers/channelController.js
+++ b/src/controllers/channelController.js
@@ -2,10 +2,7 @@ import { clearChannelsCache } from '../services/cacheService.js';
 import db from '../database/db.js';
 import { isAdultCategory, resolveAssignmentGrant } from '../utils/helpers.js';
 import { getEpgLogo, loadEpgLogosCache } from '../services/logoResolver.js';
-import {
-  mergeAssignmentCandidates,
-  rebindSeriesEpisodeAliases
-} from '../services/userChannelAssignmentService.js';
+import { retargetCategoryMapping } from '../services/categoryMappingService.js';
 
 const MAX_BULK_IDS = 5000;
 
@@ -26,120 +23,6 @@ function bulkOperationError(status, message) {
   const error = new Error(message);
   error.status = status;
   return error;
-}
-
-function reconcileMappingAssignments(mapping, targetId) {
-  const ownedAssignments = db.prepare(`
-    SELECT uc.*
-    FROM user_channels uc
-    WHERE uc.mapping_id = ? AND uc.assignment_origin = 'mapping'
-    ORDER BY uc.id
-  `).all(mapping.id);
-  if (targetId === null) {
-    for (const assignment of ownedAssignments) {
-      db.prepare(`
-        DELETE FROM user_channels
-        WHERE id = ? AND mapping_id = ? AND assignment_origin = 'mapping'
-      `).run(assignment.id, mapping.id);
-    }
-    return { assignments_removed: ownedAssignments.length, assignments_moved: 0, duplicates_merged: 0 };
-  }
-
-  let assignmentsMoved = 0;
-  let duplicatesMerged = 0;
-  const findTarget = db.prepare(`
-    SELECT *
-    FROM user_channels
-    WHERE user_category_id = ? AND provider_channel_id = ?
-    ORDER BY id
-  `);
-  const update = db.prepare(`
-    UPDATE user_channels
-    SET user_category_id = ?, sort_order = ?, custom_name = ?, is_hidden = ?,
-        assignment_origin = ?, mapping_id = ?, granted_by_admin = ?, authorization_revoked = ?
-    WHERE id = ?
-  `);
-  const deleteAssignment = db.prepare('DELETE FROM user_channels WHERE id = ?');
-
-  for (const assignment of ownedAssignments) {
-    if (Number(assignment.user_category_id) === Number(targetId)) continue;
-    const targetRows = findTarget.all(targetId, assignment.provider_channel_id);
-    if (targetRows.length === 0) {
-      if (update.run(
-        targetId,
-        assignment.sort_order,
-        assignment.custom_name || '',
-        Number(assignment.is_hidden) === 1 ? 1 : 0,
-        'mapping',
-        mapping.id,
-        Number(assignment.granted_by_admin) === 1 ? 1 : 0,
-        Number(assignment.authorization_revoked) === 1 ? 1 : 0,
-        assignment.id
-      ).changes === 1) assignmentsMoved++;
-      continue;
-    }
-
-    const merged = mergeAssignmentCandidates(
-      [...targetRows, { ...assignment, user_category_id: targetId }],
-      {
-        mappingValidator: mappingId => {
-          if (Number(mappingId) === Number(mapping.id)) return true;
-          const row = db.prepare(`
-            SELECT user_id, provider_id, user_category_id, COALESCE(category_type, 'live') AS category_type
-            FROM category_mappings
-            WHERE id = ?
-          `).get(mappingId);
-          return row && Number(row.user_id) === Number(mapping.user_id) &&
-            Number(row.provider_id) === Number(mapping.provider_id) &&
-            String(row.category_type) === String(mapping.category_type) &&
-            Number(row.user_category_id) === Number(targetId);
-        }
-      }
-    );
-    const survivorId = Number(merged.id);
-    const survivorIsSource = survivorId === Number(assignment.id);
-    const survivor = survivorIsSource ? assignment : targetRows.find(row => Number(row.id) === survivorId) || targetRows[0];
-    const losers = targetRows.filter(row => Number(row.id) !== Number(survivor.id));
-
-    if (survivorIsSource) {
-      for (const loser of targetRows) {
-        rebindSeriesEpisodeAliases(db, assignment.id, loser.id);
-        deleteAssignment.run(loser.id);
-      }
-      update.run(
-        targetId,
-        merged.sort_order,
-        merged.custom_name || '',
-        merged.is_hidden,
-        merged.assignment_origin,
-        merged.mapping_id,
-        merged.granted_by_admin,
-        merged.authorization_revoked,
-        assignment.id
-      );
-      assignmentsMoved++;
-    } else {
-      update.run(
-        targetId,
-        merged.sort_order,
-        merged.custom_name || '',
-        merged.is_hidden,
-        merged.assignment_origin,
-        merged.mapping_id,
-        merged.granted_by_admin,
-        merged.authorization_revoked,
-        survivor.id
-      );
-      for (const loser of losers) {
-        rebindSeriesEpisodeAliases(db, survivor.id, loser.id);
-        deleteAssignment.run(loser.id);
-      }
-      rebindSeriesEpisodeAliases(db, survivor.id, assignment.id);
-      deleteAssignment.run(assignment.id);
-    }
-    duplicatesMerged++;
-  }
-  return { assignments_removed: 0, assignments_moved: assignmentsMoved, duplicates_merged: duplicatesMerged };
 }
 
 export const getUserCategories = (req, res) => {
@@ -557,7 +440,8 @@ export const updateCategoryMapping = (req, res) => {
     const { user_category_id } = req.body;
 
     const mapping = db.prepare(`
-      SELECT id, user_id, provider_id, COALESCE(category_type, 'live') AS category_type
+      SELECT id, user_id, provider_id, provider_category_id,
+             COALESCE(category_type, 'live') AS category_type
       FROM category_mappings
       WHERE id = ?
     `).get(id);
@@ -572,27 +456,7 @@ export const updateCategoryMapping = (req, res) => {
       return res.status(400).json({error: 'Invalid user_category_id'});
     }
 
-    const result = db.transaction(() => {
-      if (targetId !== null) {
-        const target = db.prepare(`
-          SELECT id, user_id, COALESCE(type, 'live') AS type
-          FROM user_categories
-          WHERE id = ?
-        `).get(targetId);
-        if (!target || target.user_id !== mapping.user_id || target.type !== mapping.category_type) {
-          return false;
-        }
-      }
-
-      const reconciliation = reconcileMappingAssignments(mapping, targetId);
-      const updated = db.prepare(`
-        UPDATE category_mappings
-        SET user_category_id = ?
-        WHERE id = ? AND user_id = ?
-      `).run(targetId, id, mapping.user_id).changes === 1;
-      if (!updated) return false;
-      return { success: true, ...reconciliation };
-    })();
+    const result = db.transaction(() => retargetCategoryMapping(db, mapping, targetId))();
 
     if (!result) return res.status(400).json({error: 'Invalid user_category_id'});
 

--- a/src/controllers/providerController.js
+++ b/src/controllers/providerController.js
@@ -935,7 +935,7 @@ export const importCategories = async (req, res) => {
           });
         }
         totalCategories++;
-        results.push({ category_id: providerCategoryId, new_id: targetCategoryId, name: cat.name, channels_imported: channelsImported });
+        results.push({ category_id: cat.id, new_id: targetCategoryId, name: cat.name, channels_imported: channelsImported });
       }
       return true;
     })();

--- a/src/controllers/providerController.js
+++ b/src/controllers/providerController.js
@@ -707,7 +707,7 @@ export const importCategory = async (req, res) => {
     const catType = type || 'live';
     const providerCategoryId = Number(category_id);
 
-    if (!user_id || !Number.isInteger(providerCategoryId) || providerCategoryId <= 0 || !category_name) {
+    if (!user_id || !Number.isInteger(providerCategoryId) || providerCategoryId < 0 || !category_name) {
       return res.status(400).json({error: 'Missing required fields'});
     }
 
@@ -855,7 +855,7 @@ export const importCategories = async (req, res) => {
       let maxSort = Number(db.prepare('SELECT COALESCE(MAX(sort_order), -1) AS max_sort FROM user_categories WHERE user_id = ?').get(targetUserId).max_sort);
       for (const cat of categories) {
         const providerCategoryId = Number(cat.id);
-        if (!Number.isInteger(providerCategoryId) || providerCategoryId <= 0 || !cat.name) continue;
+        if (!Number.isInteger(providerCategoryId) || providerCategoryId < 0 || !cat.name) continue;
         const catType = cat.type || 'live';
         const existing = db.prepare(`
           SELECT cm.id, cm.user_category_id,

--- a/src/controllers/providerController.js
+++ b/src/controllers/providerController.js
@@ -14,6 +14,16 @@ import {
 
 const normalizeProviderBaseUrl = (url) => String(url || '').trim().replace(/\/+$/, '');
 const isHttpUrl = (url) => /^https?:\/\//i.test(url);
+const parseProviderCategoryId = value => {
+  if (typeof value === 'number') {
+    return Number.isSafeInteger(value) && value >= 0 ? value : null;
+  }
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) return null;
+  const parsed = Number(trimmed);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+};
 
 const replaceDefaultEpgProviderUrl = (epgUrl, fromBase, toBase) => {
   const trimmed = String(epgUrl || '').trim();
@@ -705,9 +715,9 @@ export const importCategory = async (req, res) => {
     const providerId = Number(req.params.providerId);
     const { user_id, category_id, category_name, import_channels, type } = req.body;
     const catType = type || 'live';
-    const providerCategoryId = Number(category_id);
+    const providerCategoryId = parseProviderCategoryId(category_id);
 
-    if (!user_id || !Number.isInteger(providerCategoryId) || providerCategoryId < 0 || !category_name) {
+    if (!user_id || providerCategoryId === null || !category_name) {
       return res.status(400).json({error: 'Missing required fields'});
     }
 
@@ -854,8 +864,8 @@ export const importCategories = async (req, res) => {
     const result = db.transaction(() => {
       let maxSort = Number(db.prepare('SELECT COALESCE(MAX(sort_order), -1) AS max_sort FROM user_categories WHERE user_id = ?').get(targetUserId).max_sort);
       for (const cat of categories) {
-        const providerCategoryId = Number(cat.id);
-        if (!Number.isInteger(providerCategoryId) || providerCategoryId < 0 || !cat.name) continue;
+        const providerCategoryId = parseProviderCategoryId(cat.id);
+        if (providerCategoryId === null || !cat.name) continue;
         const catType = cat.type || 'live';
         const existing = db.prepare(`
           SELECT cm.id, cm.user_category_id,

--- a/src/controllers/providerController.js
+++ b/src/controllers/providerController.js
@@ -7,6 +7,10 @@ import { updateProviderEpg } from '../services/epgService.js';
 import { clearChannelsCache } from '../services/cacheService.js';
 import { parseTimeshiftTimezone } from '../utils/timezone.js';
 import { upsertMergedUserChannelAssignment } from '../services/userChannelAssignmentService.js';
+import {
+  upsertCategoryMappingWithReconciliation,
+  validateMappingAssignmentRelationship
+} from '../services/categoryMappingService.js';
 
 const normalizeProviderBaseUrl = (url) => String(url || '').trim().replace(/\/+$/, '');
 const isHttpUrl = (url) => /^https?:\/\//i.test(url);
@@ -701,8 +705,9 @@ export const importCategory = async (req, res) => {
     const providerId = Number(req.params.providerId);
     const { user_id, category_id, category_name, import_channels, type } = req.body;
     const catType = type || 'live';
+    const providerCategoryId = Number(category_id);
 
-    if (!user_id || !category_id || !category_name) {
+    if (!user_id || !Number.isInteger(providerCategoryId) || providerCategoryId <= 0 || !category_name) {
       return res.status(400).json({error: 'Missing required fields'});
     }
 
@@ -724,74 +729,90 @@ export const importCategory = async (req, res) => {
     });
     if (grantedByAdmin === null) return res.status(403).json({error: 'Access denied'});
 
-    const isAdult = isAdultCategory(category_name) ? 1 : 0;
-
-    const maxSort = db.prepare('SELECT COALESCE(MAX(sort_order), -1) as max_sort FROM user_categories WHERE user_id = ?').get(targetUserId);
-    const newSortOrder = (maxSort?.max_sort ?? -1) + 1;
-
-    const catInfo = db.prepare('INSERT INTO user_categories (user_id, name, is_adult, sort_order, type) VALUES (?, ?, ?, ?, ?)').run(targetUserId, category_name, isAdult, newSortOrder, catType);
-    const newCategoryId = catInfo.lastInsertRowid;
-
-    db.prepare(`
-      INSERT INTO category_mappings (provider_id, user_id, provider_category_id, provider_category_name, user_category_id, auto_created, category_type)
-      VALUES (?, ?, ?, ?, ?, 0, ?)
-      ON CONFLICT(provider_id, user_id, provider_category_id, category_type)
-      DO UPDATE SET user_category_id = excluded.user_category_id
-    `).run(providerId, targetUserId, Number(category_id), category_name, newCategoryId, catType);
-    const mapping = db.prepare(`
-      SELECT id FROM category_mappings
-      WHERE provider_id = ? AND user_id = ? AND provider_category_id = ? AND category_type = ?
-    `).get(providerId, targetUserId, Number(category_id), catType);
-
-    if (import_channels) {
-      let streamType = 'live';
-      if(catType === 'movie') streamType = 'movie';
-      if(catType === 'series') streamType = 'series';
-
-      const stmt = db.prepare(`
-        SELECT id FROM provider_channels
-        WHERE provider_id = ? AND original_category_id = ? AND stream_type = ?
-        ORDER BY original_sort_order ASC, name ASC
-      `);
-
-      const channels = stmt.all(providerId, Number(category_id), streamType);
+    const result = db.transaction(() => {
+      const existing = db.prepare(`
+        SELECT cm.*,
+               COALESCE(cm.category_type, 'live') AS category_type,
+               uc.user_id AS target_user_id,
+               COALESCE(uc.type, 'live') AS target_category_type
+        FROM category_mappings cm
+        LEFT JOIN user_categories uc ON uc.id = cm.user_category_id
+        WHERE cm.provider_id = ? AND cm.user_id = ? AND cm.provider_category_id = ?
+          AND COALESCE(cm.category_type, 'live') = ?
+      `).get(providerId, targetUserId, providerCategoryId, catType);
+      const reusableTarget = existing && Number(existing.user_category_id) > 0 &&
+        Number(existing.target_user_id) === targetUserId &&
+        String(existing.target_category_type) === String(catType)
+        ? Number(existing.user_category_id)
+        : null;
+      let targetCategoryId = reusableTarget;
+      const isAdult = isAdultCategory(category_name) ? 1 : 0;
+      if (!targetCategoryId) {
+        const maxSort = db.prepare('SELECT COALESCE(MAX(sort_order), -1) as max_sort FROM user_categories WHERE user_id = ?').get(targetUserId);
+        targetCategoryId = Number(db.prepare(`
+          INSERT INTO user_categories (user_id, name, is_adult, sort_order, type)
+          VALUES (?, ?, ?, ?, ?)
+        `).run(targetUserId, category_name, isAdult, Number(maxSort?.max_sort ?? -1) + 1, catType).lastInsertRowid);
+      }
+      const mappingResult = upsertCategoryMappingWithReconciliation(db, {
+        providerId,
+        userId: targetUserId,
+        providerCategoryId,
+        providerCategoryName: category_name,
+        categoryType: catType,
+        targetCategoryId,
+        autoCreated: 0
+      });
+      targetCategoryId = mappingResult.user_category_id;
+      const mapping = mappingResult.mapping;
       let importedCount = 0;
       let mergedCount = 0;
-      db.transaction(() => {
+      if (import_channels) {
+        const streamType = catType === 'movie' || catType === 'series' ? catType : 'live';
+        const channels = db.prepare(`
+          SELECT id, provider_id, original_category_id, COALESCE(stream_type, 'live') AS stream_type
+          FROM provider_channels
+          WHERE provider_id = ? AND original_category_id = ? AND COALESCE(stream_type, 'live') = ?
+          ORDER BY original_sort_order ASC, name ASC, id
+        `).all(providerId, providerCategoryId, streamType);
         channels.forEach((ch, idx) => {
-          const result = upsertMergedUserChannelAssignment(db, {
-            user_category_id: newCategoryId,
+          const valid = validateMappingAssignmentRelationship({
+            mapping,
+            userId: targetUserId,
+            userCategoryId: targetCategoryId,
+            userCategoryType: catType,
+            providerId: ch.provider_id,
+            providerCategoryId: ch.original_category_id,
+            providerStreamType: ch.stream_type
+          });
+          const assignment = upsertMergedUserChannelAssignment(db, {
+            user_category_id: targetCategoryId,
             provider_channel_id: ch.id,
             sort_order: idx,
-            assignment_origin: 'mapping',
-            mapping_id: mapping?.id || null,
+            assignment_origin: valid ? 'mapping' : 'legacy',
+            mapping_id: valid ? mapping.id : null,
             granted_by_admin: grantedByAdmin,
             authorization_revoked: 0,
-            grant_valid: grantedByAdmin === 1
-          }, {
-            mappingValidator: mappingId => Number(mappingId) === Number(mapping?.id) && Boolean(mapping?.id)
-          });
-          importedCount += result.inserted;
-          mergedCount += result.merged;
+            grant_valid: grantedByAdmin === 1,
+            mapping_valid: valid
+          }, { mappingValidator: mappingId => Number(mappingId) === Number(mapping?.id) && valid });
+          importedCount += assignment.inserted;
+          mergedCount += assignment.merged;
         });
-      })();
+      }
+      return { targetCategoryId, mapping, isAdult, importedCount, mergedCount, reused: mappingResult.reused };
+    })();
 
-      const response = {
-        success: true,
-        category_id: newCategoryId,
-        channels_imported: importedCount,
-        is_adult: isAdult
-      };
-      if (mergedCount) response.channels_merged = mergedCount;
-      res.json(response);
-    } else {
-      res.json({
-        success: true,
-        category_id: newCategoryId,
-        channels_imported: 0,
-        is_adult: isAdult
-      });
-    }
+    clearChannelsCache(targetUserId);
+    const response = {
+      success: true,
+      category_id: result.targetCategoryId,
+      channels_imported: result.importedCount,
+      is_adult: result.isAdult
+    };
+    if (result.mergedCount) response.channels_merged = result.mergedCount;
+    if (result.reused) response.category_reused = true;
+    res.json(response);
   } catch (e) {
     console.error(e);
     res.status(500).json({error: e.message});
@@ -830,96 +851,86 @@ export const importCategories = async (req, res) => {
     let totalMerged = 0;
     let totalCategories = 0;
 
-    const insertUserCategory = db.prepare('INSERT INTO user_categories (user_id, name, is_adult, sort_order, type) VALUES (?, ?, ?, ?, ?)');
-    const getMaxSort = db.prepare('SELECT COALESCE(MAX(sort_order), -1) as max_sort FROM user_categories WHERE user_id = ?');
-
-    // Pre-fetch channels for all categories being imported to avoid N+1 queries
-    const categoriesToImportChannels = categories.filter(c => c.import_channels && c.id);
-    const categoryIds = [...new Set(categoriesToImportChannels.map(c => Number(c.id)))];
-    const channelsMap = new Map();
-
-    if (categoryIds.length > 0) {
-      // ⚡ Bolt: Use Array(n).fill('?').join(',') instead of .map(() => '?') to avoid closure allocation overhead in V8
-      const placeholders = Array(categoryIds.length).fill('?').join(',');
-      // ⚡ Bolt: Replace .all() with .iterate() to eliminate massive intermediate array allocations in V8
-      // 🎯 Why: .iterate() prevents fetching potentially 100k+ channels into a single array before mapping them.
-      const stmt = db.prepare(`
-        SELECT id, original_category_id, stream_type FROM provider_channels
-        WHERE provider_id = ? AND original_category_id IN (${placeholders})
-        ORDER BY original_sort_order ASC, name ASC
-      `);
-
-      for (const ch of stmt.iterate(providerId, ...categoryIds)) {
-        const key = `${ch.original_category_id}_${ch.stream_type}`;
-        if (!channelsMap.has(key)) channelsMap.set(key, []);
-        channelsMap.get(key).push(ch);
-      }
-    }
-
-    db.transaction(() => {
-      let maxSort = getMaxSort.get(targetUserId).max_sort;
-
-      // ⚡ Bolt: Hoist the prepared statement outside the loop to prevent parsing/compiling the SQL on every iteration.
-      const insertCategoryMapping = db.prepare(`
-        INSERT INTO category_mappings (provider_id, user_id, provider_category_id, provider_category_name, user_category_id, auto_created, category_type)
-        VALUES (?, ?, ?, ?, ?, 0, ?)
-        ON CONFLICT(provider_id, user_id, provider_category_id, category_type)
-        DO UPDATE SET user_category_id = excluded.user_category_id
-      `);
-      const getCategoryMapping = db.prepare(`
-        SELECT id FROM category_mappings
-        WHERE provider_id = ? AND user_id = ? AND provider_category_id = ? AND category_type = ?
-      `);
-
+    const result = db.transaction(() => {
+      let maxSort = Number(db.prepare('SELECT COALESCE(MAX(sort_order), -1) AS max_sort FROM user_categories WHERE user_id = ?').get(targetUserId).max_sort);
       for (const cat of categories) {
-        if (!cat.id || !cat.name) continue;
-
+        const providerCategoryId = Number(cat.id);
+        if (!Number.isInteger(providerCategoryId) || providerCategoryId <= 0 || !cat.name) continue;
         const catType = cat.type || 'live';
+        const existing = db.prepare(`
+          SELECT cm.id, cm.user_category_id,
+                 uc.user_id AS target_user_id, COALESCE(uc.type, 'live') AS target_category_type
+          FROM category_mappings cm
+          LEFT JOIN user_categories uc ON uc.id = cm.user_category_id
+          WHERE cm.provider_id = ? AND cm.user_id = ? AND cm.provider_category_id = ?
+            AND COALESCE(cm.category_type, 'live') = ?
+        `).get(providerId, targetUserId, providerCategoryId, catType);
+        const reusableTarget = existing && Number(existing.user_category_id) > 0 &&
+          Number(existing.target_user_id) === targetUserId &&
+          String(existing.target_category_type) === String(catType)
+          ? Number(existing.user_category_id)
+          : null;
+        let targetCategoryId = reusableTarget;
         const isAdult = isAdultCategory(cat.name) ? 1 : 0;
-        maxSort++;
-
-        const catInfo = insertUserCategory.run(targetUserId, cat.name, isAdult, maxSort, catType);
-        const newCategoryId = catInfo.lastInsertRowid;
-        totalCategories++;
-
-        insertCategoryMapping.run(providerId, targetUserId, Number(cat.id), cat.name, newCategoryId, catType);
-        const mapping = getCategoryMapping.get(providerId, targetUserId, Number(cat.id), catType);
-
+        if (!targetCategoryId) {
+          targetCategoryId = Number(db.prepare(`
+            INSERT INTO user_categories (user_id, name, is_adult, sort_order, type)
+            VALUES (?, ?, ?, ?, ?)
+          `).run(targetUserId, cat.name, isAdult, ++maxSort, catType).lastInsertRowid);
+        }
+        const mappingResult = upsertCategoryMappingWithReconciliation(db, {
+          providerId,
+          userId: targetUserId,
+          providerCategoryId,
+          providerCategoryName: cat.name,
+          categoryType: catType,
+          targetCategoryId,
+          autoCreated: 0
+        });
+        targetCategoryId = mappingResult.user_category_id;
+        const mapping = mappingResult.mapping;
         let channelsImported = 0;
         if (cat.import_channels) {
-          let streamType = 'live';
-          if(catType === 'movie') streamType = 'movie';
-          if(catType === 'series') streamType = 'series';
-
-          const channels = channelsMap.get(`${Number(cat.id)}_${streamType}`) || [];
-
+          const streamType = catType === 'movie' || catType === 'series' ? catType : 'live';
+          const channels = db.prepare(`
+            SELECT id, provider_id, original_category_id, COALESCE(stream_type, 'live') AS stream_type
+            FROM provider_channels
+            WHERE provider_id = ? AND original_category_id = ? AND COALESCE(stream_type, 'live') = ?
+            ORDER BY original_sort_order ASC, name ASC, id
+          `).all(providerId, providerCategoryId, streamType);
           channels.forEach((ch, idx) => {
-            const result = upsertMergedUserChannelAssignment(db, {
-              user_category_id: newCategoryId,
+            const valid = validateMappingAssignmentRelationship({
+              mapping,
+              userId: targetUserId,
+              userCategoryId: targetCategoryId,
+              userCategoryType: catType,
+              providerId: ch.provider_id,
+              providerCategoryId: ch.original_category_id,
+              providerStreamType: ch.stream_type
+            });
+            const assignment = upsertMergedUserChannelAssignment(db, {
+              user_category_id: targetCategoryId,
               provider_channel_id: ch.id,
               sort_order: idx,
-              assignment_origin: 'mapping',
-              mapping_id: mapping?.id || null,
+              assignment_origin: valid ? 'mapping' : 'legacy',
+              mapping_id: valid ? mapping.id : null,
               granted_by_admin: grantedByAdmin,
               authorization_revoked: 0,
-              grant_valid: grantedByAdmin === 1
-            }, {
-              mappingValidator: mappingId => Number(mappingId) === Number(mapping?.id) && Boolean(mapping?.id)
-            });
-            channelsImported += result.inserted;
-            totalChannels += result.inserted;
-            totalMerged += result.merged;
+              grant_valid: grantedByAdmin === 1,
+              mapping_valid: valid
+            }, { mappingValidator: mappingId => Number(mappingId) === Number(mapping?.id) && valid });
+            channelsImported += assignment.inserted;
+            totalChannels += assignment.inserted;
+            totalMerged += assignment.merged;
           });
         }
-
-        results.push({
-          category_id: cat.id,
-          new_id: newCategoryId,
-          name: cat.name,
-          channels_imported: channelsImported
-        });
+        totalCategories++;
+        results.push({ category_id: providerCategoryId, new_id: targetCategoryId, name: cat.name, channels_imported: channelsImported });
       }
+      return true;
     })();
+
+    if (result) clearChannelsCache(targetUserId);
 
     const response = {
       success: true,

--- a/src/controllers/systemController.js
+++ b/src/controllers/systemController.js
@@ -15,8 +15,13 @@ import { getGeoIpUpdatePlan, reloadGeoIpData, runGeoIpUpdateProcess } from '../s
 import { parseTimeshiftTimezone } from '../utils/timezone.js';
 import {
   normalizeAssignmentOrigin,
+  mergeAssignmentGroups,
   upsertMergedUserChannelAssignment
 } from '../services/userChannelAssignmentService.js';
+import {
+  validateMappingAssignmentRelationship,
+  validateStoredMappingAssignment
+} from '../services/categoryMappingService.js';
 
 let initialNetStats = null;
 si.networkStats().then(stats => {
@@ -447,7 +452,9 @@ export const importData = async (req, res) => {
       categories: 0,
       channels: 0,
       channels_merged: 0,
-      channels_skipped: 0
+      channels_skipped: 0,
+      channels_hidden: 0,
+      channels_authorization_revoked: 0
     };
 
     db.transaction(() => {
@@ -651,18 +658,27 @@ export const importData = async (req, res) => {
       }
 
       const userAssignments = (importData.channels || []).filter(c => c.type === 'user_assignment');
-      const getProviderChannel = db.prepare("SELECT provider_id, original_category_id, COALESCE(stream_type, 'live') AS stream_type FROM provider_channels WHERE id = ?");
+      const getProviderChannel = db.prepare(`
+        SELECT provider_id, original_category_id, COALESCE(stream_type, 'live') AS stream_type
+        FROM provider_channels WHERE id = ?
+      `);
       const getMapping = db.prepare(`
-        SELECT id, provider_id, user_id, user_category_id, COALESCE(category_type, 'live') AS category_type
+        SELECT id, provider_id, user_id, user_category_id, provider_category_id,
+               COALESCE(category_type, 'live') AS category_type
         FROM category_mappings
         WHERE id = ?
       `);
-      const getCategoryType = db.prepare("SELECT COALESCE(type, 'live') AS type FROM user_categories WHERE id = ?");
+      const sourceProviderChannels = new Map(
+        (importData.channels || []).filter(channel => !channel.type).map(channel => [Number(channel.id), channel])
+      );
+      const sourceCategories = new Map(
+        (importData.categories || []).map(category => [Number(category.id), category])
+      );
+      const candidates = [];
 
       for (const ua of userAssignments) {
         const newUserCatId = categoryIdMap.get(ua.user_category_id);
         const newProvChannelId = providerChannelIdMap.get(ua.provider_channel_id);
-
         if (!newUserCatId || !newProvChannelId) {
           stats.channels_skipped++;
           continue;
@@ -680,22 +696,33 @@ export const importData = async (req, res) => {
         const sourceMappingId = Number(ua.mapping_id);
         const sourceMapping = mappingSourceMap.get(sourceMappingId);
         const remappedMappingId = requestedOrigin === 'mapping' ? mappingIdMap.get(sourceMappingId) : null;
+        const sourceChannel = sourceProviderChannels.get(Number(ua.provider_channel_id));
+        const sourceCategory = sourceCategories.get(Number(ua.user_category_id));
         const restoredChannel = getProviderChannel.get(newProvChannelId);
-        const restoredProviderId = restoredChannel?.provider_id;
-        const restoredCategoryType = getCategoryType.get(newUserCatId)?.type || 'live';
-        const sourceMappingType = sourceMapping?.category_type || 'live';
-        const providerCategoryId = Number(restoredChannel?.original_category_id);
-        const mappingCategoryId = Number(sourceMapping?.provider_category_id);
-        const typeValid = sourceMappingType === restoredCategoryType &&
-          (String(restoredChannel?.stream_type || 'live') === sourceMappingType ||
-            (String(restoredChannel?.stream_type || 'live') === 'live' && sourceMappingType === 'radio'));
-        const validMapping = requestedOrigin === 'mapping' && sourceMapping && remappedMappingId &&
-          Number(sourceMapping.new_user_category_id) === Number(newUserCatId) &&
-          Number(sourceMapping.new_provider_id) === Number(restoredProviderId) &&
-          Number.isFinite(providerCategoryId) && providerCategoryId === mappingCategoryId && typeValid;
+        const sourceValid = requestedOrigin === 'mapping' && sourceMapping && sourceChannel && sourceCategory &&
+          validateMappingAssignmentRelationship({
+            mapping: sourceMapping,
+            userId: sourceMapping.user_id ?? sourceCategory.user_id,
+            userCategoryId: ua.user_category_id,
+            userCategoryType: sourceCategory.type,
+            providerId: sourceChannel.provider_id,
+            providerCategoryId: sourceChannel.original_category_id,
+            providerStreamType: sourceChannel.stream_type
+          });
+        const restoredValid = sourceValid && remappedMappingId && restoredChannel &&
+          validateStoredMappingAssignment(db, {
+            mappingId: remappedMappingId,
+            userId: categoryOwnerMap.get(newUserCatId),
+            userCategoryId: newUserCatId,
+            providerChannelId: newProvChannelId
+          });
+        const validMapping = Boolean(sourceValid && restoredValid &&
+          Number(mappingSourceMap.get(sourceMappingId)?.new_user_category_id) === Number(newUserCatId) &&
+          Number(mappingSourceMap.get(sourceMappingId)?.new_provider_id) === Number(restoredChannel?.provider_id) &&
+          Number(getMapping.get(Number(remappedMappingId))?.provider_category_id) === Number(restoredChannel?.original_category_id));
         const authorizationRevoked = grant === null ||
           (Number(ua.authorization_revoked) === 1 && grant !== 1) ? 1 : 0;
-        const result = upsertMergedUserChannelAssignment(db, {
+        candidates.push({
           id: ua.id,
           user_category_id: Number(newUserCatId),
           provider_channel_id: Number(newProvChannelId),
@@ -706,23 +733,33 @@ export const importData = async (req, res) => {
           mapping_id: validMapping ? Number(remappedMappingId) : null,
           granted_by_admin: grant === 1 ? 1 : 0,
           authorization_revoked: authorizationRevoked,
-          grant_valid: grant === 1
-        }, {
-          preserveId: false,
-          mappingValidator: mappingId => {
-            const mapping = getMapping.get(Number(mappingId));
-            return Boolean(mapping && Number(mapping.user_category_id) === Number(newUserCatId) &&
-              Number(mapping.provider_id) === Number(restoredProviderId) &&
-              Number(mapping.user_id) === Number(categoryOwnerMap.get(newUserCatId)) &&
-              Number(mapping.provider_category_id) === providerCategoryId &&
-              String(mapping.category_type || 'live') === String(restoredCategoryType));
-          }
+          grant_valid: grant === 1,
+          mapping_valid: validMapping
         });
-        if (result.skipped) stats.channels_skipped++;
-        else {
-          stats.channels += result.inserted;
-          stats.channels_merged += result.merged;
+      }
+
+      const grouped = mergeAssignmentGroups(candidates, { preserveLowestId: true });
+      const getAssignmentById = db.prepare('SELECT id FROM user_channels WHERE id = ?');
+      for (const group of grouped.groups) {
+        const candidate = { ...group.candidate };
+        candidate.id = group.validIds.find(id => !getAssignmentById.get(id)) || null;
+        const result = upsertMergedUserChannelAssignment(db, candidate, {
+          preserveId: true,
+          mappingValidator: mappingId => validateStoredMappingAssignment(db, {
+            mappingId,
+            userId: categoryOwnerMap.get(candidate.user_category_id),
+            userCategoryId: candidate.user_category_id,
+            providerChannelId: candidate.provider_channel_id
+          })
+        });
+        if (result.skipped) {
+          stats.channels_skipped++;
+          continue;
         }
+        stats.channels += result.inserted;
+        stats.channels_merged += group.duplicateCount + result.merged;
+        stats.channels_hidden += Number(result.hidden) === 1 ? 1 : 0;
+        stats.channels_authorization_revoked += Number(result.authorization_revoked) === 1 ? 1 : 0;
       }
 
     })();

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -12,6 +12,7 @@ import {
   normalizeAssignmentOrigin,
   upsertMergedUserChannelAssignment
 } from '../services/userChannelAssignmentService.js';
+import { validateStoredMappingAssignment } from '../services/categoryMappingService.js';
 
 const getClonedProviderChannelName = (channel) => {
   if (typeof channel.name === 'string' && channel.name.trim()) return channel.name;
@@ -350,15 +351,6 @@ export const createUser = async (req, res) => {
                     JOIN user_categories cat ON uc.user_category_id = cat.id
                     WHERE cat.user_id = ?
                 `).all(sourceUserId);
-                const getClonedMapping = db.prepare(`
-                    SELECT id, provider_id, user_id, user_category_id, provider_category_id,
-                           COALESCE(category_type, 'live') AS category_type
-                    FROM category_mappings
-                    WHERE id = ? AND user_id = ?
-                `);
-                const getClonedProvider = db.prepare("SELECT provider_id, original_category_id, COALESCE(stream_type, 'live') AS stream_type FROM provider_channels WHERE id = ?");
-                const getClonedCategory = db.prepare("SELECT COALESCE(type, 'live') AS type FROM user_categories WHERE id = ? AND user_id = ?");
-
                 for (const uc of sourceUserChans) {
                     const newCatId = categoryMap[uc.user_category_id];
                     const newProvChanId = channelMap[uc.provider_channel_id];
@@ -368,9 +360,6 @@ export const createUser = async (req, res) => {
                         const remappedMappingId = sourceOrigin === 'mapping'
                           ? mappingIdMap.get(Number(uc.mapping_id)) || null
                           : null;
-                        const provider = getClonedProvider.get(newProvChanId);
-                        const providerId = provider?.provider_id;
-                        const categoryType = String(getClonedCategory.get(newCatId, newUserId)?.type || 'live');
                         upsertMergedUserChannelAssignment(db, {
                             user_category_id: Number(newCatId),
                             provider_channel_id: Number(newProvChanId),
@@ -383,15 +372,12 @@ export const createUser = async (req, res) => {
                             authorization_revoked: Number(uc.authorization_revoked) === 1 ? 1 : 0,
                             grant_valid: false
                         }, {
-                            mappingValidator: mappingId => {
-                                const mapping = getClonedMapping.get(Number(mappingId), newUserId);
-                                return Boolean(mapping && Number(mapping.user_category_id) === Number(newCatId) &&
-                                    Number(mapping.provider_id) === Number(providerId) &&
-                                    Number(mapping.provider_category_id) === Number(provider?.original_category_id) &&
-                                    String(mapping.category_type || 'live') === categoryType &&
-                                    (String(provider?.stream_type || 'live') === String(mapping.category_type || 'live') ||
-                                      String(provider?.stream_type || 'live') === 'live' && String(mapping.category_type || 'live') === 'radio'));
-                            }
+                            mappingValidator: mappingId => validateStoredMappingAssignment(db, {
+                                mappingId,
+                                userId: newUserId,
+                                userCategoryId: newCatId,
+                                providerChannelId: newProvChanId
+                            })
                         });
                     }
                 }

--- a/src/services/categoryMappingService.js
+++ b/src/services/categoryMappingService.js
@@ -147,9 +147,42 @@ export function reconcileMappingAssignments(database, mapping, targetId, { mappi
   let assignmentsMoved = 0;
   let duplicatesMerged = 0;
   for (const assignment of ownedAssignments) {
-    if (Number(assignment.user_category_id) === Number(targetId)) continue;
+    const mappingValid = isValidMapping(mapping.id, {
+      ...assignment,
+      user_category_id: targetId
+    });
+    if (Number(assignment.user_category_id) === Number(targetId)) {
+      if (!mappingValid) {
+        update.run(
+          assignment.user_category_id,
+          assignment.sort_order,
+          assignment.custom_name || '',
+          Number(assignment.is_hidden) === 1 ? 1 : 0,
+          'legacy',
+          null,
+          Number(assignment.granted_by_admin) === 1 ? 1 : 0,
+          Number(assignment.authorization_revoked) === 1 ? 1 : 0,
+          assignment.id
+        );
+      }
+      continue;
+    }
     const targetRows = findTarget.all(targetId, assignment.provider_channel_id);
     if (targetRows.length === 0) {
+      if (!mappingValid) {
+        update.run(
+          assignment.user_category_id,
+          assignment.sort_order,
+          assignment.custom_name || '',
+          Number(assignment.is_hidden) === 1 ? 1 : 0,
+          'legacy',
+          null,
+          Number(assignment.granted_by_admin) === 1 ? 1 : 0,
+          Number(assignment.authorization_revoked) === 1 ? 1 : 0,
+          assignment.id
+        );
+        continue;
+      }
       if (update.run(
         targetId,
         assignment.sort_order,

--- a/src/services/categoryMappingService.js
+++ b/src/services/categoryMappingService.js
@@ -1,0 +1,297 @@
+import {
+  mergeAssignmentCandidates,
+  rebindSeriesEpisodeAliases
+} from './userChannelAssignmentService.js';
+
+const normalizeType = value => String(value || 'live').toLowerCase();
+
+export function validateMappingAssignmentRelationship({
+  mapping,
+  userId,
+  userCategoryId,
+  userCategoryType,
+  providerId,
+  providerCategoryId,
+  providerStreamType
+} = {}) {
+  if (!mapping) return false;
+
+  const mappingProviderCategoryId = Number(mapping.provider_category_id);
+  const restoredProviderCategoryId = Number(providerCategoryId);
+  if (!Number.isInteger(Number(mapping.id)) || Number(mapping.id) <= 0 ||
+      !Number.isInteger(Number(mapping.user_id)) || Number(mapping.user_id) !== Number(userId) ||
+      !Number.isInteger(Number(mapping.user_category_id)) || Number(mapping.user_category_id) !== Number(userCategoryId) ||
+      !Number.isInteger(Number(mapping.provider_id)) || Number(mapping.provider_id) !== Number(providerId) ||
+      !Number.isInteger(mappingProviderCategoryId) || !Number.isInteger(restoredProviderCategoryId) ||
+      mappingProviderCategoryId !== restoredProviderCategoryId) {
+    return false;
+  }
+
+  const mappingType = normalizeType(mapping.category_type);
+  const categoryType = normalizeType(userCategoryType);
+  const streamType = normalizeType(providerStreamType);
+  return mappingType === categoryType &&
+    ((mappingType !== 'radio' && streamType === mappingType) ||
+      (streamType === 'live' && mappingType === 'radio'));
+}
+
+const mappingSelect = `
+  SELECT id, provider_id, user_id, provider_category_id, provider_category_name,
+         user_category_id, auto_created, COALESCE(category_type, 'live') AS category_type
+  FROM category_mappings
+`;
+
+export function getCategoryMapping(database, mappingId) {
+  return database.prepare(`${mappingSelect} WHERE id = ?`).get(mappingId);
+}
+
+export function validateStoredMappingAssignment(database, {
+  mappingId,
+  userId,
+  userCategoryId,
+  providerChannelId
+} = {}) {
+  const mapping = getCategoryMapping(database, mappingId);
+  const category = database.prepare(`
+    SELECT id, user_id, COALESCE(type, 'live') AS type
+    FROM user_categories
+    WHERE id = ?
+  `).get(userCategoryId);
+  const channel = database.prepare(`
+    SELECT provider_id, original_category_id, COALESCE(stream_type, 'live') AS stream_type
+    FROM provider_channels
+    WHERE id = ?
+  `).get(providerChannelId);
+  return Boolean(category && channel && category.user_id === Number(userId) &&
+    validateMappingAssignmentRelationship({
+      mapping,
+      userId,
+      userCategoryId,
+      userCategoryType: category.type,
+      providerId: channel.provider_id,
+      providerCategoryId: channel.original_category_id,
+      providerStreamType: channel.stream_type
+    }));
+}
+
+export function validateMappingTarget(database, mapping, targetId) {
+  if (targetId === null) return true;
+  const target = database.prepare(`
+    SELECT id, user_id, COALESCE(type, 'live') AS type
+    FROM user_categories
+    WHERE id = ?
+  `).get(targetId);
+  return Boolean(target && Number(target.user_id) === Number(mapping.user_id) &&
+    normalizeType(target.type) === normalizeType(mapping.category_type));
+}
+
+export function reconcileMappingAssignments(database, mapping, targetId, { mappingValidator } = {}) {
+  const ownedAssignments = database.prepare(`
+    SELECT uc.*
+    FROM user_channels uc
+    WHERE uc.mapping_id = ? AND uc.assignment_origin = 'mapping'
+    ORDER BY uc.id
+  `).all(mapping.id);
+
+  if (targetId === null) {
+    const remove = database.prepare(`
+      DELETE FROM user_channels
+      WHERE id = ? AND mapping_id = ? AND assignment_origin = 'mapping'
+    `);
+    let removed = 0;
+    for (const assignment of ownedAssignments) removed += remove.run(assignment.id, mapping.id).changes;
+    return { assignments_removed: removed, assignments_moved: 0, duplicates_merged: 0 };
+  }
+
+  if (!validateMappingTarget(database, mapping, targetId)) return null;
+
+  const target = database.prepare(`
+    SELECT id, user_id, COALESCE(type, 'live') AS type
+    FROM user_categories
+    WHERE id = ?
+  `).get(targetId);
+  const findTarget = database.prepare(`
+    SELECT * FROM user_channels
+    WHERE user_category_id = ? AND provider_channel_id = ?
+    ORDER BY id
+  `);
+  const update = database.prepare(`
+    UPDATE user_channels
+    SET user_category_id = ?, sort_order = ?, custom_name = ?, is_hidden = ?,
+        assignment_origin = ?, mapping_id = ?, granted_by_admin = ?, authorization_revoked = ?
+    WHERE id = ?
+  `);
+  const deleteAssignment = database.prepare('DELETE FROM user_channels WHERE id = ?');
+
+  const isValidMapping = (mappingId, row) => {
+    if (mappingValidator) return mappingValidator(mappingId, row);
+    const provider = database.prepare(`
+      SELECT provider_id, original_category_id, COALESCE(stream_type, 'live') AS stream_type
+      FROM provider_channels
+      WHERE id = ?
+    `).get(row?.provider_channel_id);
+    const candidate = Number(mappingId) === Number(mapping.id)
+      ? { ...mapping, user_category_id: targetId }
+      : getCategoryMapping(database, mappingId);
+    return Boolean(provider && validateMappingAssignmentRelationship({
+      mapping: candidate,
+      userId: mapping.user_id,
+      userCategoryId: targetId,
+      userCategoryType: target.type,
+      providerId: provider.provider_id,
+      providerCategoryId: provider.original_category_id,
+      providerStreamType: provider.stream_type
+    }));
+  };
+
+  let assignmentsMoved = 0;
+  let duplicatesMerged = 0;
+  for (const assignment of ownedAssignments) {
+    if (Number(assignment.user_category_id) === Number(targetId)) continue;
+    const targetRows = findTarget.all(targetId, assignment.provider_channel_id);
+    if (targetRows.length === 0) {
+      if (update.run(
+        targetId,
+        assignment.sort_order,
+        assignment.custom_name || '',
+        Number(assignment.is_hidden) === 1 ? 1 : 0,
+        'mapping',
+        mapping.id,
+        Number(assignment.granted_by_admin) === 1 ? 1 : 0,
+        Number(assignment.authorization_revoked) === 1 ? 1 : 0,
+        assignment.id
+      ).changes === 1) assignmentsMoved++;
+      continue;
+    }
+
+    const merged = mergeAssignmentCandidates(
+      [...targetRows, { ...assignment, user_category_id: targetId }],
+      { mappingValidator: isValidMapping }
+    );
+    const survivorId = Number(merged.id);
+    const survivorIsSource = survivorId === Number(assignment.id);
+    const survivor = survivorIsSource
+      ? assignment
+      : targetRows.find(row => Number(row.id) === survivorId) || targetRows[0];
+    const losers = targetRows.filter(row => Number(row.id) !== Number(survivor.id));
+
+    if (survivorIsSource) {
+      for (const loser of targetRows) {
+        rebindSeriesEpisodeAliases(database, assignment.id, loser.id);
+        deleteAssignment.run(loser.id);
+      }
+      update.run(
+        targetId,
+        merged.sort_order,
+        merged.custom_name || '',
+        merged.is_hidden,
+        merged.assignment_origin,
+        merged.mapping_id,
+        merged.granted_by_admin,
+        merged.authorization_revoked,
+        assignment.id
+      );
+      assignmentsMoved++;
+    } else {
+      update.run(
+        targetId,
+        merged.sort_order,
+        merged.custom_name || '',
+        merged.is_hidden,
+        merged.assignment_origin,
+        merged.mapping_id,
+        merged.granted_by_admin,
+        merged.authorization_revoked,
+        survivor.id
+      );
+      for (const loser of losers) {
+        rebindSeriesEpisodeAliases(database, survivor.id, loser.id);
+        deleteAssignment.run(loser.id);
+      }
+      rebindSeriesEpisodeAliases(database, survivor.id, assignment.id);
+      deleteAssignment.run(assignment.id);
+    }
+    duplicatesMerged++;
+  }
+
+  return { assignments_removed: 0, assignments_moved: assignmentsMoved, duplicates_merged: duplicatesMerged };
+}
+
+export function retargetCategoryMapping(database, mapping, targetId) {
+  if (!validateMappingTarget(database, mapping, targetId)) return null;
+  const reconciliation = reconcileMappingAssignments(database, mapping, targetId);
+  if (!reconciliation) return null;
+  const updated = database.prepare(`
+    UPDATE category_mappings
+    SET user_category_id = ?
+    WHERE id = ? AND user_id = ?
+  `).run(targetId, mapping.id, mapping.user_id).changes === 1;
+  return updated ? { success: true, ...reconciliation } : null;
+}
+
+export function unmapCategoryMapping(database, mapping) {
+  return retargetCategoryMapping(database, mapping, null);
+}
+
+export function upsertCategoryMappingWithReconciliation(database, {
+  providerId,
+  userId,
+  providerCategoryId,
+  providerCategoryName,
+  categoryType = 'live',
+  targetCategoryId,
+  autoCreated = 0
+} = {}) {
+  const existing = database.prepare(`${mappingSelect}
+    WHERE provider_id = ? AND user_id = ? AND provider_category_id = ?
+      AND COALESCE(category_type, 'live') = ?
+  `).get(providerId, userId, providerCategoryId, categoryType);
+
+  if (!existing) {
+    if (!targetCategoryId) throw new Error('Mapping target required');
+    const info = database.prepare(`
+      INSERT INTO category_mappings
+        (provider_id, user_id, provider_category_id, provider_category_name, user_category_id, auto_created, category_type)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run(providerId, userId, providerCategoryId, providerCategoryName, targetCategoryId, autoCreated, categoryType);
+    return {
+      mapping: getCategoryMapping(database, info.lastInsertRowid),
+      user_category_id: Number(targetCategoryId),
+      reused: false,
+      retargeted: false
+    };
+  }
+
+  if (existing.user_category_id && validateMappingTarget(database, existing, existing.user_category_id)) {
+    const reconciliation = reconcileMappingAssignments(database, existing, existing.user_category_id);
+    if (!reconciliation) throw new Error('Invalid mapping target');
+    database.prepare(`
+      UPDATE category_mappings
+      SET provider_category_name = ?, auto_created = ?
+      WHERE id = ?
+    `).run(providerCategoryName, autoCreated, existing.id);
+    return {
+      mapping: getCategoryMapping(database, existing.id),
+      user_category_id: Number(existing.user_category_id),
+      reused: true,
+      retargeted: false,
+      reconciliation
+    };
+  }
+
+  if (!targetCategoryId) throw new Error('Mapping target required');
+  const retargeted = retargetCategoryMapping(database, existing, targetCategoryId);
+  if (!retargeted) throw new Error('Invalid mapping target');
+  database.prepare(`
+    UPDATE category_mappings
+    SET provider_category_name = ?, auto_created = ?, category_type = ?
+    WHERE id = ?
+  `).run(providerCategoryName, autoCreated, categoryType, existing.id);
+  return {
+    mapping: getCategoryMapping(database, existing.id),
+    user_category_id: Number(targetCategoryId),
+    reused: false,
+    retargeted: true,
+    reconciliation: retargeted
+  };
+}

--- a/src/services/userChannelAssignmentService.js
+++ b/src/services/userChannelAssignmentService.js
@@ -26,7 +26,12 @@ export function mergeAssignmentCandidates(candidates, { mappingValidator } = {})
     const aId = Number(a.id);
     const bId = Number(b.id);
     if (Number.isInteger(aId) && Number.isInteger(bId) && aId !== bId) return aId - bId;
-    return a._source_index - b._source_index;
+    const stableKey = row => JSON.stringify([
+      row.custom_name || '', row.sort_order, row.is_hidden,
+      row.mapping_id, row.provider_channel_id, row.granted_by_admin,
+      row.authorization_revoked, row.assignment_origin
+    ]);
+    return stableKey(a).localeCompare(stableKey(b));
   });
   let preferred = ordered[0];
   let assignmentOrigin = preferred.assignment_origin;
@@ -67,6 +72,36 @@ export function mergeAssignmentCandidates(candidates, { mappingValidator } = {})
     granted_by_admin: validGrant ? 1 : (requestedGrant ? 1 : 0),
     authorization_revoked: validGrant ? 0 : (rows.some(row => Number(row.authorization_revoked) === 1) ? 1 : 0)
   };
+}
+
+export function mergeAssignmentGroups(candidates, { mappingValidator, preserveLowestId = false } = {}) {
+  const groups = new Map();
+  let skipped = 0;
+  for (const candidate of candidates || []) {
+    const categoryId = Number(candidate?.user_category_id);
+    const providerChannelId = Number(candidate?.provider_channel_id);
+    if (!Number.isInteger(categoryId) || categoryId <= 0 ||
+        !Number.isInteger(providerChannelId) || providerChannelId <= 0) {
+      skipped++;
+      continue;
+    }
+    const key = `${categoryId}:${providerChannelId}`;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(candidate);
+  }
+
+  const merged = [];
+  for (const [key, rows] of [...groups.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+    const candidate = mergeAssignmentCandidates(rows, { mappingValidator });
+    if (!candidate) continue;
+    const validIds = rows
+      .map(row => Number(row.id))
+      .filter(id => Number.isInteger(id) && id > 0)
+      .sort((a, b) => a - b);
+    if (preserveLowestId && validIds.length > 0) candidate.id = validIds[0];
+    merged.push({ key, candidate, rows, duplicateCount: Math.max(0, rows.length - 1), validIds });
+  }
+  return { groups: merged, skipped };
 }
 
 export function rebindSeriesEpisodeAliases(database, survivorId, loserId) {

--- a/tests/category_mapping_import_regression.test.js
+++ b/tests/category_mapping_import_regression.test.js
@@ -150,4 +150,19 @@ describe('category import mapping lifecycle', () => {
     }), bulk);
     expect(bulk.json).toHaveBeenCalledWith(expect.objectContaining({ success: true, channels_imported: 0 }));
   });
+
+  it('rejects blank single category IDs and skips them in bulk imports', async () => {
+    const { providerId } = addProvider();
+    const single = response();
+    await importCategory(request(providerId, {
+      user_id: 1, category_id: ' ', category_name: 'Invalid', import_channels: true, type: 'live'
+    }), single);
+    expect(single.status).toHaveBeenCalledWith(400);
+
+    const bulk = response();
+    await importCategories(request(providerId, {
+      user_id: 1, categories: [{ id: null, name: 'Invalid', import_channels: true, type: 'live' }]
+    }), bulk);
+    expect(bulk.json).toHaveBeenCalledWith(expect.objectContaining({ success: true, categories_imported: 0 }));
+  });
 });

--- a/tests/category_mapping_import_regression.test.js
+++ b/tests/category_mapping_import_regression.test.js
@@ -1,0 +1,129 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'fs';
+
+const { TEST_DB_DIR } = vi.hoisted(() => {
+  const fsModule = require('fs');
+  const os = require('os');
+  const path = require('path');
+  return { TEST_DB_DIR: fsModule.mkdtempSync(path.join(os.tmpdir(), 'iptv-category-import-')) };
+});
+
+vi.mock('../src/config/constants.js', () => ({
+  DATA_DIR: TEST_DB_DIR,
+  EPG_DB_PATH: `${TEST_DB_DIR}/epg.db`,
+  BCRYPT_ROUNDS: 1,
+  DEFAULT_USER_AGENT: 'TestAgent'
+}));
+vi.mock('../src/services/cacheService.js', () => ({ clearChannelsCache: vi.fn() }));
+vi.mock('../src/services/epgService.js', () => ({ updateProviderEpg: vi.fn() }));
+vi.mock('../src/services/syncService.js', () => ({
+  performSync: vi.fn(),
+  checkProviderExpiry: vi.fn(async () => {}),
+  deleteProviderChannelCascade: vi.fn()
+}));
+vi.mock('../src/utils/network.js', () => ({ fetchSafe: vi.fn(async () => ({ ok: false })) }));
+vi.mock('../src/utils/crypto.js', () => ({
+  encrypt: value => String(value || ''),
+  decrypt: value => String(value || ''),
+  JWT_SECRET: 'test-secret',
+  ENCRYPTION_KEY: 'test-key-32-bytes-length-12345678'
+}));
+
+import db, { initDb } from '../src/database/db.js';
+import { importCategory, importCategories } from '../src/controllers/providerController.js';
+
+const response = () => ({ json: vi.fn(), status: vi.fn().mockReturnThis() });
+
+describe('category import mapping lifecycle', () => {
+  beforeAll(() => initDb(true));
+
+  beforeEach(() => {
+    db.pragma('foreign_keys = OFF');
+    for (const table of ['user_channels', 'category_mappings', 'provider_channels', 'providers', 'user_categories', 'users']) {
+      db.prepare(`DELETE FROM ${table}`).run();
+    }
+    db.pragma('foreign_keys = ON');
+    db.prepare("INSERT INTO users (id, username, password) VALUES (1, 'user', 'p')").run();
+  });
+
+  afterAll(() => {
+    db.close();
+    fs.rmSync(TEST_DB_DIR, { recursive: true, force: true });
+  });
+
+  const addProvider = () => {
+    const providerId = db.prepare(`
+      INSERT INTO providers (name, url, username, password, user_id)
+      VALUES ('Provider', 'http://provider.example', 'u', 'p', 1)
+    `).run().lastInsertRowid;
+    const channelId = db.prepare(`
+      INSERT INTO provider_channels
+        (provider_id, remote_stream_id, name, original_category_id, stream_type)
+      VALUES (?, 10, 'Channel', 10, 'live')
+    `).run(providerId).lastInsertRowid;
+    return { providerId: Number(providerId), channelId: Number(channelId) };
+  };
+
+  const request = (providerId, body) => ({
+    params: { providerId: String(providerId) },
+    body,
+    user: { id: 1, is_admin: true }
+  });
+
+  it('reuses the existing mapped target on repeated single imports', async () => {
+    const { providerId } = addProvider();
+    const body = { user_id: 1, category_id: 10, category_name: 'News', import_channels: true, type: 'live' };
+    const first = response();
+    await importCategory(request(providerId, body), first);
+    const firstId = first.json.mock.calls[0][0].category_id;
+    const second = response();
+    await importCategory(request(providerId, body), second);
+
+    expect(second.json.mock.calls[0][0]).toEqual(expect.objectContaining({ category_id: firstId, category_reused: true }));
+    expect(db.prepare('SELECT COUNT(*) AS count FROM user_categories').get().count).toBe(1);
+    expect(db.prepare('SELECT COUNT(*) AS count FROM category_mappings').get().count).toBe(1);
+    expect(db.prepare('SELECT COUNT(*) AS count FROM user_channels').get().count).toBe(1);
+    expect(db.prepare('SELECT assignment_origin FROM user_channels').get()).toEqual({ assignment_origin: 'mapping' });
+  });
+
+  it('reuses existing targets and merges assignments in repeated bulk imports', async () => {
+    const { providerId } = addProvider();
+    const body = {
+      user_id: 1,
+      categories: [{ id: 10, name: 'News', import_channels: true, type: 'live' }]
+    };
+    const first = response();
+    await importCategories(request(providerId, body), first);
+    const second = response();
+    await importCategories(request(providerId, body), second);
+
+    expect(second.json.mock.calls[0][0]).toEqual(expect.objectContaining({ categories_imported: 1, channels_imported: 0 }));
+    expect(db.prepare('SELECT COUNT(*) AS count FROM user_categories').get().count).toBe(1);
+    expect(db.prepare('SELECT COUNT(*) AS count FROM user_channels').get().count).toBe(1);
+  });
+
+  it('repairs mapping-owned rows stranded outside the current target', async () => {
+    const { providerId, channelId } = addProvider();
+    const oldCategoryId = db.prepare("INSERT INTO user_categories (user_id, name, type) VALUES (1, 'Old', 'live')").run().lastInsertRowid;
+    const targetCategoryId = db.prepare("INSERT INTO user_categories (user_id, name, type) VALUES (1, 'News', 'live')").run().lastInsertRowid;
+    const mappingId = db.prepare(`
+      INSERT INTO category_mappings
+        (provider_id, user_id, provider_category_id, provider_category_name, user_category_id, category_type)
+      VALUES (?, 1, 10, 'News', ?, 'live')
+    `).run(providerId, targetCategoryId).lastInsertRowid;
+    db.prepare(`
+      INSERT INTO user_channels
+        (user_category_id, provider_channel_id, assignment_origin, mapping_id)
+      VALUES (?, ?, 'mapping', ?)
+    `).run(oldCategoryId, channelId, mappingId);
+
+    const res = response();
+    await importCategory(request(providerId, {
+      user_id: 1, category_id: 10, category_name: 'News', import_channels: true, type: 'live'
+    }), res);
+
+    expect(db.prepare('SELECT user_category_id, assignment_origin, mapping_id FROM user_channels').get()).toEqual({
+      user_category_id: Number(targetCategoryId), assignment_origin: 'mapping', mapping_id: Number(mappingId)
+    });
+  });
+});

--- a/tests/category_mapping_import_regression.test.js
+++ b/tests/category_mapping_import_regression.test.js
@@ -90,10 +90,11 @@ describe('category import mapping lifecycle', () => {
     const { providerId } = addProvider();
     const body = {
       user_id: 1,
-      categories: [{ id: 10, name: 'News', import_channels: true, type: 'live' }]
+      categories: [{ id: '10', name: 'News', import_channels: true, type: 'live' }]
     };
     const first = response();
     await importCategories(request(providerId, body), first);
+    expect(first.json.mock.calls[0][0].results[0].category_id).toBe('10');
     const second = response();
     await importCategories(request(providerId, body), second);
 

--- a/tests/category_mapping_import_regression.test.js
+++ b/tests/category_mapping_import_regression.test.js
@@ -126,4 +126,28 @@ describe('category import mapping lifecycle', () => {
       user_category_id: Number(targetCategoryId), assignment_origin: 'mapping', mapping_id: Number(mappingId)
     });
   });
+
+  it('accepts uncategorized provider category zero for single and bulk imports', async () => {
+    const providerId = db.prepare(`
+      INSERT INTO providers (name, url, username, password, user_id)
+      VALUES ('Provider', 'http://provider.example', 'u', 'p', 1)
+    `).run().lastInsertRowid;
+    db.prepare(`
+      INSERT INTO provider_channels
+        (provider_id, remote_stream_id, name, original_category_id, stream_type)
+      VALUES (?, 11, 'Uncategorized', 0, 'live')
+    `).run(providerId);
+
+    const single = response();
+    await importCategory(request(providerId, {
+      user_id: 1, category_id: '0', category_name: 'Uncategorized', import_channels: true, type: 'live'
+    }), single);
+    expect(single.json).toHaveBeenCalledWith(expect.objectContaining({ success: true, channels_imported: 1 }));
+
+    const bulk = response();
+    await importCategories(request(providerId, {
+      user_id: 1, categories: [{ id: '0', name: 'Uncategorized', import_channels: true, type: 'live' }]
+    }), bulk);
+    expect(bulk.json).toHaveBeenCalledWith(expect.objectContaining({ success: true, channels_imported: 0 }));
+  });
 });

--- a/tests/controllers/backup_restore_authorization.test.js
+++ b/tests/controllers/backup_restore_authorization.test.js
@@ -274,6 +274,62 @@ describe('user backup restore authorization', () => {
     });
   });
 
+  it.each([
+    [[200, 100]],
+    [[100, 200]],
+  ])('normalizes duplicate backup rows independently of payload order (%s)', (order) => {
+    const providerChannelId = addProviderChannel(1);
+    const data = backupData(1);
+    data.format_version = 2;
+    data.assignment_provenance_version = 1;
+    data.userChannels = order.map(id => ({
+      id,
+      user_category_id: 100,
+      provider_channel_id: providerChannelId,
+      sort_order: id === 100 ? 1 : 4,
+      custom_name: id === 100 ? '' : 'Stable name',
+      is_hidden: id === 100 ? 0 : 1,
+      assignment_origin: id === 100 ? 'mapping' : 'manual',
+      mapping_id: null,
+    }));
+    const backupId = addBackup(data);
+
+    restore(backupId);
+
+    expect(db.prepare(`
+      SELECT id, sort_order, custom_name, is_hidden, assignment_origin
+      FROM user_channels
+    `).get()).toEqual({
+      id: 100,
+      sort_order: 1,
+      custom_name: 'Stable name',
+      is_hidden: 1,
+      assignment_origin: 'manual'
+    });
+  });
+
+  it('falls back to the next valid source ID when the lowest ID collides', () => {
+    const providerChannelId = addProviderChannel(1);
+    db.prepare("INSERT INTO user_categories (id, user_id, name, type) VALUES (900, 2, 'Other', 'series')").run();
+    db.prepare(`
+      INSERT INTO user_channels (id, user_category_id, provider_channel_id, assignment_origin)
+      VALUES (100, 900, ?, 'legacy')
+    `).run(providerChannelId);
+    const data = backupData(1);
+    data.userChannels = [
+      { id: 200, user_category_id: 100, provider_channel_id: providerChannelId, assignment_origin: 'legacy' },
+      { id: 100, user_category_id: 100, provider_channel_id: providerChannelId, assignment_origin: 'legacy' },
+    ];
+    const backupId = addBackup(data);
+
+    restore(backupId);
+
+    expect(db.prepare(`
+      SELECT id FROM user_channels
+      WHERE user_category_id = 100 AND provider_channel_id = ?
+    `).get(providerChannelId)).toEqual({ id: 200 });
+  });
+
   it('uses current ownership and skips missing provider channels', () => {
     const providerChannelId = addProviderChannel(1);
     const data = backupData(1, { provider_channel_id: providerChannelId, granted_by_admin: 0 });

--- a/tests/controllers/channelController.test.js
+++ b/tests/controllers/channelController.test.js
@@ -755,7 +755,7 @@ describe('Channel Controller - createUserCategory', () => {
             (provider_id, user_id, provider_category_id, provider_category_name, user_category_id, category_type)
           VALUES (?, 2, 77, 'Provider', ?, 'live')
         `).run(provider, source).lastInsertRowid;
-        const channel = db.prepare("INSERT INTO provider_channels (provider_id, remote_stream_id, name, stream_type) VALUES (?, 77, 'Series', 'live')").run(provider).lastInsertRowid;
+        const channel = db.prepare("INSERT INTO provider_channels (provider_id, remote_stream_id, name, original_category_id, stream_type) VALUES (?, 77, 'Series', 77, 'live')").run(provider).lastInsertRowid;
         const assignment = db.prepare(`
           INSERT INTO user_channels
             (user_category_id, provider_channel_id, sort_order, custom_name, is_hidden, assignment_origin, mapping_id)
@@ -780,6 +780,34 @@ describe('Channel Controller - createUserCategory', () => {
           .toEqual({ user_category_id: target, mapping_id: mapping, is_hidden: 1, custom_name: 'Custom' });
         expect(db.prepare('SELECT id, user_channel_id FROM series_episode_aliases WHERE id = ?').get(alias))
           .toEqual({ id: alias, user_channel_id: assignment });
+    });
+
+    it('demotes stale mapping-owned assignments before retargeting', () => {
+        const provider = db.prepare("INSERT INTO providers (name, url, username, password, user_id) VALUES ('Stale Mapping Provider', 'http://provider.test', 'u', 'p', 2)").run().lastInsertRowid;
+        const source = db.prepare("INSERT INTO user_categories (user_id, name, type) VALUES (2, 'Stale Source', 'live')").run().lastInsertRowid;
+        const target = db.prepare("INSERT INTO user_categories (user_id, name, type) VALUES (2, 'Stale Target', 'live')").run().lastInsertRowid;
+        const mapping = db.prepare(`
+          INSERT INTO category_mappings
+            (provider_id, user_id, provider_category_id, provider_category_name, user_category_id, category_type)
+          VALUES (?, 2, 77, 'Provider', ?, 'live')
+        `).run(provider, source).lastInsertRowid;
+        const channel = db.prepare("INSERT INTO provider_channels (provider_id, remote_stream_id, name, original_category_id, stream_type) VALUES (?, 77, 'Stale Channel', 99, 'live')").run(provider).lastInsertRowid;
+        const assignment = db.prepare(`
+          INSERT INTO user_channels (user_category_id, provider_channel_id, assignment_origin, mapping_id)
+          VALUES (?, ?, 'mapping', ?)
+        `).run(source, channel, mapping).lastInsertRowid;
+        const res = response();
+
+        channelController.updateCategoryMapping({
+            params: { id: String(mapping) }, body: { user_category_id: String(target) },
+            user: { id: 2, is_admin: false }
+        }, res);
+
+        expect(res.json).toHaveBeenCalledWith({
+            success: true, assignments_removed: 0, assignments_moved: 0, duplicates_merged: 0
+        });
+        expect(db.prepare('SELECT user_category_id, assignment_origin, mapping_id FROM user_channels WHERE id = ?').get(assignment))
+          .toEqual({ user_category_id: source, assignment_origin: 'legacy', mapping_id: null });
     });
 
     it('merges a retargeted assignment into a manual target and preserves aliases', () => {

--- a/tests/export_regression.test.js
+++ b/tests/export_regression.test.js
@@ -295,6 +295,60 @@ describe('Export/Import Regression Tests', () => {
         ]);
     });
 
+    it('preserves validated modern mapping provenance after ID remapping', async () => {
+        db.prepare('PRAGMA foreign_keys = OFF').run();
+        for (const table of ['user_channels', 'category_mappings', 'sync_configs', 'provider_channels', 'providers', 'user_categories', 'users']) {
+            db.prepare(`DELETE FROM ${table}`).run();
+        }
+        db.prepare('PRAGMA foreign_keys = ON').run();
+
+        const userId = db.prepare("INSERT INTO users (username, password) VALUES ('mapped_import', 'pass')").run().lastInsertRowid;
+        const providerId = db.prepare(`
+            INSERT INTO providers (name, url, username, password, user_id)
+            VALUES ('Mapped Provider', 'http://mapped.example', 'u', ?, ?)
+        `).run(encrypt('provider-pass'), userId).lastInsertRowid;
+        const channelId = db.prepare(`
+            INSERT INTO provider_channels (provider_id, remote_stream_id, name, original_category_id, stream_type)
+            VALUES (?, 701, 'Mapped Series', 77, 'series')
+        `).run(providerId).lastInsertRowid;
+        const categoryId = db.prepare("INSERT INTO user_categories (user_id, name, type) VALUES (?, 'Mapped', 'series')").run(userId).lastInsertRowid;
+        const mappingId = db.prepare(`
+            INSERT INTO category_mappings
+              (provider_id, user_id, provider_category_id, provider_category_name, user_category_id, category_type)
+            VALUES (?, ?, 77, 'Mapped', ?, 'series')
+        `).run(providerId, userId, categoryId).lastInsertRowid;
+        db.prepare(`
+            INSERT INTO user_channels (user_category_id, provider_channel_id, assignment_origin, mapping_id)
+            VALUES (?, ?, 'mapping', ?)
+        `).run(categoryId, channelId, mappingId);
+
+        let exportedBuffer;
+        systemController.exportData(
+            { user: { is_admin: true }, body: { password: TEST_EXPORT_PASSWORD, user_id: 'all' }, query: {} },
+            { setHeader: vi.fn(), status: vi.fn().mockReturnThis(), json: vi.fn(), send: vi.fn(buffer => { exportedBuffer = buffer; }) }
+        );
+        const exportedData = JSON.parse(zlib.gunzipSync(decryptWithPassword(exportedBuffer, TEST_EXPORT_PASSWORD)).toString('utf8'));
+        const sourceMappingId = exportedData.mappings.find(mapping => mapping.id === Number(mappingId)).id;
+        fs.writeFileSync(tempFilePath, encryptWithPassword(zlib.gzipSync(JSON.stringify(exportedData)), TEST_EXPORT_PASSWORD));
+
+        db.prepare('PRAGMA foreign_keys = OFF').run();
+        for (const table of ['user_channels', 'category_mappings', 'sync_configs', 'provider_channels', 'providers', 'user_categories', 'users']) {
+            db.prepare(`DELETE FROM ${table}`).run();
+        }
+        db.prepare('PRAGMA foreign_keys = ON').run();
+        const resImport = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+        await systemController.importData(
+            { user: { is_admin: true }, body: { password: TEST_EXPORT_PASSWORD }, file: { path: tempFilePath } },
+            resImport
+        );
+
+        const restored = db.prepare('SELECT assignment_origin, mapping_id FROM user_channels').get();
+        expect(restored.assignment_origin).toBe('mapping');
+        expect(Number(restored.mapping_id)).not.toBe(Number(sourceMappingId));
+        expect(db.prepare('SELECT provider_category_id FROM category_mappings WHERE id = ?').get(restored.mapping_id))
+            .toEqual({ provider_category_id: 77 });
+    });
+
     it('merges duplicate assignments during system import and reports unique counts', async () => {
         db.prepare('PRAGMA foreign_keys = OFF').run();
         for (const table of ['user_channels', 'category_mappings', 'sync_configs', 'provider_channels', 'providers', 'user_categories', 'users']) {


### PR DESCRIPTION
## Summary
- Fixes the version-2 system-import provenance regression caused by a missing `provider_category_id` in the mapping lookup.
- Centralizes mapping relationship validation and transactional reconciliation for mapping retargets and repeated single/bulk category imports.
- Pre-groups backup and system-import assignment payloads before writes for deterministic duplicate merges and stable IDs.

## Mapping integrity
- Modern mapping ownership is retained only when user, target category, provider, provider category, content type, stream compatibility, remapped mapping, and current authorization all match.
- Invalid or stale provenance is fail-safe demoted to an unowned legacy/imported assignment; assignments are not deleted solely for invalid provenance.
- Radio mappings accept live provider streams only.
- Clone, backup restore, system import, category imports, and mapping retarget validation use the shared relationship helper.
- Retargeting validates direct and already-targeted mapping rows; stale rows are demoted before lifecycle operations.

## Repeated category imports
- Existing valid mapping targets are reused.
- Mapping-owned rows are reconciled transactionally and missing provider-channel assignments are merged into the existing target.
- Manual, legacy, and imported assignments remain untouched.
- Uncategorized provider category ID `0` remains supported.
- Cache invalidation occurs after commit.

## Deterministic duplicate handling
- Backup and full-system imports group by target category/provider channel before inserting.
- Merge precedence preserves manual/legacy/imported ownership, hidden state, deterministic non-empty names, lowest sort order, series aliases, and fail-closed authorization.
- The lowest available positive source assignment ID is selected independent of payload order; unrelated ID collisions fall back deterministically.

## Validation
- `npm ci`: passed.
- `npm run lint`: passed (0 errors; 147 pre-existing warnings).
- `npm audit --audit-level=high`: 0 vulnerabilities.
- `npm audit --omit=dev --audit-level=high`: 0 vulnerabilities.
- `npm ci --dry-run`: passed.
- `npm run build`: passed.
- Focused regression suites: 4 files, 79 tests passed; broad focused coverage: 11 files, 132 tests passed.
- Three isolated final-head full suites: 93 files and 608 tests passed in each run.
- Docker image `iptv-manager-import-reconciliation-hotfix`: built successfully from the final head using the Colima Docker context (including a clean no-cache build).
- GitHub Actions: no workflow runs or combined status checks are configured for this repository.
- Real-client smoke tests: not run because no IPTVnator/OTT Navigator client binaries, session, or traffic-capture client were available in the environment; automated compatibility coverage was used instead.

## Review
- Final Codex review: “Didn't find any major issues”, reviewed commit `0065d10e2d`, issue comment `5146212309` at `2026-07-31T18:28:36Z`.
- No unresolved current-head P1/P2 findings; earlier findings are outdated on the final head.
- Fallback subagent review also found no P1; its only P2 matched the already-fixed direct-reconciliation issue.

## Compatibility
Existing sync, clone, migration, Stalker, Xtream, M3U, HDHomeRun, share, catch-up, empty-snapshot, large-catalog, and authorization regression coverage remains green.

## Readiness
Ready for normal protected-branch review and merge. No release, tag, publication, or deployment is included.