### PR TITLE
test: isolate database fixtures in CI tests

### DIFF
--- a/tests/controllers/channelController.test.js
+++ b/tests/controllers/channelController.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
 import fs from 'fs';
 
 const { TEST_DB_DIR } = vi.hoisted(() => {
@@ -34,18 +34,26 @@ vi.mock('../../src/utils/crypto.js', () => {
 
 // Import modules AFTER mocking
 import db, { initDb } from '../../src/database/db.js';
+import epgDb, { initEpgDb } from '../../src/database/epgDb.js';
 import * as channelController from '../../src/controllers/channelController.js';
 import { channelsJsonCache } from '../../src/services/cacheService.js';
 
 describe('Channel Controller - createUserCategory', () => {
+    beforeAll(() => {
+        initEpgDb();
+    });
+
     afterAll(() => {
         db.close();
+        epgDb.close();
         fs.rmSync(TEST_DB_DIR, { recursive: true, force: true });
     });
 
     beforeEach(() => {
         // Clear DB
         initDb(true);
+        epgDb.prepare('DELETE FROM epg_programs').run();
+        epgDb.prepare('DELETE FROM epg_channels').run();
         const tables = ['user_channels', 'category_mappings', 'user_categories', 'provider_channels', 'providers', 'users', 'admin_users'];
         db.pragma('foreign_keys = OFF');
         tables.forEach(t => db.prepare(`DELETE FROM ${t}`).run());

--- a/tests/controllers/xtream_channels_json.test.js
+++ b/tests/controllers/xtream_channels_json.test.js
@@ -1,10 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock dependencies
-const { mockDb } = vi.hoisted(() => {
+const { mockDb, mockEpgDb } = vi.hoisted(() => {
   return {
     mockDb: {
       prepare: vi.fn(),
+    },
+    mockEpgDb: {
+      prepare: vi.fn(() => ({ all: vi.fn(() => []) })),
     },
   };
 });
@@ -12,6 +15,10 @@ const { mockDb } = vi.hoisted(() => {
 vi.mock('../../src/database/db.js', () => ({
   default: mockDb,
   openDbConnection: vi.fn(() => ({ prepare: mockDb.prepare, close: vi.fn() })),
+}));
+
+vi.mock('../../src/database/epgDb.js', () => ({
+  default: mockEpgDb,
 }));
 
 vi.mock('node-fetch', () => ({

--- a/tests/managers/stream_manager_smart.test.js
+++ b/tests/managers/stream_manager_smart.test.js
@@ -10,7 +10,7 @@ describe('StreamManager Smart Limits', () => {
       mockStmt = {
         get: vi.fn(),
         run: vi.fn(),
-        all: vi.fn()
+        all: vi.fn().mockReturnValue([])
       };
       mockDb = {
         prepare: vi.fn().mockReturnValue(mockStmt)


### PR DESCRIPTION
## Summary
- initialize the EPG database in the channel controller fixture
- mock the EPG database in the Xtream controller fixture
- return an empty result from the SQLite stream mock

This removes misleading `no such table: epg_channels` and stale-cleanup messages from CI while retaining the intentional rollback-error coverage.

## Validation
- `npm test` — 95 files, 619 tests passed
- `npm run lint` — passed
- `git diff --check` — passed