### PR TITLE
Keep provider selection available for list editing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,9 +27,10 @@ reliability, authentication behavior, and Docker upgrade compatibility.
 - Avoid broad refactors in controllers that handle streaming, auth, provider
   sync, EPG, imports/exports, or database migrations.
 - `provider_access` is disabled for normal users by default and controls only
-  upstream provider management and catalog visibility. It must not remove a
-  user's ability to edit their own channel, movie, series, or category-scoped
-  EPG mappings.
+  upstream provider management and connection-details visibility. Provider
+  names/options and catalog rows remain available for list editing. It must not
+  remove a user's ability to edit their own channel, movie, series, or
+  category-scoped EPG mappings.
 
 ## Package and Build Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,9 +28,10 @@ reliability, authentication behavior, and Docker upgrade compatibility.
   sync, EPG, imports/exports, or database migrations.
 - `provider_access` is disabled for normal users by default and controls only
   upstream provider management and connection-details visibility. Provider
-  names/options and catalog rows remain available for list editing. It must not
-  remove a user's ability to edit their own channel, movie, series, or
-  category-scoped EPG mappings.
+  names/options and catalog rows remain available for list editing; restricted
+  catalog responses must omit raw stream URLs, HTTP headers, and DRM metadata.
+  It must not remove a user's ability to edit their own channel, movie, series,
+  or category-scoped EPG mappings.
 
 ## Package and Build Rules
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ### Core Functionality
 - **Multi-User Management**: Support for multiple users with individual channel configurations, secure login, and customizable concurrent stream limits (max connections).
-- **Per-User Provider Access**: Administrators can show or hide the upstream provider catalog per user without removing access to that user's channel, movie, series, or EPG mapping lists.
+- **Per-User Provider Access**: Administrators can show or hide the upstream provider information and management box per user without removing provider selection or access to that user's channel, movie, series, or EPG mapping lists.
 - **Provider Management**: Connect to multiple IPTV providers via Xtream Codes API with automatic connection pooling.
 - **Category Organization**: Drag & drop sorting and visual channel assignment.
 - **EPG Integration**: Comprehensive Electronic Program Guide (EPG) support with automatic updates.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -78,7 +78,9 @@ provider cloning preserve this setting.
 Normal users receive only their own provider names/options and provider catalog
 rows. With `provider_access` disabled, `GET /api/providers` omits connection
 details and the provider management box is hidden; own provider catalog and
-category-import operations remain available for list editing.
+category-import operations remain available for list editing. Restricted
+catalog responses omit raw stream metadata, including original URLs, HTTP
+headers, and DRM data.
 
 ## Categories and Channels
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -32,8 +32,10 @@ Stalker device create/update payloads accept an optional `parental_pin` containi
 the PIN or its encrypted value and expose only `parental_pin_configured`.
 
 User create/update payloads accept an optional `provider_access` boolean. It is
-disabled by default and controls whether the normal user may view their
-upstream providers and provider catalog.
+disabled by default and controls whether the normal user may view provider
+connection details and the provider management box. Provider names/options and
+the user's own provider catalog remain available for editing channel, movie,
+series, and category-scoped EPG lists.
 
 Deleting a user removes user-owned providers and dependent runtime/configuration
 rows first, including provider icon cache entries, share links, temporary
@@ -73,8 +75,10 @@ name (for example `Europe/Berlin` or `UTC`). Empty or null uses the server
 runtime timezone; invalid names are rejected. Provider export/import and user
 provider cloning preserve this setting.
 
-Normal users receive only their own providers and provider catalog when
-`provider_access` is enabled; otherwise these provider endpoints return `403`.
+Normal users receive only their own provider names/options and provider catalog
+rows. With `provider_access` disabled, `GET /api/providers` omits connection
+details and the provider management box is hidden; own provider catalog and
+category-import operations remain available for list editing.
 
 ## Categories and Channels
 
@@ -152,8 +156,9 @@ Poll `GET /api/mapping/jobs/:id` for `status`, `progress`, and `matched`.
 Admins may pass `all_providers: true` to auto-map or reset EPG mappings across
 all providers.
 
-Provider-scoped mapping reads require the same provider ownership and
-`provider_access` permission as provider catalog reads.
+Provider-scoped mapping reads require provider ownership and the
+`provider_access` permission. Provider catalog reads used by a user's own list
+editor do not require that setting.
 
 Category-scoped EPG mapping remains available to normal users without
 `provider_access`; it is limited to their own categories and authorized

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -23,9 +23,10 @@ tests. Keep it in sync when environment variables or startup behavior changes.
 
 Administrators can enable the stored `provider_access` setting separately for
 each normal user. It is disabled by default and controls only upstream provider
-management and provider catalog visibility. A user without it can still edit
-their own channel, movie, and series lists, including category-scoped EPG
-mappings. Administrators are not restricted by this setting.
+management and connection-details visibility. A user without it still receives
+their own provider names/options and catalog rows so they can edit channel,
+movie, and series lists, including category-scoped EPG mappings. Administrators
+are not restricted by this setting.
 
 ## Network and Proxy
 

