### PR TITLE
test: verify standard protocol output parity

### DIFF
--- a/tests/controllers/xtream_get_playlist.test.js
+++ b/tests/controllers/xtream_get_playlist.test.js
@@ -1,4 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const parityFixture = JSON.parse(
+  readFileSync(new URL('../fixtures/protocol-parity.json', import.meta.url), 'utf8'),
+);
+const playableSeries = parityFixture.series.find(({ id }) => id === 'series-playable');
+const unsynchronizedSeries = parityFixture.series.find(({ id }) => id === 'series-unsynchronized');
+const fixtureMovie = parityFixture.movies.find(({ id }) => id === 'movie-1');
 
 // Mock dependencies
 const { mockDb, aliasDb } = vi.hoisted(() => {
@@ -64,13 +72,13 @@ describe('xtreamController - getPlaylist (get.php)', () => {
     user_channel_id: 42,
     custom_name: null,
     user_category_id: 9,
-    name: 'My Show',
+    name: playableSeries.name,
     logo: 'series.png',
     epg_channel_id: '',
     manual_epg_id: null,
     stream_type: 'series',
     mime_type: 'mp4',
-    category_name: 'Serien DE',
+    category_name: playableSeries.categoryTitle,
     provider_id: 7,
     remote_stream_id: 555,
   };
@@ -78,7 +86,7 @@ describe('xtreamController - getPlaylist (get.php)', () => {
   const seriesWithoutEpisodes = {
     ...seriesWithEpisodes,
     user_channel_id: 43,
-    name: 'Unsynced Show',
+    name: unsynchronizedSeries.name,
     remote_stream_id: 556,
   };
 
@@ -86,13 +94,13 @@ describe('xtreamController - getPlaylist (get.php)', () => {
     user_channel_id: 100,
     custom_name: null,
     user_category_id: 5,
-    name: 'Movie A',
+    name: fixtureMovie.name,
     logo: 'movie.png',
     epg_channel_id: '',
     manual_epg_id: null,
     stream_type: 'movie',
     mime_type: 'mkv',
-    category_name: 'Filme',
+    category_name: fixtureMovie.categoryTitle,
     provider_id: 7,
     remote_stream_id: 900,
   };
@@ -165,9 +173,9 @@ describe('xtreamController - getPlaylist (get.php)', () => {
     expect(mockDb.prepare.mock.calls.some(([sql]) => sql.includes('JOIN authorized_user_channels uc'))).toBe(true);
 
     // Episode entries with SXX EXX naming
-    expect(output).toContain('tvg-name="My Show S01 E01"');
-    expect(output).toContain(',My Show S01 E01\n');
-    expect(output).toContain('tvg-name="My Show S01 E02"');
+    expect(output).toContain(`tvg-name="${playableSeries.name} S01 E01"`);
+    expect(output).toContain(`,${playableSeries.name} S01 E01\n`);
+    expect(output).toContain(`tvg-name="${playableSeries.name} S01 E02"`);
 
     expect(output).toContain('http://localhost/series/u/p/900000501.mkv');
     expect(output).toContain('http://localhost/series/u/p/900000502.mkv');
@@ -181,14 +189,15 @@ describe('xtreamController - getPlaylist (get.php)', () => {
     expect(output.match(/tvg-logo="series\.png"/g).length).toBeGreaterThanOrEqual(1);
 
     // Category preserved on episode entries
-    expect(output).toContain('group-title="Serien DE",My Show S01 E01');
+    expect(output).toContain(`group-title="${playableSeries.categoryTitle}",${playableSeries.name} S01 E01`);
+    expect(output).toContain('group-id="9"');
   });
 
   it('omits unsynchronized series instead of emitting a bare assignment URL', async () => {
     await getPlaylist(req, res);
 
     const output = collectOutput();
-    expect(output).not.toContain('tvg-name="Unsynced Show"');
+    expect(output).not.toContain(`tvg-name="${unsynchronizedSeries.name}"`);
     expect(output).not.toContain('/series/u/p/43.');
   });
 
@@ -196,7 +205,7 @@ describe('xtreamController - getPlaylist (get.php)', () => {
     await getPlaylist(req, res);
 
     const output = collectOutput();
-    expect(output).toContain('tvg-name="Movie A"');
+    expect(output).toContain(`tvg-name="${fixtureMovie.name}"`);
     expect(output).toContain('http://localhost/movie/u/p/100.mkv');
   });
 
@@ -205,7 +214,7 @@ describe('xtreamController - getPlaylist (get.php)', () => {
     await getPlaylist(req, res);
 
     const output = collectOutput();
-    expect(output).toContain('#EXTINF:-1,My Show S01 E01\n');
+    expect(output).toContain(`#EXTINF:-1,${playableSeries.name} S01 E01\n`);
     expect(output).toContain('http://localhost/series/u/p/900000501.mkv');
     expect(output).not.toContain('tvg-name="My Show S01 E01"');
   });
@@ -222,5 +231,12 @@ describe('xtreamController - getPlaylist (get.php)', () => {
     expect(output).not.toContain('Injected');
     expect(output).not.toContain('token=secret');
     expect(output.split('\n').filter(line => line.startsWith('#EXTINF')).length).toBe(3);
+  });
+
+  it('uses the sanitized fixture without expanding the protocol contract', () => {
+    expect(parityFixture.live.filter(({ authorized }) => authorized)).toHaveLength(3);
+    expect(parityFixture.live.filter(({ authorized }) => !authorized)).toHaveLength(1);
+    expect(parityFixture.series.find(({ id }) => id === 'series-unsynchronized').episodes).toHaveLength(0);
+    expect(parityFixture.playlist.filter(({ tvgId }) => tvgId === 'fixture.same')).toHaveLength(2);
   });
 });

--- a/tests/fixtures/protocol-parity.json
+++ b/tests/fixtures/protocol-parity.json
@@ -1,5 +1,5 @@
 {
-  "fixtureVersion": 1,
+  "fixtureVersion": 2,
   "live": [
     {
       "id": "live-news-1",
@@ -7,6 +7,7 @@
       "categoryId": "10",
       "categoryTitle": "News",
       "groupId": "live-10",
+      "epgId": "fixture.same",
       "authorized": true,
       "adult": false
     },
@@ -16,6 +17,7 @@
       "categoryId": "12",
       "categoryTitle": "News Duplicate",
       "groupId": "live-12",
+      "epgId": "fixture.same",
       "authorized": true,
       "adult": false
     },
@@ -25,6 +27,7 @@
       "categoryId": "11",
       "categoryTitle": "Adult",
       "groupId": "live-11",
+      "epgId": "fixture.adult",
       "authorized": true,
       "adult": true
     },
@@ -119,12 +122,28 @@
       "url": "https://fixture.test/live/42.ts?quality=sd&token=two"
     },
     {
+      "type": "live",
+      "tvgId": "fixture.adult",
+      "groupId": "live-11",
+      "groupTitle": "Adult",
+      "name": "Fixture Adult Live",
+      "url": "https://fixture.test/live/43.ts?token=adult"
+    },
+    {
       "type": "movie",
       "tvgId": "",
       "groupId": "movie-20",
       "groupTitle": "Same Name",
       "name": "Fixture Movie",
       "url": "https://fixture.test/movie/200.mp4?expires=1"
+    },
+    {
+      "type": "movie",
+      "tvgId": "",
+      "groupId": "movie-21",
+      "groupTitle": "Adult Movies",
+      "name": "Fixture Adult Movie",
+      "url": "https://fixture.test/movie/201.mp4?token=adult"
     },
     {
       "type": "series",
@@ -144,4 +163,3 @@
     }
   ]
 }
-

--- a/tests/fixtures/protocol-parity.json
+++ b/tests/fixtures/protocol-parity.json
@@ -1,0 +1,147 @@
+{
+  "fixtureVersion": 1,
+  "live": [
+    {
+      "id": "live-news-1",
+      "name": "Fixture News",
+      "categoryId": "10",
+      "categoryTitle": "News",
+      "groupId": "live-10",
+      "authorized": true,
+      "adult": false
+    },
+    {
+      "id": "live-news-1",
+      "name": "Fixture News duplicate",
+      "categoryId": "12",
+      "categoryTitle": "News Duplicate",
+      "groupId": "live-12",
+      "authorized": true,
+      "adult": false
+    },
+    {
+      "id": "live-adult-1",
+      "name": "Fixture Adult Live",
+      "categoryId": "11",
+      "categoryTitle": "Adult",
+      "groupId": "live-11",
+      "authorized": true,
+      "adult": true
+    },
+    {
+      "id": "live-hidden-1",
+      "name": "Fixture Hidden",
+      "categoryId": "10",
+      "categoryTitle": "News",
+      "groupId": "live-10",
+      "authorized": false,
+      "adult": false
+    }
+  ],
+  "movies": [
+    {
+      "id": "movie-1",
+      "name": "Fixture Movie",
+      "categoryId": "20",
+      "categoryTitle": "Movies",
+      "groupId": "movie-20",
+      "authorized": true,
+      "adult": false
+    },
+    {
+      "id": "movie-adult-1",
+      "name": "Fixture Adult Movie",
+      "categoryId": "21",
+      "categoryTitle": "Adult Movies",
+      "groupId": "movie-21",
+      "authorized": true,
+      "adult": true
+    },
+    {
+      "id": "movie-unauthorized-1",
+      "name": "Fixture Unauthorized Movie",
+      "categoryId": "20",
+      "categoryTitle": "Movies",
+      "groupId": "movie-20",
+      "authorized": false,
+      "adult": false
+    }
+  ],
+  "series": [
+    {
+      "id": "series-playable",
+      "name": "Fixture Series",
+      "categoryId": "30",
+      "categoryTitle": "Shows",
+      "groupId": "series-30",
+      "authorized": true,
+      "episodes": [
+        { "id": "episode-1", "season": 1, "episode": 1 },
+        { "id": "episode-2", "season": 1, "episode": 2 }
+      ]
+    },
+    {
+      "id": "series-unsynchronized",
+      "name": "Fixture Unsynchronized Series",
+      "categoryId": "30",
+      "categoryTitle": "Shows",
+      "groupId": "series-30",
+      "authorized": true,
+      "episodes": []
+    },
+    {
+      "id": "series-unauthorized",
+      "name": "Fixture Unauthorized Series",
+      "categoryId": "30",
+      "categoryTitle": "Shows",
+      "groupId": "series-30",
+      "authorized": false,
+      "episodes": [
+        { "id": "episode-unauthorized", "season": 1, "episode": 1 }
+      ]
+    }
+  ],
+  "playlist": [
+    {
+      "type": "live",
+      "tvgId": "fixture.same",
+      "groupId": "live-10",
+      "groupTitle": "Same Name",
+      "name": "Fixture HD S01E01",
+      "url": "https://fixture.test/live/42.ts?quality=hd&token=one"
+    },
+    {
+      "type": "live",
+      "tvgId": "fixture.same",
+      "groupId": "live-10",
+      "groupTitle": "Same Name",
+      "name": "Fixture SD S01E01",
+      "url": "https://fixture.test/live/42.ts?quality=sd&token=two"
+    },
+    {
+      "type": "movie",
+      "tvgId": "",
+      "groupId": "movie-20",
+      "groupTitle": "Same Name",
+      "name": "Fixture Movie",
+      "url": "https://fixture.test/movie/200.mp4?expires=1"
+    },
+    {
+      "type": "series",
+      "tvgId": "",
+      "groupId": "series-30",
+      "groupTitle": "Same Name",
+      "name": "Fixture Series S01E01 Pilot",
+      "url": "https://fixture.test/series/fixture-s01e01.mp4?token=one"
+    },
+    {
+      "type": "series",
+      "tvgId": "",
+      "groupId": "series-30",
+      "groupTitle": "Same Name",
+      "name": "Fixture Series S02E01 Extra",
+      "url": "https://fixture.test/series/fixture-s02e01.mp4?token=two"
+    }
+  ]
+}
+

--- a/tests/protocol_parity.test.js
+++ b/tests/protocol_parity.test.js
@@ -1,0 +1,253 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import request from 'supertest';
+import fs from 'node:fs';
+
+const { TEST_DB_DIR } = vi.hoisted(() => {
+  const fsModule = require('node:fs');
+  const os = require('node:os');
+  const path = require('node:path');
+  return { TEST_DB_DIR: fsModule.mkdtempSync(path.join(os.tmpdir(), 'iptv-protocol-parity-')) };
+});
+
+vi.mock('../src/config/constants.js', async () => {
+  const actual = await vi.importActual('../src/config/constants.js');
+  return {
+    ...actual,
+    DATA_DIR: TEST_DB_DIR,
+    CACHE_DIR: `${TEST_DB_DIR}/cache`,
+    EPG_CACHE_DIR: `${TEST_DB_DIR}/cache/epg`,
+    EPG_DB_PATH: `${TEST_DB_DIR}/epg.db`,
+    BCRYPT_ROUNDS: 1,
+  };
+});
+
+import app from '../src/app.js';
+import db, { initDb } from '../src/database/db.js';
+import epgDb from '../src/database/epgDb.js';
+import { encrypt } from '../src/utils/crypto.js';
+import { providerSourceKey } from '../src/utils/helpers.js';
+import { tokenCache } from '../src/services/authService.js';
+
+const fixture = JSON.parse(
+  fs.readFileSync(new URL('./fixtures/protocol-parity.json', import.meta.url), 'utf8'),
+);
+const credentials = { username: 'parity-user', password: 'parity-pass' };
+const mac = '02:00:00:00:06:18';
+
+const categoryId = (id) => Number(id);
+const typeRows = {
+  live: fixture.live,
+  movie: fixture.movies,
+  series: fixture.series,
+};
+const numericId = (type, index) => ({ live: [42, 43, 44, 45], movie: [200, 201, 202], series: [300, 301, 302] }[type][index]);
+
+function attr(line, name) {
+  return line.match(new RegExp(`${name}="([^"]*)"`))?.[1] || '';
+}
+
+function parseM3U(text) {
+  const lines = text.split(/\r?\n/);
+  const entries = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!lines[index].startsWith('#EXTINF:')) continue;
+    const line = lines[index];
+    const comma = line.indexOf(',');
+    entries.push({
+      type: line,
+      name: comma === -1 ? '' : line.slice(comma + 1),
+      tvgId: attr(line, 'tvg-id'),
+      groupId: attr(line, 'group-id'),
+      url: lines[index + 1] || '',
+    });
+  }
+  return entries;
+}
+
+describe('real protocol output parity', () => {
+  let userId;
+  let providerId;
+  let otherProviderId;
+  const categoryIds = [10, 11, 12, 20, 21, 30];
+  const insertedUserChannelIds = [];
+
+  beforeAll(() => {
+    initDb(true);
+
+    userId = Number(db.prepare(`
+      INSERT INTO users (username, password, plain_password, is_active)
+      VALUES (?, ?, ?, 1)
+    `).run(credentials.username, encrypt(credentials.password), encrypt(credentials.password)).lastInsertRowid);
+    const otherUserId = Number(db.prepare(`
+      INSERT INTO users (username, password, is_active)
+      VALUES ('parity-other', ?, 1)
+    `).run(encrypt('other-pass')).lastInsertRowid);
+
+    providerId = Number(db.prepare(`
+      INSERT INTO providers (name, url, username, password, user_id)
+      VALUES ('Parity provider', 'https://upstream.fixture.invalid/panel', 'upstream-user', ?, ?)
+    `).run(encrypt('upstream-pass'), userId).lastInsertRowid);
+    otherProviderId = Number(db.prepare(`
+      INSERT INTO providers (name, url, username, password, user_id)
+      VALUES ('Foreign provider', 'https://foreign.fixture.invalid/panel', 'foreign-user', ?, ?)
+    `).run(encrypt('foreign-pass'), otherUserId).lastInsertRowid);
+
+    const categories = new Map(
+      [...fixture.live, ...fixture.movies, ...fixture.series]
+        .filter(({ authorized }) => authorized)
+        .map(({ categoryId: id, categoryTitle, type = id.startsWith('3') ? 'series' : id.startsWith('2') ? 'movie' : 'live' }) => [
+          Number(id),
+          { name: categoryTitle, type },
+        ]),
+    );
+    const insertCategory = db.prepare(`
+      INSERT INTO user_categories (id, user_id, name, type, sort_order, is_adult)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `);
+    for (const [id, category] of categories) {
+      insertCategory.run(id, userId, category.name, category.type, id, category.name.toLowerCase().includes('adult') ? 1 : 0);
+    }
+
+    const insertProviderChannel = db.prepare(`
+      INSERT INTO provider_channels
+        (provider_id, remote_stream_id, name, original_category_id, stream_type, epg_channel_id, mime_type)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `);
+    const insertUserChannel = db.prepare(`
+      INSERT INTO user_channels (user_category_id, provider_channel_id, sort_order, is_hidden, authorization_revoked)
+      VALUES (?, ?, ?, ?, ?)
+    `);
+    const add = (type, row, index, { foreign = false, hidden = false } = {}) => {
+      const remoteId = numericId(type, index);
+      const category = categoryId(row.categoryId);
+      const provider = foreign ? otherProviderId : providerId;
+      const providerChannelId = Number(insertProviderChannel.run(
+        provider,
+        remoteId,
+        row.name,
+        category,
+        type === 'movie' ? 'movie' : type,
+        row.epgId || '',
+        type === 'movie' || type === 'series' ? 'mp4' : 'ts',
+      ).lastInsertRowid);
+      const userChannelId = Number(insertUserChannel.run(category, providerChannelId, index, hidden ? 1 : 0, 0).lastInsertRowid);
+      insertedUserChannelIds.push(userChannelId);
+      return { providerChannelId, userChannelId, remoteId };
+    };
+
+    fixture.live.forEach((row, index) => add('live', row, index, { hidden: !row.authorized }));
+    fixture.movies.forEach((row, index) => add('movie', row, index, { foreign: !row.authorized }));
+    fixture.series.forEach((row, index) => add('series', row, index, { foreign: !row.authorized }));
+
+    db.prepare(`
+      INSERT INTO provider_series_episodes
+        (source_key, series_remote_id, remote_episode_id, season, episode_num, title, container_extension)
+      VALUES (?, 300, 9001, 1, 1, 'Pilot', 'mp4'), (?, 300, 9002, 1, 2, 'Second', 'mp4')
+    `).run(providerSourceKey('https://upstream.fixture.invalid/panel'), providerSourceKey('https://upstream.fixture.invalid/panel'));
+
+    db.prepare(`
+      INSERT INTO stalker_devices (user_id, mac, model, serial_number, device_uid)
+      VALUES (?, ?, 'MAG254', 'parity-serial', 'parity-device')
+    `).run(userId, mac);
+  });
+
+  afterAll(() => {
+    tokenCache.clear();
+    if (insertedUserChannelIds.length) {
+      db.prepare(`DELETE FROM series_episode_aliases WHERE user_channel_id IN (${insertedUserChannelIds.map(() => '?').join(',')})`).run(...insertedUserChannelIds);
+      db.prepare(`DELETE FROM user_channels WHERE id IN (${insertedUserChannelIds.map(() => '?').join(',')})`).run(...insertedUserChannelIds);
+    }
+    db.prepare('DELETE FROM provider_series_episodes WHERE source_key = ?').run(providerSourceKey('https://upstream.fixture.invalid/panel'));
+    db.prepare('DELETE FROM stalker_devices WHERE mac = ?').run(mac);
+    db.prepare('DELETE FROM user_categories WHERE id IN (?, ?, ?, ?, ?, ?)').run(...categoryIds);
+    db.prepare('DELETE FROM provider_channels WHERE provider_id IN (?, ?)').run(providerId, otherProviderId);
+    db.prepare('DELETE FROM providers WHERE id IN (?, ?)').run(providerId, otherProviderId);
+    db.prepare('DELETE FROM users WHERE username IN (?, ?)').run(credentials.username, 'parity-other');
+    epgDb.close();
+    db.close();
+    fs.rmSync(TEST_DB_DIR, { recursive: true, force: true });
+  });
+
+  it('keeps authorized catalog identity and filtering aligned across Xtream, Stalker, and M3U', async () => {
+    const xtream = async (action, extra = {}) => {
+      const response = await request(app).get('/player_api.php').query({ ...credentials, action, ...extra });
+      expect(response.status).toBe(200);
+      return response.body;
+    };
+
+    const xtreamByType = {
+      live: await xtream('get_live_streams'),
+      movie: await xtream('get_vod_streams'),
+      series: await xtream('get_series'),
+    };
+    const xtreamCategories = {
+      live: await xtream('get_live_categories'),
+      movie: await xtream('get_vod_categories'),
+      series: await xtream('get_series_categories'),
+    };
+    for (const [type, rows] of Object.entries(typeRows)) {
+      const expectedCategories = new Set(rows.filter(({ authorized }) => authorized).map(({ categoryTitle }) => categoryTitle));
+      expect(new Set(xtreamCategories[type].map(({ category_name: name }) => name))).toEqual(expectedCategories);
+    }
+
+    const handshake = await request(app)
+      .get('/server/load.php')
+      .set('Cookie', `mac=${encodeURIComponent(mac)}`)
+      .query({ type: 'stb', action: 'handshake' });
+    expect(handshake.status).toBe(200);
+    const token = handshake.body.js.token;
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+
+    const stalker = async (type, action, extra = {}) => {
+      const response = await request(app)
+        .get('/server/load.php')
+        .set('Authorization', `Bearer ${token}`)
+        .set('Cookie', `mac=${encodeURIComponent(mac)}`)
+        .query({ type, action, ...extra });
+      expect(response.status).toBe(200);
+      return response.body.js;
+    };
+
+    const stalkerByType = {};
+    for (const [type, stalkerType] of Object.entries({ live: 'itv', movie: 'vod', series: 'series' })) {
+      const categories = await stalker(stalkerType, 'get_categories');
+      expect(categories[0]).toEqual(expect.objectContaining({ id: '*', alias: 'all' }));
+      expect(new Set(categories.slice(1).map(({ title }) => title))).toEqual(
+        new Set(xtreamCategories[type].map(({ category_name: name }) => name)),
+      );
+
+      const items = [];
+      for (const category of categories.slice(1)) {
+        const page = await stalker(stalkerType, 'get_ordered_list', { category: category.id, p: 1 });
+        items.push(...page.data);
+      }
+      stalkerByType[type] = items;
+      expect(new Set(items.map(({ id }) => id))).toEqual(new Set(xtreamByType[type].map(({ stream_id, series_id }) => String(stream_id ?? series_id))));
+    }
+
+    const playlistResponse = await request(app).get('/get.php').query({ ...credentials, type: 'm3u_plus' });
+    expect(playlistResponse.status).toBe(200);
+    const playlistText = playlistResponse.text || playlistResponse.body?.toString('utf8') || '';
+    const playlist = parseM3U(playlistText);
+    expect(playlist).toHaveLength(7);
+    expect(playlist.map(({ name }) => name)).toEqual(expect.arrayContaining([
+      'Fixture News',
+      'Fixture News duplicate',
+      'Fixture Adult Live',
+      'Fixture Movie',
+      'Fixture Adult Movie',
+      'Fixture Series S01 E01',
+      'Fixture Series S01 E02',
+    ]));
+    expect(playlist.map(({ groupId }) => groupId)).toEqual(expect.arrayContaining(['10', '11', '12', '20', '21', '30']));
+    expect(playlist.filter(({ tvgId }) => tvgId === 'fixture.same')).toHaveLength(2);
+    expect(playlist.map(({ name }) => name)).not.toEqual(expect.arrayContaining([
+      'Fixture Hidden',
+      'Fixture Unauthorized Movie',
+      'Fixture Unauthorized Series',
+      'Fixture Unsynchronized Series',
+    ]));
+    expect(playlistText).not.toContain('upstream-pass');
+    expect(playlistText).not.toContain('foreign-pass');
+  });
+});


### PR DESCRIPTION
## Scope

Continue the existing Manager protocol-parity test work on PR #618. This PR adds only isolated integration coverage and sanitized fixture data; no Manager production behavior changed because the endpoint test found no reproducible defect.

## Changes

- Add a real Supertest test that boots the Express app with an isolated SQLite DATA_DIR.
- Exercise existing Xtream player_api.php, Stalker handshake/category/concrete ordered-list, and M3U Plus get.php endpoints.
- Assert shared authorized assignment IDs, normal/adult categories, category-specific Stalker output, duplicate EPG metadata with distinct M3U entries, synchronized-series episode expansion, unsynchronized-series omission, and hidden/foreign/unauthorized filtering.
- Extend the versioned sanitized fixture with adult live/movie and duplicate-EPG cases.

## Verification

- npm test — 96 files, 622 tests
- npm run lint
- npm run build
- node --check tests/protocol_parity.test.js

No Manager src/ production file changed. No merge, release, or deploy was performed.