### PR TITLE
fix: avoid logging handled upload errors as server failures

### DIFF
--- a/src/middleware/errorHandler.js
+++ b/src/middleware/errorHandler.js
@@ -1,9 +1,8 @@
 import multer from 'multer';
 
 export const errorHandler = (err, req, res, next) => {
-  console.error(err.stack);
-
   if (res.headersSent) {
+    console.error(err.stack);
     return next(err);
   }
 
@@ -19,5 +18,6 @@ export const errorHandler = (err, req, res, next) => {
   }
 
   // Default to 500
+  console.error(err.stack);
   res.status(500).json({ error: 'Internal Server Error' });
 };

--- a/tests/middleware_error.test.js
+++ b/tests/middleware_error.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import request from 'supertest';
 import express from 'express';
 import multer from 'multer';
@@ -57,5 +57,20 @@ describe('Error Handling Middleware', () => {
         expect(res.status).toBe(413);
         expect(res.headers['content-type']).toMatch(/json/);
         expect(res.body).toEqual({ error: 'Payload too large' });
+    });
+
+    it('should only log unexpected errors as server errors', async () => {
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        await request(app).get('/error');
+        expect(consoleError).toHaveBeenCalledOnce();
+
+        consoleError.mockClear();
+        await request(app).get('/multer-error');
+        await request(app).get('/multer-other-error');
+        await request(app).get('/body-parser-error');
+
+        expect(consoleError).not.toHaveBeenCalled();
+        consoleError.mockRestore();
     });
 });


### PR DESCRIPTION
## Summary
- keep Multer and body-parser limit responses unchanged
- avoid logging expected client input errors as server-error stack traces
- retain error logging for unexpected failures and already-started responses

## Validation
- `npm test` — 95 files, 620 tests passed
- `npm run lint` — passed
- `git diff --check` — passed