--- a/public/app.js
+++ b/public/app.js
@@ -1030,11 +1030,14 @@ document.getElementById('edit-user-form').addEventListener('submit', async e => 
 
 // === Provider Management ===
 async function loadProviders(filterUserId = null) {
-  const canViewProviders = currentUser && (currentUser.is_admin || Number(currentUser.provider_access) === 1);
   const section = document.getElementById('provider-section');
   const requestGeneration = sessionGeneration;
   const providers = await fetchJSON('/api/providers');
   if (requestGeneration !== sessionGeneration || !currentUser) return;
+  if (!currentUser.is_admin) await refreshCurrentUserPermissions();
+  if (requestGeneration !== sessionGeneration || !currentUser) return;
+
+  const canViewProviders = currentUser.is_admin || Number(currentUser.provider_access) === 1;
 
   updateChannelProviderSelect(providers);
 
@@ -1690,6 +1693,8 @@ async function loadProviderCategories() {
     const requestGeneration = sessionGeneration;
     const categories = await fetchJSON(`/api/providers/${providerId}/categories?type=${type}`);
     if (requestGeneration !== sessionGeneration || !currentUser) return;
+    if (!currentUser.is_admin) await refreshCurrentUserPermissions();
+    if (requestGeneration !== sessionGeneration || !currentUser) return;
     providerCategories = categories;
     renderProviderCategories();
   } catch (e) {
@@ -1941,6 +1946,8 @@ async function fetchProviderChannels(reset) {
     const res = await fetchJSON(url);
 
     isLoadingChannels = false;
+    if (requestGeneration !== sessionGeneration || !currentUser) return;
+    if (!currentUser.is_admin) await refreshCurrentUserPermissions();
     if (requestGeneration !== sessionGeneration || !currentUser) return;
 
     // Handle Response (supports new object structure and legacy array)

--- a/public/app.js
+++ b/public/app.js
@@ -1562,11 +1562,13 @@ function clearSessionSensitiveState({preserveUserState = false} = {}) {
     epgMappingMode = 'provider';
     currentMappingChannelId = null;
   }
-  channelPage = 1;
-  channelSearch = '';
-  channelTotal = 0;
-  isLoadingChannels = false;
-  providerCategories = [];
+  if (!preserveUserState) {
+    channelPage = 1;
+    channelSearch = '';
+    channelTotal = 0;
+    isLoadingChannels = false;
+    providerCategories = [];
+  }
 
   const section = document.getElementById('provider-section');
   if (section) section.classList.add('d-none');
@@ -1579,18 +1581,18 @@ function clearSessionSensitiveState({preserveUserState = false} = {}) {
   const providerList = document.getElementById('provider-list');
   if (providerList) providerList.innerHTML = '';
   const channelList = document.getElementById('provider-channel-list');
-  if (channelList) channelList.innerHTML = '';
+  if (channelList && !preserveUserState) channelList.innerHTML = '';
   const categoryList = document.getElementById('provider-categories-list');
-  if (categoryList) categoryList.innerHTML = '';
+  if (categoryList && !preserveUserState) categoryList.innerHTML = '';
   const searchInput = document.getElementById('provider-channel-search');
-  if (searchInput) {
+  if (searchInput && !preserveUserState) {
     searchInput.value = '';
     searchInput.disabled = true;
   }
   const searchClear = document.getElementById('provider-channel-search-clear');
-  if (searchClear) searchClear.classList.add('d-none');
+  if (searchClear && !preserveUserState) searchClear.classList.add('d-none');
   const categorySearch = document.getElementById('category-import-search');
-  if (categorySearch) categorySearch.value = '';
+  if (categorySearch && !preserveUserState) categorySearch.value = '';
   const bulkFrom = document.getElementById('provider-bulk-url-from');
   if (bulkFrom) bulkFrom.value = '';
   const bulkTo = document.getElementById('provider-bulk-url-to');
@@ -1603,7 +1605,7 @@ function clearSessionSensitiveState({preserveUserState = false} = {}) {
   const saveProviderButton = document.getElementById('save-provider-btn');
   if (saveProviderButton) saveProviderButton.textContent = t('addProvider');
   const availableHeader = document.getElementById('available-channels-header');
-  if (availableHeader) availableHeader.textContent = t('available', {count: 0});
+  if (availableHeader && !preserveUserState) availableHeader.textContent = t('available', {count: 0});
   if (!preserveUserState) updateChannelProviderSelect([]);
   updateStatsCounters('providers', 0);
 

--- a/public/app.js
+++ b/public/app.js
@@ -1701,6 +1701,12 @@ async function loadProviderCategories() {
     renderProviderCategories();
   } catch (e) {
     console.error(' Error:', e);
+    if (e.message === 'Access denied') {
+      providerCategories = [];
+      list.innerHTML = `<li class="list-group-item text-muted">${t('pleaseSelectProvider')}</li>`;
+      try { await loadProviders(selectedUserId); } catch {}
+      return;
+    }
     list.innerHTML = `<li class="list-group-item text-danger">${t('loadingError')}</li>`;
   }
 }
@@ -1967,6 +1973,23 @@ async function fetchProviderChannels(reset) {
 
   } catch(e) {
     isLoadingChannels = false;
+    if (e.message === 'Access denied') {
+        channelPage = 1;
+        channelSearch = '';
+        channelTotal = 0;
+        list.innerHTML = `<li class="list-group-item text-muted">${t('pleaseSelectProvider')}</li>`;
+        const searchInput = document.getElementById('provider-channel-search');
+        if (searchInput) {
+            searchInput.value = '';
+            searchInput.disabled = true;
+        }
+        const searchClear = document.getElementById('provider-channel-search-clear');
+        if (searchClear) searchClear.classList.add('d-none');
+        const availableHeader = document.getElementById('available-channels-header');
+        if (availableHeader) availableHeader.textContent = t('available', {count: 0});
+        try { await loadProviders(selectedUserId); } catch {}
+        return;
+    }
     if (reset) {
         list.innerHTML = `<li class="list-group-item text-danger">${t('loadingError')}</li>`;
     }

--- a/public/app.js
+++ b/public/app.js
@@ -1685,6 +1685,7 @@ async function loadProviderCategories() {
   const modalEl = document.getElementById('importCategoryModal');
   const list = document.getElementById('provider-categories-list');
   list.innerHTML = `<li class="list-group-item text-muted">${t('loadingCategories')}</li>`;
+  const requestGeneration = sessionGeneration;
   
   if (!modalEl.classList.contains('show')) {
       const modal = new bootstrap.Modal(modalEl);
@@ -1692,16 +1693,16 @@ async function loadProviderCategories() {
   }
 
   try {
-    const requestGeneration = sessionGeneration;
     const categories = await fetchJSON(`/api/providers/${providerId}/categories?type=${type}`);
-    if (requestGeneration !== sessionGeneration || !currentUser) return;
+    if (requestGeneration !== sessionGeneration || !currentUser || select.value !== providerId) return;
     if (!currentUser.is_admin) await refreshCurrentUserPermissions();
-    if (requestGeneration !== sessionGeneration || !currentUser) return;
+    if (requestGeneration !== sessionGeneration || !currentUser || select.value !== providerId) return;
     providerCategories = categories;
     renderProviderCategories();
   } catch (e) {
     console.error(' Error:', e);
     if (e.message === 'Access denied') {
+      select.value = '';
       providerCategories = [];
       list.innerHTML = `<li class="list-group-item text-muted">${t('pleaseSelectProvider')}</li>`;
       try { await loadProviders(selectedUserId); } catch {}
@@ -1954,9 +1955,9 @@ async function fetchProviderChannels(reset) {
     const res = await fetchJSON(url);
 
     isLoadingChannels = false;
-    if (requestGeneration !== sessionGeneration || !currentUser) return;
+    if (requestGeneration !== sessionGeneration || !currentUser || select.value !== providerId) return;
     if (!currentUser.is_admin) await refreshCurrentUserPermissions();
-    if (requestGeneration !== sessionGeneration || !currentUser) return;
+    if (requestGeneration !== sessionGeneration || !currentUser || select.value !== providerId) return;
 
     // Handle Response (supports new object structure and legacy array)
     let channels = [];
@@ -1974,6 +1975,7 @@ async function fetchProviderChannels(reset) {
   } catch(e) {
     isLoadingChannels = false;
     if (e.message === 'Access denied') {
+        select.value = '';
         channelPage = 1;
         channelSearch = '';
         channelTotal = 0;

--- a/public/app.js
+++ b/public/app.js
@@ -1032,20 +1032,27 @@ document.getElementById('edit-user-form').addEventListener('submit', async e => 
 async function loadProviders(filterUserId = null) {
   const canViewProviders = currentUser && (currentUser.is_admin || Number(currentUser.provider_access) === 1);
   const section = document.getElementById('provider-section');
+  const requestGeneration = sessionGeneration;
+  const providers = await fetchJSON('/api/providers');
+  if (requestGeneration !== sessionGeneration || !currentUser) return;
+
+  updateChannelProviderSelect(providers);
+
   if (!canViewProviders) {
-    clearSessionSensitiveState({preserveUserState: true});
+    updateStatsCounters('providers', 0);
+    if (section) section.classList.add('d-none');
+    const userSection = document.getElementById('user-section');
+    if (userSection) {
+      userSection.classList.remove('col-md-6');
+      userSection.classList.add('col-md-12');
+    }
     return;
   }
 
-  const requestGeneration = sessionGeneration;
-  const providers = await fetchJSON('/api/providers');
-  if (requestGeneration !== sessionGeneration || !currentUser || !(currentUser.is_admin || Number(currentUser.provider_access) === 1)) return;
   updateStatsCounters('providers', providers.length);
 
   const list = document.getElementById('provider-list');
   list.innerHTML = '';
-
-  updateChannelProviderSelect(providers);
 
   const targetUserId = filterUserId || selectedUserId;
   const userSection = document.getElementById('user-section');
@@ -1594,7 +1601,7 @@ function clearSessionSensitiveState({preserveUserState = false} = {}) {
   if (saveProviderButton) saveProviderButton.textContent = t('addProvider');
   const availableHeader = document.getElementById('available-channels-header');
   if (availableHeader) availableHeader.textContent = t('available', {count: 0});
-  updateChannelProviderSelect([]);
+  if (!preserveUserState) updateChannelProviderSelect([]);
   updateStatsCounters('providers', 0);
 
   if (!preserveUserState) {
@@ -1682,7 +1689,7 @@ async function loadProviderCategories() {
   try {
     const requestGeneration = sessionGeneration;
     const categories = await fetchJSON(`/api/providers/${providerId}/categories?type=${type}`);
-    if (requestGeneration !== sessionGeneration || !currentUser || !(currentUser.is_admin || Number(currentUser.provider_access) === 1)) return;
+    if (requestGeneration !== sessionGeneration || !currentUser) return;
     providerCategories = categories;
     renderProviderCategories();
   } catch (e) {
@@ -1934,7 +1941,7 @@ async function fetchProviderChannels(reset) {
     const res = await fetchJSON(url);
 
     isLoadingChannels = false;
-    if (requestGeneration !== sessionGeneration || !currentUser || !(currentUser.is_admin || Number(currentUser.provider_access) === 1)) return;
+    if (requestGeneration !== sessionGeneration || !currentUser) return;
 
     // Handle Response (supports new object structure and legacy array)
     let channels = [];

--- a/scripts/playwright_smoke.mjs
+++ b/scripts/playwright_smoke.mjs
@@ -291,6 +291,9 @@ async function run() {
     await grantedUserPage.locator('#channel-provider-select').selectOption(String(providerId));
     await grantedUserPage.locator('#provider-channel-list').getByText(liveFixture.channelName, {exact: true})
       .waitFor({state: 'visible', timeout: 15000});
+    if (await grantedUserPage.locator('#provider-channel-search').isDisabled()) {
+      throw new Error('Provider catalog search must remain usable after permission refresh');
+    }
     await assertHidden(grantedUserPage.locator('#provider-section'), 'Revoked users must lose the Provider section after catalog refresh');
 
     const deniedProviderMapping = await grantedUserPage.evaluate(async ({providerId}) => {

--- a/scripts/playwright_smoke.mjs
+++ b/scripts/playwright_smoke.mjs
@@ -310,6 +310,61 @@ async function run() {
     await assertHidden(grantedUserPage.locator('#login-modal'), 'Provider denial must not show the login modal');
     await assertHidden(grantedUserPage.locator('#provider-section'), 'Revoked users must lose the Provider section');
     await assertVisible(grantedUserPage.locator('#user-details-content'), 'Provider denial must preserve list editing');
+
+    const ownershipChangeStatus = await adminPage.evaluate(async ({providerId}) => {
+      const token = localStorage.getItem('jwt_token');
+      const response = await fetch(`/api/providers/${providerId}`, {
+        method: 'PUT',
+        headers: {Authorization: `Bearer ${token}`, 'Content-Type': 'application/json'},
+        body: JSON.stringify({
+          name: 'Reassigned Playwright Provider',
+          url: 'http://provider.example',
+          username: 'upstream',
+          password: 'secret',
+          epg_url: 'http://provider.example/epg.xml',
+          user_id: null,
+          epg_enabled: false,
+          max_connections: 1
+        })
+      });
+      return response.status;
+    }, {providerId});
+    if (ownershipChangeStatus !== 200) throw new Error(`Provider ownership change failed: ${ownershipChangeStatus}`);
+
+    const ownershipDeniedResponse = grantedUserPage.waitForResponse(response =>
+      response.url().includes(`/api/providers/${providerId}/channels`) && response.status() === 403
+    );
+    await grantedUserPage.locator('#channel-provider-select').evaluate((select, value) => {
+      select.value = String(value);
+      select.dispatchEvent(new Event('change', {bubbles: true}));
+    }, providerId);
+    await ownershipDeniedResponse;
+    await grantedUserPage.locator(`#channel-provider-select option[value="${providerId}"]`)
+      .waitFor({state: 'detached', timeout: 15000});
+    if (await grantedUserPage.locator('#provider-channel-list').getByText(liveFixture.channelName, {exact: true}).count()) {
+      throw new Error('Ownership denial must clear stale provider catalog rows');
+    }
+
+    const restoreOwnershipStatus = await adminPage.evaluate(async ({providerId, userId}) => {
+      const token = localStorage.getItem('jwt_token');
+      const response = await fetch(`/api/providers/${providerId}`, {
+        method: 'PUT',
+        headers: {Authorization: `Bearer ${token}`, 'Content-Type': 'application/json'},
+        body: JSON.stringify({
+          name: 'Playwright Provider',
+          url: 'http://provider.example',
+          username: 'upstream',
+          password: 'secret',
+          epg_url: 'http://provider.example/epg.xml',
+          user_id: userId,
+          epg_enabled: false,
+          max_connections: 1
+        })
+      });
+      return response.status;
+    }, {providerId, userId});
+    if (restoreOwnershipStatus !== 200) throw new Error(`Provider ownership restore failed: ${restoreOwnershipStatus}`);
+
     await grantedUserPage.locator('#nav-epg-mapping').click();
     await grantedUserPage.locator(`#epg-mapping-category-select option[value="${liveFixture.categoryId}"]`)
       .waitFor({state: 'attached', timeout: 15000});

--- a/scripts/playwright_smoke.mjs
+++ b/scripts/playwright_smoke.mjs
@@ -100,9 +100,19 @@ async function run() {
     `).run(userId, categoryName, type).lastInsertRowid);
     const channelName = `Playwright ${type} Channel ${Date.now()}`;
     const providerChannelId = Number(db.prepare(`
-      INSERT INTO provider_channels (provider_id, remote_stream_id, name, stream_type)
-      VALUES (?, ?, ?, ?)
-    `).run(providerId, 1001 + index, channelName, type).lastInsertRowid);
+      INSERT INTO provider_channels (provider_id, remote_stream_id, name, stream_type, metadata)
+      VALUES (?, ?, ?, ?, ?)
+    `).run(
+      providerId,
+      1001 + index,
+      channelName,
+      type,
+      index === 0 ? JSON.stringify({
+        original_url: 'http://upstream.example/live/user:secret',
+        http_headers: {Authorization: 'Bearer header-secret'},
+        drm: {license_key: 'license-secret'}
+      }) : null
+    ).lastInsertRowid);
     const userChannelId = Number(db.prepare(`
       INSERT INTO user_channels (user_category_id, provider_channel_id, sort_order, assignment_origin)
       VALUES (?, ?, 0, 'manual')
@@ -158,6 +168,22 @@ async function run() {
     if (providerResponse.status !== 200) throw new Error(`Expected provider options, got ${providerResponse.status}`);
     if (providerResponse.body.some(provider => 'url' in provider || 'username' in provider || 'epg_url' in provider)) {
       throw new Error('Provider details must stay hidden when provider access is disabled');
+    }
+    const restrictedCatalogResponse = await page.evaluate(async ({providerId}) => {
+      const token = localStorage.getItem('jwt_token');
+      const response = await fetch(`/api/providers/${providerId}/channels?type=live&page=1&limit=50`, {
+        headers: {Authorization: `Bearer ${token}`}
+      });
+      return {status: response.status, body: await response.json()};
+    }, {providerId});
+    if (restrictedCatalogResponse.status !== 200) {
+      throw new Error(`Expected restricted provider catalog, got ${restrictedCatalogResponse.status}`);
+    }
+    const restrictedCatalog = Array.isArray(restrictedCatalogResponse.body)
+      ? restrictedCatalogResponse.body
+      : restrictedCatalogResponse.body.channels;
+    if (!Array.isArray(restrictedCatalog) || restrictedCatalog.some(channel => 'metadata' in channel || JSON.stringify(channel).includes('secret'))) {
+      throw new Error('Provider channel metadata must stay hidden when provider access is disabled');
     }
     await assertVisible(page.locator('#user-details-content'), 'Regular users must retain list editing details');
     const category = page.locator('#category-list').getByText(liveFixture.categoryName, {exact: true});

--- a/scripts/playwright_smoke.mjs
+++ b/scripts/playwright_smoke.mjs
@@ -110,6 +110,11 @@ async function run() {
     return {type, categoryName, categoryId, channelName, providerChannelId, userChannelId};
   });
   const liveFixture = listFixtures[0];
+  const providerOnlyChannelName = `Playwright Available Channel ${Date.now()}`;
+  db.prepare(`
+    INSERT INTO provider_channels (provider_id, remote_stream_id, name, stream_type)
+    VALUES (?, ?, ?, 'live')
+  `).run(providerId, 2001, providerOnlyChannelName);
 
   server = app.listen(0);
   await new Promise((resolve, reject) => {
@@ -145,17 +150,28 @@ async function run() {
     await login(page, baseUrl, userUsername, userPassword);
     await assertHidden(page.locator('#user-section'), 'Regular users must not see User Management');
     await assertHidden(page.locator('#provider-section'), 'Provider section must be hidden by default');
-    const deniedResponse = await page.evaluate(async () => {
+    const providerResponse = await page.evaluate(async () => {
       const token = localStorage.getItem('jwt_token');
       const response = await fetch('/api/providers', {headers: {Authorization: `Bearer ${token}`}});
-      return response.status;
+      return {status: response.status, body: await response.json()};
     });
-    if (deniedResponse !== 403) throw new Error(`Expected provider API denial, got ${deniedResponse}`);
+    if (providerResponse.status !== 200) throw new Error(`Expected provider options, got ${providerResponse.status}`);
+    if (providerResponse.body.some(provider => 'url' in provider || 'username' in provider || 'epg_url' in provider)) {
+      throw new Error('Provider details must stay hidden when provider access is disabled');
+    }
     await assertVisible(page.locator('#user-details-content'), 'Regular users must retain list editing details');
     const category = page.locator('#category-list').getByText(liveFixture.categoryName, {exact: true});
     await category.waitFor({state: 'visible', timeout: 15000});
     await category.click();
     await page.locator('#user-channel-list').getByText(liveFixture.channelName, {exact: true}).waitFor({state: 'visible', timeout: 15000});
+    await page.locator(`#channel-provider-select option[value="${providerId}"]`)
+      .waitFor({state: 'attached', timeout: 15000});
+    await page.locator('#channel-provider-select').selectOption(String(providerId));
+    const availableChannel = page.locator('#provider-channel-list li').filter({hasText: providerOnlyChannelName});
+    await availableChannel.waitFor({state: 'visible', timeout: 15000});
+    await availableChannel.getByRole('button').click();
+    await page.locator('#user-channel-list').getByText(providerOnlyChannelName, {exact: true})
+      .waitFor({state: 'visible', timeout: 15000});
     for (const fixture of listFixtures.slice(1)) {
       await page.locator(`label[for="cat-filter-${fixture.type}"]`).click();
       const typeCategory = page.locator('#category-list').getByText(fixture.categoryName, {exact: true});
@@ -270,20 +286,25 @@ async function run() {
     }, {userId});
     if (revokeStatus !== 200) throw new Error(`Provider access revoke failed: ${revokeStatus}`);
 
-    const deniedCatalog = await grantedUserPage.evaluate(async ({providerId}) => {
+    const deniedProviderMapping = await grantedUserPage.evaluate(async ({providerId}) => {
       try {
-        await window.fetchJSON(`/api/providers/${providerId}/channels?type=live`);
+        await window.fetchJSON(`/api/mapping/${providerId}`);
         return {message: 'unexpected success', token: Boolean(localStorage.getItem('jwt_token'))};
       } catch (error) {
         return {message: error.message, token: Boolean(localStorage.getItem('jwt_token'))};
       }
     }, {providerId});
-    if (deniedCatalog.message !== 'Access denied' || !deniedCatalog.token) {
-      throw new Error(`Provider denial must preserve the login session: ${JSON.stringify(deniedCatalog)}`);
+    if (deniedProviderMapping.message !== 'Access denied' || !deniedProviderMapping.token) {
+      throw new Error(`Provider permission refresh must preserve the login session: ${JSON.stringify(deniedProviderMapping)}`);
     }
     await assertHidden(grantedUserPage.locator('#login-modal'), 'Provider denial must not show the login modal');
     await assertHidden(grantedUserPage.locator('#provider-section'), 'Revoked users must lose the Provider section');
     await assertVisible(grantedUserPage.locator('#user-details-content'), 'Provider denial must preserve list editing');
+    await grantedUserPage.locator(`#channel-provider-select option[value="${providerId}"]`)
+      .waitFor({state: 'attached', timeout: 15000});
+    await grantedUserPage.locator('#channel-provider-select').selectOption(String(providerId));
+    await grantedUserPage.locator('#provider-channel-list').getByText(liveFixture.channelName, {exact: true})
+      .waitFor({state: 'visible', timeout: 15000});
     await grantedUserPage.locator('#nav-epg-mapping').click();
     await grantedUserPage.locator(`#epg-mapping-category-select option[value="${liveFixture.categoryId}"]`)
       .waitFor({state: 'attached', timeout: 15000});

--- a/scripts/playwright_smoke.mjs
+++ b/scripts/playwright_smoke.mjs
@@ -286,6 +286,13 @@ async function run() {
     }, {userId});
     if (revokeStatus !== 200) throw new Error(`Provider access revoke failed: ${revokeStatus}`);
 
+    await grantedUserPage.locator(`#channel-provider-select option[value="${providerId}"]`)
+      .waitFor({state: 'attached', timeout: 15000});
+    await grantedUserPage.locator('#channel-provider-select').selectOption(String(providerId));
+    await grantedUserPage.locator('#provider-channel-list').getByText(liveFixture.channelName, {exact: true})
+      .waitFor({state: 'visible', timeout: 15000});
+    await assertHidden(grantedUserPage.locator('#provider-section'), 'Revoked users must lose the Provider section after catalog refresh');
+
     const deniedProviderMapping = await grantedUserPage.evaluate(async ({providerId}) => {
       try {
         await window.fetchJSON(`/api/mapping/${providerId}`);
@@ -300,11 +307,6 @@ async function run() {
     await assertHidden(grantedUserPage.locator('#login-modal'), 'Provider denial must not show the login modal');
     await assertHidden(grantedUserPage.locator('#provider-section'), 'Revoked users must lose the Provider section');
     await assertVisible(grantedUserPage.locator('#user-details-content'), 'Provider denial must preserve list editing');
-    await grantedUserPage.locator(`#channel-provider-select option[value="${providerId}"]`)
-      .waitFor({state: 'attached', timeout: 15000});
-    await grantedUserPage.locator('#channel-provider-select').selectOption(String(providerId));
-    await grantedUserPage.locator('#provider-channel-list').getByText(liveFixture.channelName, {exact: true})
-      .waitFor({state: 'visible', timeout: 15000});
     await grantedUserPage.locator('#nav-epg-mapping').click();
     await grantedUserPage.locator(`#epg-mapping-category-select option[value="${liveFixture.categoryId}"]`)
       .waitFor({state: 'attached', timeout: 15000});

--- a/src/controllers/providerCatalogController.js
+++ b/src/controllers/providerCatalogController.js
@@ -13,6 +13,11 @@ export const getProviderChannels = (req, res) => {
         if (!provider || provider.user_id !== req.user.id) return res.status(403).json({error: 'Access denied'});
     }
 
+    const canViewChannelMetadata = req.user.is_admin || Number(req.user.provider_access) === 1;
+    const channelFields = canViewChannelMetadata
+      ? '*'
+      : 'id, provider_id, remote_stream_id, name, original_category_id, logo, stream_type, epg_channel_id, original_sort_order, tv_archive, tv_archive_duration, mime_type, rating, rating_5based, added, plot, "cast", director, genre, releaseDate, youtube_trailer, episode_run_time';
+
     if (page || limit || search) {
       const pageNum = parseInt(page) || 1;
       const limitNum = parseInt(limit) || 50;
@@ -35,7 +40,7 @@ export const getProviderChannels = (req, res) => {
       const countQuery = `SELECT COUNT(*) as count ${baseQuery}`;
       const total = db.prepare(countQuery).get(...params).count;
 
-      const dataQuery = `SELECT * ${baseQuery} ORDER BY original_sort_order ASC, name ASC LIMIT ? OFFSET ?`;
+      const dataQuery = `SELECT ${channelFields} ${baseQuery} ORDER BY original_sort_order ASC, name ASC LIMIT ? OFFSET ?`;
       const rows = db.prepare(dataQuery).all(...params, limitNum, offset);
 
       return res.json({
@@ -46,7 +51,7 @@ export const getProviderChannels = (req, res) => {
       });
     }
 
-    let query = 'SELECT * FROM provider_channels WHERE provider_id = ?';
+    let query = `SELECT ${channelFields} FROM provider_channels WHERE provider_id = ?`;
     const params = [providerId];
 
     if (type) {

--- a/src/controllers/providerCatalogController.js
+++ b/src/controllers/providerCatalogController.js
@@ -5,10 +5,6 @@ import { isAdultCategory } from '../utils/helpers.js';
 
 export const getProviderChannels = (req, res) => {
   try {
-    if (!req.user.is_admin && !req.user.provider_access) {
-      return res.status(403).json({error: 'Access denied'});
-    }
-
     const { type, page, limit, search } = req.query;
     const providerId = Number(req.params.id);
 
@@ -67,10 +63,6 @@ export const getProviderChannels = (req, res) => {
 
 export const getProviderCategories = async (req, res) => {
   try {
-    if (!req.user.is_admin && !req.user.provider_access) {
-      return res.status(403).json({error: 'Access denied'});
-    }
-
     const id = Number(req.params.id);
     const type = req.query.type || 'live'; // 'live', 'movie', 'series'
 

--- a/src/controllers/providerCategoryImportController.js
+++ b/src/controllers/providerCategoryImportController.js
@@ -10,10 +10,6 @@ import { parseProviderCategoryId } from './providerControllerUtils.js';
 
 export const importCategory = async (req, res) => {
   try {
-    if (!req.user.is_admin && !req.user.provider_access) {
-      return res.status(403).json({error: 'Access denied'});
-    }
-
     const providerId = Number(req.params.providerId);
     const { user_id, category_id, category_name, import_channels, type } = req.body;
     const catType = type || 'live';
@@ -133,10 +129,6 @@ export const importCategory = async (req, res) => {
 
 export const importCategories = async (req, res) => {
   try {
-    if (!req.user.is_admin && !req.user.provider_access) {
-      return res.status(403).json({error: 'Access denied'});
-    }
-
     const providerId = Number(req.params.providerId);
     const { user_id, categories } = req.body;
 

--- a/src/controllers/providerController.js
+++ b/src/controllers/providerController.js
@@ -50,10 +50,6 @@ const fetchProviderDetails = async (url, username, password) => {
 
 export const getProviders = (req, res) => {
   try {
-    if (!req.user.is_admin && !req.user.provider_access) {
-      return res.status(403).json({error: 'Access denied'});
-    }
-
     let { user_id } = req.query;
 
     if (!req.user.is_admin) {
@@ -73,7 +69,12 @@ export const getProviders = (req, res) => {
     }
 
     const providers = db.prepare(query).all(...params);
+    const canViewProviderDetails = req.user.is_admin || Number(req.user.provider_access) === 1;
     const safeProviders = providers.map(p => {
+      if (!canViewProviderDetails) {
+        return {id: p.id, name: p.name, user_id: p.user_id};
+      }
+
       let lastUpdate = p.last_epg_update || 0;
 
       let plainPassword = null;

--- a/tests/user_provider_access.test.js
+++ b/tests/user_provider_access.test.js
@@ -54,6 +54,7 @@ describe('per-user upstream provider visibility', () => {
   let providerId;
   let providerChannelId;
   let categoryId;
+  let sensitiveMetadata;
 
   beforeAll(() => {
     initDb(true);
@@ -74,6 +75,12 @@ describe('per-user upstream provider visibility', () => {
       INSERT INTO provider_channels (provider_id, remote_stream_id, name)
       VALUES (?, ?, ?)
     `).run(providerId, 1, 'Visible Channel').lastInsertRowid);
+    sensitiveMetadata = JSON.stringify({
+      original_url: 'http://upstream.example/live/user:secret',
+      http_headers: {Authorization: 'Bearer header-secret'},
+      drm: {license_key: 'license-secret'}
+    });
+    db.prepare('UPDATE provider_channels SET metadata = ? WHERE id = ?').run(sensitiveMetadata, providerChannelId);
 
     categoryId = Number(db.prepare(`
       INSERT INTO user_categories (user_id, name, type)
@@ -135,6 +142,32 @@ describe('per-user upstream provider visibility', () => {
     expect(res.body).toEqual([
       expect.objectContaining({id: providerChannelId, name: 'Visible Channel'})
     ]);
+  });
+
+  it('redacts provider channel metadata without provider access', () => {
+    const restrictedRes = response();
+
+    providerCatalogController.getProviderChannels({
+      user: { id: userId, is_admin: false, provider_access: 0 },
+      params: { id: providerId },
+      query: {}
+    }, restrictedRes);
+
+    expect(restrictedRes.statusCode).toBe(200);
+    expect(restrictedRes.body[0]).not.toHaveProperty('metadata');
+    expect(JSON.stringify(restrictedRes.body)).not.toContain('secret');
+
+    const grantedRes = response();
+    providerCatalogController.getProviderChannels({
+      user: { id: userId, is_admin: false, provider_access: 1 },
+      params: { id: providerId },
+      query: {}
+    }, grantedRes);
+
+    expect(grantedRes.statusCode).toBe(200);
+    expect(grantedRes.body).toEqual(expect.arrayContaining([
+      expect.objectContaining({id: providerChannelId, metadata: sensitiveMetadata})
+    ]));
   });
 
   it('denies provider EPG mapping access when provider access is disabled', () => {

--- a/tests/user_provider_access.test.js
+++ b/tests/user_provider_access.test.js
@@ -109,7 +109,7 @@ describe('per-user upstream provider visibility', () => {
     expect(db.prepare('SELECT provider_access FROM users WHERE id = ?').get(userId).provider_access).toBe(1);
   });
 
-  it('denies provider list access when provider access is disabled', () => {
+  it('returns owned provider options without exposing provider details', () => {
     db.prepare('UPDATE users SET provider_access = 0 WHERE id = ?').run(userId);
     const res = response();
 
@@ -118,11 +118,11 @@ describe('per-user upstream provider visibility', () => {
       query: {}
     }, res);
 
-    expect(res.statusCode).toBe(403);
-    expect(res.body).toEqual({ error: 'Access denied' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual([{id: providerId, name: 'Visible Provider', user_id: userId}]);
   });
 
-  it('denies provider channel access when provider access is disabled', () => {
+  it('returns owned provider channels for list editing without provider access', () => {
     const res = response();
 
     providerCatalogController.getProviderChannels({
@@ -131,8 +131,10 @@ describe('per-user upstream provider visibility', () => {
       query: {}
     }, res);
 
-    expect(res.statusCode).toBe(403);
-    expect(res.body).toEqual({ error: 'Access denied' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual([
+      expect.objectContaining({id: providerChannelId, name: 'Visible Channel'})
+    ]);
   });
 
   it('denies provider EPG mapping access when provider access is disabled', () => {


### PR DESCRIPTION
## Änderung

Normale Nutzer sehen weiterhin keine User-Verwaltung und keine Provider-Informations-/Verwaltungsbox. Wenn der Admin den Provider-Zugriff nicht freigibt, bleiben aber erhalten:

- Provider-Auswahl im Listen-Editor
- Provider-Kanäle zum Hinzufügen
- Kanal-, Movie-, Serienlisten- und Kategorie-EPG-Bearbeitung
- Provider-Kategorie-Importe für den eigenen Provider

Die API liefert ohne Provider-Zugriff nur die für die Auswahl nötigen Provider-Grunddaten; Verbindungsdetails bleiben verborgen. Die bestehende Admin-Steuerung pro User bleibt erhalten.

## Verifikation

- Playwright Smoke
- 96 Vitest-Dateien / 630 Tests
- ESLint
- Build